### PR TITLE
Add UpdateDraftEntryTimeFieldValue mutation

### DIFF
--- a/src/Mutations/UpdateDraftEntryTimeFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTimeFieldValue.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WPGraphQLGravityForms\Mutations;
+
+/**
+ * Update a Gravity Forms draft entry time field value.
+ */
+class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
+    /**
+     * Mutation name.
+     */
+	const NAME = 'updateDraftEntryTimeFieldValue';
+
+	/**
+     * @return array The input field value.
+     */
+	protected function get_value_input_field() : array {
+		return [
+			'type'        => 'String',
+			'description' => __( 'The form field value.', 'wp-graphql-gravity-forms' ),
+		];
+	}
+
+    /**
+     * @param string The field value.
+     *
+     * @return string The sanitized field value.
+     */
+	protected function prepare_field_value( string $value ) : string {
+		return sanitize_text_field( $value );
+	}
+}

--- a/src/Types/Field/TimeField.php
+++ b/src/Types/Field/TimeField.php
@@ -35,7 +35,16 @@ class TimeField extends Field {
                 FieldProperty\InputNameProperty::get(),
                 FieldProperty\IsRequiredProperty::get(),
                 FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\SizeProperty::get()
+                FieldProperty\SizeProperty::get(),
+								[
+									/**
+									 * Possible values: 12, 24
+									 */
+									'timeFormat' => [
+										'type'        => 'String',
+										'description' => __('Determines how the time is displayed.', 'wp-graphql-gravity-forms'),
+                    ],
+								]
                 // @TODO: Add placeholders.
             ),
         ] );

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -167,6 +167,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['update_draft_entry_signature_field_value']    = new Mutations\UpdateDraftEntrySignatureFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_text_area_field_value']    = new Mutations\UpdateDraftEntryTextAreaFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_text_field_value']         = new Mutations\UpdateDraftEntryTextFieldValue( $this->instances['draft_entry_data_manipulator'] );
+		$this->instances['update_draft_entry_time_field_value']         = new Mutations\UpdateDraftEntryTimeFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_website_field_value']      = new Mutations\UpdateDraftEntryWebsiteFieldValue( $this->instances['draft_entry_data_manipulator'] );
 	}
 


### PR DESCRIPTION
This PR adds `UpdateDraftEntryTimeFieldValue` mutation.

Additionally, it adds `timeFormat` to the list of `TimeField` object fields. While other GF properties are missing (and should be added in a separate PR), I felt this was necessary for developers to use `UpdateDraftEntryTimeFieldValue`, as the timeFormat determines whether you want the input value to be submitted as `23:01` or `11:01 PM`.
