### PR TITLE
Check if FieldValue exists in $entry before trying to return it. 

### DIFF
--- a/src/Types/Field/FieldValue/AddressFieldValue.php
+++ b/src/Types/Field/FieldValue/AddressFieldValue.php
@@ -63,12 +63,12 @@ class AddressFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'street'  => $entry[ $field['inputs'][0]['id'] ],
-            'lineTwo' => $entry[ $field['inputs'][1]['id'] ],
-            'city'    => $entry[ $field['inputs'][2]['id'] ],
-            'state'   => $entry[ $field['inputs'][3]['id'] ],
-            'zip'     => $entry[ $field['inputs'][4]['id'] ],
-            'country' => $entry[ $field['inputs'][5]['id'] ],
+            'street'  => array_key_exists( $field['inputs'][0]['id'], $entry ) ? $entry[ $field['inputs'][0]['id'] ] : null,
+            'lineTwo'  => array_key_exists( $field['inputs'][1]['id'], $entry ) ? $entry[ $field['inputs'][1]['id'] ] : null,
+            'city'  => array_key_exists( $field['inputs'][2]['id'], $entry ) ? $entry[ $field['inputs'][2]['id'] ] : null,
+            'state'  => array_key_exists( $field['inputs'][3]['id'], $entry ) ? $entry[ $field['inputs'][3]['id'] ] : null,
+            'zip'  => array_key_exists( $field['inputs'][4]['id'], $entry ) ? $entry[ $field['inputs'][4]['id'] ] : null,
+            'country'  => array_key_exists( $field['inputs'][5]['id'], $entry ) ? $entry[ $field['inputs'][5]['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/AddressFieldValue.php
+++ b/src/Types/Field/FieldValue/AddressFieldValue.php
@@ -63,12 +63,12 @@ class AddressFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'street'  => array_key_exists( $field['inputs'][0]['id'], $entry ) ? $entry[ $field['inputs'][0]['id'] ] : null,
-            'lineTwo'  => array_key_exists( $field['inputs'][1]['id'], $entry ) ? $entry[ $field['inputs'][1]['id'] ] : null,
-            'city'  => array_key_exists( $field['inputs'][2]['id'], $entry ) ? $entry[ $field['inputs'][2]['id'] ] : null,
-            'state'  => array_key_exists( $field['inputs'][3]['id'], $entry ) ? $entry[ $field['inputs'][3]['id'] ] : null,
-            'zip'  => array_key_exists( $field['inputs'][4]['id'], $entry ) ? $entry[ $field['inputs'][4]['id'] ] : null,
-            'country'  => array_key_exists( $field['inputs'][5]['id'], $entry ) ? $entry[ $field['inputs'][5]['id'] ] : null,
+            'street'  => $entry[ $field['inputs'][0]['id'] ] ?? null,
+            'lineTwo' => $entry[ $field['inputs'][1]['id'] ] ?? null,
+            'city'    => $entry[ $field['inputs'][2]['id'] ] ?? null,
+            'state'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
+            'zip'     => $entry[ $field['inputs'][4]['id'] ] ?? null,
+            'country' => $entry[ $field['inputs'][5]['id'] ] ?? null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/DateFieldValue.php
+++ b/src/Types/Field/FieldValue/DateFieldValue.php
@@ -43,7 +43,7 @@ class DateFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
+            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/DateFieldValue.php
+++ b/src/Types/Field/FieldValue/DateFieldValue.php
@@ -43,7 +43,7 @@ class DateFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/EmailFieldValue.php
+++ b/src/Types/Field/FieldValue/EmailFieldValue.php
@@ -43,7 +43,7 @@ class EmailFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
+            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/EmailFieldValue.php
+++ b/src/Types/Field/FieldValue/EmailFieldValue.php
@@ -43,7 +43,7 @@ class EmailFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/MultiSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/MultiSelectFieldValue.php
@@ -42,8 +42,9 @@ class MultiSelectFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field values.
      */
     public static function get( array $entry, GF_Field $field ) : array {
+			error_log(print_r($entry, true));
         return [
-            'values' => json_decode( $entry[ $field['id'] ], true ),
+            'values' => array_key_exists( $field['id'], $entry ) ? json_decode( $entry[ $field['id'] ], true ) : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/MultiSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/MultiSelectFieldValue.php
@@ -44,7 +44,7 @@ class MultiSelectFieldValue implements Hookable, Type, FieldValue {
     public static function get( array $entry, GF_Field $field ) : array {
 			error_log(print_r($entry, true));
         return [
-            'values' => array_key_exists( $field['id'], $entry ) ? json_decode( $entry[ $field['id'] ], true ) : null,
+            'values' => isset( $entry[ $field['id'] ] ) ? json_decode( $entry[ $field['id'] ], true ) : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -59,11 +59,11 @@ class NameFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
 			return [
-					'prefix' => isset( $entry[ $field['inputs'][0]['id'] ] ) ? $entry[ $field['inputs'][0]['id'] ] : null,
-					'first'  => isset( $entry[ $field['inputs'][1]['id'] ] ) ? $entry[ $field['inputs'][1]['id'] ]: null,
-					'middle' => isset( $entry[ $field['inputs'][2]['id'] ] ) ? $entry[ $field['inputs'][2]['id'] ] : null,
-					'last'   => isset( $entry[ $field['inputs'][3]['id'] ]) ? $entry[ $field['inputs'][3]['id'] ] : null,
-					'suffix' => isset( $entry[ $field['inputs'][4]['id'] ] ) ? $entry[ $field['inputs'][4]['id'] ] : null,
+					'prefix' => $entry[ $field['inputs'][0]['id'] ] ?? null,
+					'first'  => $entry[ $field['inputs'][1]['id'] ] ?? null,
+					'middle' => $entry[ $field['inputs'][2]['id'] ] ?? null,
+					'last'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
+					'suffix' => $entry[ $field['inputs'][4]['id'] ] ?? null,
 			];
     }
 }

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -59,11 +59,11 @@ class NameFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'prefix' => $entry[ $field['inputs'][0]['id'] ],
-            'first'  => $entry[ $field['inputs'][1]['id'] ],
-            'middle' => $entry[ $field['inputs'][2]['id'] ],
-            'last'   => $entry[ $field['inputs'][3]['id'] ],
-            'suffix' => $entry[ $field['inputs'][4]['id'] ],
+						'prefix'  => array_key_exists( $field['inputs'][0]['id'], $entry ) ? $entry[ $field['inputs'][0]['id'] ] : null,
+						'first'  => array_key_exists( $field['inputs'][1]['id'], $entry ) ? $entry[ $field['inputs'][1]['id'] ] : null,
+						'middle'  => array_key_exists( $field['inputs'][2]['id'], $entry ) ? $entry[ $field['inputs'][2]['id'] ] : null,
+						'last'  => array_key_exists( $field['inputs'][3]['id'], $entry ) ? $entry[ $field['inputs'][3]['id'] ] : null,
+						'suffix'  => array_key_exists( $field['inputs'][4]['id'], $entry ) ? $entry[ $field['inputs'][4]['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/NumberFieldValue.php
+++ b/src/Types/Field/FieldValue/NumberFieldValue.php
@@ -43,7 +43,7 @@ class NumberFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
+            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/NumberFieldValue.php
+++ b/src/Types/Field/FieldValue/NumberFieldValue.php
@@ -43,7 +43,7 @@ class NumberFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/PhoneFieldValue.php
+++ b/src/Types/Field/FieldValue/PhoneFieldValue.php
@@ -43,7 +43,7 @@ class PhoneFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
+            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/PhoneFieldValue.php
+++ b/src/Types/Field/FieldValue/PhoneFieldValue.php
@@ -43,7 +43,7 @@ class PhoneFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/SelectFieldValue.php
+++ b/src/Types/Field/FieldValue/SelectFieldValue.php
@@ -43,7 +43,7 @@ class SelectFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
+            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/SelectFieldValue.php
+++ b/src/Types/Field/FieldValue/SelectFieldValue.php
@@ -43,7 +43,7 @@ class SelectFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/SignatureFieldValue.php
+++ b/src/Types/Field/FieldValue/SignatureFieldValue.php
@@ -42,7 +42,7 @@ class SignatureFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field value.
      */
     public static function get( array $entry, GF_Field $field ) : array {
-        if ( ! function_exists( 'gf_signature' ) || ! $entry[ $field['id'] ] ) {
+        if ( ! function_exists( 'gf_signature' ) || ! array_key_exists( $field['id'], $entry ) ) {
             return [ 'url' => null ];
         }
 

--- a/src/Types/Field/FieldValue/TimeFieldValue.php
+++ b/src/Types/Field/FieldValue/TimeFieldValue.php
@@ -54,7 +54,7 @@ class TimeFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field value.
      */
     public static function get( array $entry, GF_Field $field ) : array {
-			if( ! array_key_exists( $field['id'], $entry )){
+			if ( ! isset( $entry [ $field['id'] ] ) ) {
 				return [ 
 					'displayValue' => null,
 					'hours' => null,

--- a/src/Types/Field/FieldValue/TimeFieldValue.php
+++ b/src/Types/Field/FieldValue/TimeFieldValue.php
@@ -54,18 +54,27 @@ class TimeFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field value.
      */
     public static function get( array $entry, GF_Field $field ) : array {
-        $display_value  = $entry[ $field['id'] ];
-        $parts_by_colon = explode( ':', $display_value );
-        $hours          = $parts_by_colon[0] ?? '';
-        $parts_by_space = explode( ' ', $display_value );
-        $am_pm          = $parts_by_space[1] ?? '';
-        $minutes        = rtrim( ltrim( $display_value, "{$hours}:" ), " {$am_pm}" );
+			if( ! array_key_exists( $field['id'], $entry )){
+				return [ 
+					'displayValue' => null,
+					'hours' => null,
+					'minutes' => null,
+					'amPm'=> null,
+				];
+			}
 
-        return [
-            'displayValue' => $display_value,
-            'hours'        => $hours,
-            'minutes'      => $minutes,
-            'amPm'         => $am_pm,
-        ];
+			$display_value  = $entry[ $field['id'] ];
+			$parts_by_colon = explode( ':', $display_value );
+			$hours          = $parts_by_colon[0] ?? '';
+			$parts_by_space = explode( ' ', $display_value );
+			$am_pm          = $parts_by_space[1] ?? '';
+			$minutes        = rtrim( ltrim( $display_value, "{$hours}:" ), " {$am_pm}" );
+
+			return [
+					'displayValue' => $display_value,
+					'hours'        => $hours,
+					'minutes'      => $minutes,
+					'amPm'         => $am_pm,
+			];
     }
 }

--- a/src/Types/Field/FieldValue/WebsiteFieldValue.php
+++ b/src/Types/Field/FieldValue/WebsiteFieldValue.php
@@ -43,7 +43,7 @@ class WebsiteFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
         return [
-            'value' => (string) $entry[ $field['id'] ],
+            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
         ];
     }
 }

--- a/src/Types/Field/FieldValue/WebsiteFieldValue.php
+++ b/src/Types/Field/FieldValue/WebsiteFieldValue.php
@@ -42,8 +42,8 @@ class WebsiteFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field value.
      */
     public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => array_key_exists( $field['id'], $entry ) ? (string) $entry[ $field['id'] ] : null,
-        ];
+			return [
+				'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+			];
     }
 }


### PR DESCRIPTION
Address #16 .

This PR implements checks whether the FieldValue exists in `$entry` before trying to return the value. Prevents all those unnecessary error_log warnings when you're doing mutations on a single field.

**Note**: I opted for using `array_key_exists( $field['id'], $entry )` over `isset( $entry[ $field['id'] )`, as I feel it is more robust. That said, I did not change the few `{fieldtype}Field.php` that already use `isset`. If the maintainers have a preference for one or the other, I'm happy to switch this pr to use `isset()` or update the other files to use `array_key_exists`.

I _had to_ change the preexisting SignatureFieldValue check. since `! $entry[ $field['id'] ]` isnt the same as either `array_key_exists` or `isset`.