### PR TITLE
Add UpdateDraftEntryNameFieldValue mutation

### DIFF
--- a/src/Mutations/UpdateDraftEntryNameFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNameFieldValue.php
@@ -35,7 +35,7 @@ class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 				$this->field['inputs'][1]['id']  => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
 				$this->field['inputs'][2]['id'] => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
 				$this->field['inputs'][3]['id']  => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
-				$this->field['inputs'][0]['id']  => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
+				$this->field['inputs'][4]['id']  => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
 			];
 	}
 }

--- a/src/Mutations/UpdateDraftEntryNameFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNameFieldValue.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WPGraphQLGravityForms\Mutations;
+
+use WPGraphQLGravityForms\Types\Input\NameInput;
+
+/**
+ * Update a Gravity Forms draft entry name field value.
+ */
+class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
+	/**
+	 * Mutation name.
+	 */
+	const NAME = 'updateDraftEntryNameFieldValue';
+
+	/**
+	 * @return array The input field value.
+	 */
+	protected function get_value_input_field() : array {
+		return [
+			'type'        => NameInput::TYPE,
+			'description' => __( 'The form field value.', 'wp-graphql-gravity-forms' ),
+		];
+	}
+
+	/**
+	 * @param string The field value.
+	 *
+	 * @return array The sanitized field value.
+	 */
+	protected function prepare_field_value( array $value ) : array {
+		return [ $this->field->id => 
+			[
+				'prefix' => array_key_exists( 'prefix', $value ) ? sanitize_text_field( $value['prefix'] ) : null,
+				'first' => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
+				'middle' => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
+				'last' => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
+				'suffix' => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
+			]
+		];
+	}
+}

--- a/src/Mutations/UpdateDraftEntryNameFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNameFieldValue.php
@@ -29,14 +29,13 @@ class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 	 * @return array The sanitized field value.
 	 */
 	protected function prepare_field_value( array $value ) : array {
-		return [ $this->field->id => 
+		return 
 			[
-				'prefix' => array_key_exists( 'prefix', $value ) ? sanitize_text_field( $value['prefix'] ) : null,
-				'first' => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
-				'middle' => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
-				'last' => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
-				'suffix' => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
-			]
-		];
+				$this->field['inputs'][0]['id'] => array_key_exists( 'prefix', $value ) ? sanitize_text_field( $value['prefix'] ) : null,
+				$this->field['inputs'][1]['id']  => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
+				$this->field['inputs'][2]['id'] => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
+				$this->field['inputs'][3]['id']  => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
+				$this->field['inputs'][0]['id']  => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
+			];
 	}
 }

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -59,11 +59,11 @@ class NameFieldValue implements Hookable, Type, FieldValue {
      */
     public static function get( array $entry, GF_Field $field ) : array {
 			return [
-					'prefix' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['prefix'] : null,
-					'first' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['first'] : null,
-					'middle' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['middle'] : null,
-					'last' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['last'] : null,
-					'suffix' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['suffix'] : null,
+					'prefix' => isset( $entry[ $field['inputs'][0]['id'] ] ) ? $entry[ $field['inputs'][0]['id'] ] : null,
+					'first'  => isset( $entry[ $field['inputs'][1]['id'] ] ) ? $entry[ $field['inputs'][1]['id'] ]: null,
+					'middle' => isset( $entry[ $field['inputs'][2]['id'] ] ) ? $entry[ $field['inputs'][2]['id'] ] : null,
+					'last'   => isset( $entry[ $field['inputs'][3]['id'] ]) ? $entry[ $field['inputs'][3]['id'] ] : null,
+					'suffix' => isset( $entry[ $field['inputs'][4]['id'] ] ) ? $entry[ $field['inputs'][4]['id'] ] : null,
 			];
     }
 }

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -58,12 +58,12 @@ class NameFieldValue implements Hookable, Type, FieldValue {
      * @return array Entry field value.
      */
     public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'prefix' => $entry[ $field['inputs'][0]['id'] ],
-            'first'  => $entry[ $field['inputs'][1]['id'] ],
-            'middle' => $entry[ $field['inputs'][2]['id'] ],
-            'last'   => $entry[ $field['inputs'][3]['id'] ],
-            'suffix' => $entry[ $field['inputs'][4]['id'] ],
-        ];
+			return [
+					'prefix' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['prefix'] : null,
+					'first' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['first'] : null,
+					'middle' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['middle'] : null,
+					'last' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['last'] : null,
+					'suffix' => isset( $entry[ $field['id'] ] ) ? $entry[ $field['id'] ]['suffix'] : null,
+			];
     }
 }

