### PR TITLE
Fixed syntax error.

### DIFF
--- a/src/Types/Field/RadioField.php
+++ b/src/Types/Field/RadioField.php
@@ -41,7 +41,7 @@ class RadioField extends Field {
                         'type'        => 'Boolean',
                         'description' => __( 'Indicates whether the \'Enable "other" choice\' option is checked in the editor.', 'wp-graphql-gravity-forms' ),
                     ],
-                ],
+                ]
             ),
         ] );
     }


### PR DESCRIPTION
The trailing comma was preventing me from activating the plugin — with this removed, the plugin works and fields are also queryable which was an issue using the [0.1.0](https://github.com/harness-software/wp-graphql-gravity-forms/releases/tag/0.1.0) release for me.