--- a/src/Types/Input/NameInput.php
+++ b/src/Types/Input/NameInput.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WPGraphQLGravityForms\Types\Input;
+
+use WPGraphQLGravityForms\Interfaces\Hookable;
+use WPGraphQLGravityForms\Interfaces\InputType;
+
+/**
+ * Input fields for name field.
+ */
+class NameInput implements Hookable, InputType {
+    /**
+     * Type registered in WPGraphQL.
+     */
+    const TYPE = 'NameInput';
+
+    public function register_hooks() {
+        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+    }
+
+    public function register_input_type() {
+        register_graphql_input_type( self::TYPE, [
+            'description' => __( 'Input fields for name field.', 'wp-graphql-gravity-forms' ),
+            'fields'      => [
+                'prefix' => [
+                    'type'        => 'String',
+                    'description' => __( 'Prefix, such as Mr., Mrs. etc.', 'wp-graphql-gravity-forms' ),
+                ],
+                'first' => [
+                    'type'        => 'String',
+                    'description' => __( 'First name.', 'wp-graphql-gravity-forms' ),
+                ],
+                'middle' => [
+                    'type'        => 'String',
+                    'description' => __( 'Middle name.', 'wp-graphql-gravity-forms' ),
+                ],
+                'last' => [
+                    'type'        => 'String',
+                    'description' => __( 'Last name.', 'wp-graphql-gravity-forms' ),
+                ],
+                'suffix' => [
+                    'type'        => 'String',
+                    'description' => __( 'Suffix, such as Sr., Jr. etc.', 'wp-graphql-gravity-forms' ),
+                ],
+            ],
+        ] );
+    }
+}

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -130,6 +130,7 @@ final class WPGraphQLGravityForms {
 
 		// Input
 		$this->instances['checkbox_input']             = new Input\CheckboxInput();
+		$this->instances['name_input']                 = new Input\NameInput();
 		$this->instances['entries_date_fiters_input']  = new Input\EntriesDateFiltersInput();
 		$this->instances['entries_field_fiters_input'] = new Input\EntriesFieldFiltersInput();
 		$this->instances['entries_sorting_input']      = new Input\EntriesSortingInput();
@@ -160,6 +161,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['update_draft_entry_date_field_value']         = new Mutations\UpdateDraftEntryDateFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_email_field_value']        = new Mutations\UpdateDraftEntryEmailFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_multi_select_field_value'] = new Mutations\UpdateDraftEntryMultiSelectFieldValue( $this->instances['draft_entry_data_manipulator'] );
+		$this->instances['update_draft_entry_name_field_value']       = new Mutations\UpdateDraftEntryNameFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_number_field_value']       = new Mutations\UpdateDraftEntryNumberFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_phone_field_value']        = new Mutations\UpdateDraftEntryPhoneFieldValue( $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['update_draft_entry_radio_field_value']        = new Mutations\UpdateDraftEntryRadioFieldValue( $this->instances['draft_entry_data_manipulator'] );


### PR DESCRIPTION
This PR adds the `UpdateDraftEntryNameFieldValue` mutation. 
Based on [Twansparant's comment](https://github.com/harness-software/wp-graphql-gravity-forms/issues/17#issuecomment-634641265).