### PR TITLE
Plugin Linting

### DIFF
--- a/src/Connections/EntryFieldConnection.php
+++ b/src/Connections/EntryFieldConnection.php
@@ -19,132 +19,143 @@ use WPGraphQLGravityForms\Types\FieldError\FieldError;
 use WPGraphQLGravityForms\DataManipulators\FieldsDataManipulator;
 
 class EntryFieldConnection implements Hookable, Connection {
-    /**
-     * The from field name.
-     */
-    const FROM_FIELD = 'fields';
+	/**
+	 * The from field name.
+	 */
+	const FROM_FIELD = 'fields';
 
-    /**
-     * WPGraphQL for Gravity Forms plugin's class instances.
-     *
-     * @var array
-     */
-    private $instances;
+	/**
+	 * WPGraphQL for Gravity Forms plugin's class instances.
+	 *
+	 * @var array
+	 */
+	private $instances;
 
-    /**
-     * @param array WPGraphQL for Gravity Forms plugin's class instances.
-     */
-    public function __construct( array $instances ) {
-        $this->instances = $instances;
-    }
+	/**
+	 * @param array WPGraphQL for Gravity Forms plugin's class instances.
+	 */
+	public function __construct( array $instances ) {
+		$this->instances = $instances;
+	}
 
-    public function register_hooks() {
-        add_action('init', [ $this, 'register_connection' ] );
-    }
+	public function register_hooks() {
+		add_action( 'init', [ $this, 'register_connection' ] );
+	}
 
-    public function register_connection() {
-        register_graphql_connection( [
-            'fromType'      => Entry::TYPE,
-            'toType'        => ObjectFieldUnion::TYPE,
-            'fromFieldName' => self::FROM_FIELD,
-            'edgeFields' => [
-                'fieldValue' => [
-                    'type'        => ObjectFieldValueUnion::TYPE,
-                    'description' => __( 'Field value.', 'wp-graphql-gravity-forms' ),
-                    'resolve' => function( array $root, array $args, AppContext $context, ResolveInfo $info ) {
-                        $field = $this->get_field_by_gf_field_type( $root['node']['type'] );
+	public function register_connection() {
+		register_graphql_connection(
+			[
+				'fromType'      => Entry::TYPE,
+				'toType'        => ObjectFieldUnion::TYPE,
+				'fromFieldName' => self::FROM_FIELD,
+				'edgeFields'    => [
+					'fieldValue' => [
+						'type'        => ObjectFieldValueUnion::TYPE,
+						'description' => __( 'Field value.', 'wp-graphql-gravity-forms' ),
+						'resolve'     => function( array $root, array $args, AppContext $context, ResolveInfo $info ) {
+							$field = $this->get_field_by_gf_field_type( $root['node']['type'] );
 
-                        if ( ! $field ) {
-                            return null;
-                        }
+							if ( ! $field ) {
+								return null;
+							}
 
-                        $value_class = $this->get_field_value_class( $field );
+							$value_class = $this->get_field_value_class( $field );
 
-                        // Account for fields that do not have a value class.
-                        if ( ! $value_class ) {
-                            return null;
-                        }
+							// Account for fields that do not have a value class.
+							if ( ! $value_class ) {
+								return null;
+							}
 
-                        return array_merge(
-                            // 'value_class' is included here to pass it through to the "resolveType"
-                            // callback function in ObjectFieldValueUnion.
-                            [ 'value_class' => $value_class ],
-                            $value_class::get( $root['source'], $root['node'] )
-                        );
-                    }
-                ],
-            ],
-            'resolve' => function( $root, array $args, AppContext $context, ResolveInfo $info ) : array {
-                $form  = GFAPI::get_form( $root['formId'] );
+							return array_merge(
+								// 'value_class' is included here to pass it through to the "resolveType"
+								// callback function in ObjectFieldValueUnion.
+								[ 'value_class' => $value_class ],
+								$value_class::get( $root['source'], $root['node'] )
+							);
+						},
+					],
+				],
+				'resolve'       => function( $root, array $args, AppContext $context, ResolveInfo $info ) : array {
+					$form = GFAPI::get_form( $root['formId'] );
 
-                if ( ! $form ) {
-                    throw new UserError( __( 'The form used to generate this entry was not found.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $form ) {
+						throw new UserError( __( 'The form used to generate this entry was not found.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $fields     = ( new FieldsDataManipulator() )->manipulate( $form['fields'] );
-                $connection = Relay::connectionFromArray( $fields, $args );
+					$fields     = ( new FieldsDataManipulator() )->manipulate( $form['fields'] );
+					$connection = Relay::connectionFromArray( $fields, $args );
 
-                // Add the entry to each edge with a key of 'source'. This is needed so that
-                // the fieldValue edge field resolver has has access to the form entry.
-                $connection['edges'] = array_map( function( $edge ) use ( $root ) {
-                    $edge['source'] = $root;
-                    return $edge;
-                }, $connection['edges'] );
+					// Add the entry to each edge with a key of 'source'. This is needed so that
+					// the fieldValue edge field resolver has has access to the form entry.
+					$connection['edges'] = array_map(
+						function( $edge ) use ( $root ) {
+							$edge['source'] = $root;
+							return $edge;
+						},
+						$connection['edges']
+					);
 
-                $nodes               = array_map( fn( $edge ) => $edge['node'] ?? null, $connection['edges'] );
-                $connection['nodes'] = $nodes ?: null;
-                return $connection;
-            },
-        ] );
-    }
+					$nodes               = array_map( fn( $edge ) => $edge['node'] ?? null, $connection['edges'] );
+					$connection['nodes'] = $nodes ?: null;
+					return $connection;
+				},
+			]
+		);
+	}
 
-    /**
-     * @param string $gf_field_type The Gravity Forms field type.
-     *
-     * @return Field|null The corresponding WPGraphQL field, or null if not found.
-     */
-    private function get_field_by_gf_field_type( string $gf_field_type ) {
-        $fields = array_filter( $this->instances, fn( $instance ) => $instance instanceof Field );
+	/**
+	 * @param string $gf_field_type The Gravity Forms field type.
+	 *
+	 * @return Field|null The corresponding WPGraphQL field, or null if not found.
+	 */
+	private function get_field_by_gf_field_type( string $gf_field_type ) {
+		$fields = array_filter( $this->instances, fn( $instance ) => $instance instanceof Field );
 
-        /**
-         * Filter for adding custom field class instances.
-         * Classes must extend the WPGraphQLGravityForms\Types\Field\Field class and
-         * contain a "GF_TYPE" class constant specifying the Gravity Forms field type.
-         *
-         * @param array $fields Gravity Forms field class instances.
-         */
-        $fields = apply_filters( 'wp_graphql_gf_form_field_instances', $fields );
+		/**
+		 * Filter for adding custom field class instances.
+		 * Classes must extend the WPGraphQLGravityForms\Types\Field\Field class and
+		 * contain a "GF_TYPE" class constant specifying the Gravity Forms field type.
+		 *
+		 * @param array $fields Gravity Forms field class instances.
+		 */
+		$fields = apply_filters( 'wp_graphql_gf_form_field_instances', $fields );
 
-        $field_array = array_filter( $fields, function( $instance ) use ( $gf_field_type ) {
-            return $instance instanceof Field && $instance::GF_TYPE === $gf_field_type;
-        } );
+		$field_array = array_filter(
+			$fields,
+			function( $instance ) use ( $gf_field_type ) {
+				return $instance instanceof Field && $instance::GF_TYPE === $gf_field_type;
+			}
+		);
 
-        return $field_array ? array_values( $field_array )[0] : null;
-    }
+		return $field_array ? array_values( $field_array )[0] : null;
+	}
 
-    /**
-     * Get the field value class associated with a form field.
-     *
-     * @param  Field $field The field class.
-     *
-     * @return FieldValue|null The field value class or null if not found.
-     */
-    private function get_field_value_class( Field $field ) {
-        $field_values = array_filter( $this->instances, fn( $instance ) => $instance instanceof FieldValueInterface );
+	/**
+	 * Get the field value class associated with a form field.
+	 *
+	 * @param  Field $field The field class.
+	 *
+	 * @return FieldValue|null The field value class or null if not found.
+	 */
+	private function get_field_value_class( Field $field ) {
+		$field_values = array_filter( $this->instances, fn( $instance ) => $instance instanceof FieldValueInterface );
 
-        /**
-         * Filter for adding custom field value class instances.
-         * Classes must implement the WPGraphQLGravityForms\Interfaces\FieldValue interface
-         * and contain a "TYPE" class constant string in this format: "<field_name>Value".
-         *
-         * @param array $field_values Field value class instances.
-         */
-        $field_values = apply_filters( 'wp_graphql_gf_field_value_instances', $field_values );
+		/**
+		 * Filter for adding custom field value class instances.
+		 * Classes must implement the WPGraphQLGravityForms\Interfaces\FieldValue interface
+		 * and contain a "TYPE" class constant string in this format: "<field_name>Value".
+		 *
+		 * @param array $field_values Field value class instances.
+		 */
+		$field_values = apply_filters( 'wp_graphql_gf_field_value_instances', $field_values );
 
-        $value_class_array = array_filter( $field_values, function( $instance ) use ( $field ) {
-            return $instance instanceof FieldValueInterface && $instance::TYPE === $field::TYPE . 'Value';
-        } );
+		$value_class_array = array_filter(
+			$field_values,
+			function( $instance ) use ( $field ) {
+				return $instance instanceof FieldValueInterface && $instance::TYPE === $field::TYPE . 'Value';
+			}
+		);
 
-        return $value_class_array ? array_values( $value_class_array )[0] : null;
-    }
+		return $value_class_array ? array_values( $value_class_array )[0] : null;
+	}
 }

--- a/src/Connections/EntryFieldConnection.php
+++ b/src/Connections/EntryFieldConnection.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Connection - EntryField
+ *
+ * Registers connections from GravityFormsEntry.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -18,6 +26,9 @@ use WPGraphQLGravityForms\Types\Union\ObjectFieldValueUnion;
 use WPGraphQLGravityForms\Types\FieldError\FieldError;
 use WPGraphQLGravityForms\DataManipulators\FieldsDataManipulator;
 
+/**
+ * Class - EntryFieldConnection.
+ */
 class EntryFieldConnection implements Hookable, Connection {
 	/**
 	 * The from field name.
@@ -32,16 +43,24 @@ class EntryFieldConnection implements Hookable, Connection {
 	private $instances;
 
 	/**
-	 * @param array WPGraphQL for Gravity Forms plugin's class instances.
+	 * Constructor.
+	 *
+	 * @param array $instances WPGraphQL for Gravity Forms plugin's class instances.
 	 */
 	public function __construct( array $instances ) {
 		$this->instances = $instances;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'init', [ $this, 'register_connection' ] );
 	}
 
+	/**
+	 * Register connection from GravityFormsEntry type to other types.
+	 */
 	public function register_connection() {
 		register_graphql_connection(
 			[
@@ -104,6 +123,8 @@ class EntryFieldConnection implements Hookable, Connection {
 	}
 
 	/**
+	 * Get the WPGraphQL field for a Gravity Forms field type.
+	 *
 	 * @param string $gf_field_type The Gravity Forms field type.
 	 *
 	 * @return Field|null The corresponding WPGraphQL field, or null if not found.

--- a/src/Connections/FormFieldConnection.php
+++ b/src/Connections/FormFieldConnection.php
@@ -22,36 +22,40 @@ class FormFieldConnection implements Hookable, Connection {
 	const FROM_FIELD = 'fields';
 
 	public function register_hooks() {
-			add_action('init', [ $this, 'register_connection' ] );
+			add_action( 'init', [ $this, 'register_connection' ] );
 	}
 
 	public function register_connection() {
-		register_graphql_connection( [
-			'fromType'      => Form::TYPE,
-			'toType'        => ObjectFieldUnion::TYPE,
-			'fromFieldName' => self::FROM_FIELD,
-			'resolve'       => function( array $root, array $args, AppContext $context, ResolveInfo $info ) : array {
-				$fields              = ( new FieldsDataManipulator() )->manipulate( $root['fields'] );
-				$connection          = Relay::connectionFromArray( $fields, $args );
-				$nodes               = array_map( fn( $edge ) => $edge['node'] ?? null, $connection['edges'] );
-				$connection['nodes'] = $nodes ?: null;
+		register_graphql_connection(
+			[
+				'fromType'      => Form::TYPE,
+				'toType'        => ObjectFieldUnion::TYPE,
+				'fromFieldName' => self::FROM_FIELD,
+				'resolve'       => function( array $root, array $args, AppContext $context, ResolveInfo $info ) : array {
+					$fields              = ( new FieldsDataManipulator() )->manipulate( $root['fields'] );
+					$connection          = Relay::connectionFromArray( $fields, $args );
+					$nodes               = array_map( fn( $edge ) => $edge['node'] ?? null, $connection['edges'] );
+					$connection['nodes'] = $nodes ?: null;
 
-				return $connection;
-			},
-		] );
-	
-		register_graphql_connection( [
-			'fromType'      => Form::TYPE,
-			'toType'        => Entry::TYPE,
-			'fromFieldName' => 'entries',
-			'resolve'       => function( array $root, array $args, AppContext $context, ResolveInfo $info) : array {
-				$form_entries           = GFAPI::get_entries( $root['formId'] );
-				$entry_data_manipulator = new EntryDataManipulator();
-				$entries                = array_map( fn( array $entry ) => $entry_data_manipulator->manipulate( $entry ), $form_entries );
-				$connection             = Relay::connectionFromArray( $entries, $args);
+					return $connection;
+				},
+			]
+		);
 
-				return $connection;
-			},
-		]);
+		register_graphql_connection(
+			[
+				'fromType'      => Form::TYPE,
+				'toType'        => Entry::TYPE,
+				'fromFieldName' => 'entries',
+				'resolve'       => function( array $root, array $args, AppContext $context, ResolveInfo $info ) : array {
+					$form_entries           = GFAPI::get_entries( $root['formId'] );
+					$entry_data_manipulator = new EntryDataManipulator();
+					$entries                = array_map( fn( array $entry ) => $entry_data_manipulator->manipulate( $entry ), $form_entries );
+					$connection             = Relay::connectionFromArray( $entries, $args );
+
+					return $connection;
+				},
+			]
+		);
 	}
 }

--- a/src/Connections/FormFieldConnection.php
+++ b/src/Connections/FormFieldConnection.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Connection - FormField
+ *
+ * Registers connections from GravityFormsForm.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -15,16 +23,25 @@ use WPGraphQLGravityForms\Types\Field\Field;
 use WPGraphQLGravityForms\Types\Union\ObjectFieldUnion;
 use WPGraphQLGravityForms\DataManipulators\FieldsDataManipulator;
 
+/**
+ * Class - FormFieldConnection
+ */
 class FormFieldConnection implements Hookable, Connection {
 	/**
 	 * The from field name.
 	 */
 	const FROM_FIELD = 'fields';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 			add_action( 'init', [ $this, 'register_connection' ] );
 	}
 
+	/**
+	 * Register connection from GravityFormsForm type to other types.
+	 */
 	public function register_connection() {
 		register_graphql_connection(
 			[

--- a/src/Connections/RootQueryEntriesConnection.php
+++ b/src/Connections/RootQueryEntriesConnection.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Connection - RootQueryEntries
+ *
+ * Registers connections from RootQuery.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -13,16 +21,25 @@ use WPGraphQLGravityForms\Types\Input\EntriesDateFiltersInput;
 use WPGraphQLGravityForms\Types\Input\EntriesFieldFiltersInput;
 use WPGraphQLGravityForms\Types\Input\EntriesSortingInput;
 
+/**
+ * Class - RootQueryEntriesConnection
+ */
 class RootQueryEntriesConnection implements Hookable, Connection {
 	/**
 	 * The from field name.
 	 */
 	const FROM_FIELD = 'gravityFormsEntries';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'init', [ $this, 'register_connection' ] );
 	}
 
+	/**
+	 * Register connection from RootQuery type to GravityFormsEntry type.
+	 */
 	public function register_connection() {
 		register_graphql_connection(
 			[
@@ -76,6 +93,12 @@ class RootQueryEntriesConnection implements Hookable, Connection {
 		);
 	}
 
+	/**
+	 * Gets array of form ids.
+	 *
+	 * @param array $args The input arguments for the query.
+	 * @return array
+	 */
 	private function get_form_ids( array $args ) : array {
 		if ( ! empty( $args['where']['formIds'] ) && is_array( $args['where']['formIds'] ) ) {
 			return array_map( 'absint', $args['where']['formIds'] );

--- a/src/Connections/RootQueryEntriesConnection.php
+++ b/src/Connections/RootQueryEntriesConnection.php
@@ -14,71 +14,73 @@ use WPGraphQLGravityForms\Types\Input\EntriesFieldFiltersInput;
 use WPGraphQLGravityForms\Types\Input\EntriesSortingInput;
 
 class RootQueryEntriesConnection implements Hookable, Connection {
-    /**
-     * The from field name.
-     */
-    const FROM_FIELD = 'gravityFormsEntries';
+	/**
+	 * The from field name.
+	 */
+	const FROM_FIELD = 'gravityFormsEntries';
 
-    public function register_hooks() {
-        add_action('init', [ $this, 'register_connection' ] );
-    }
+	public function register_hooks() {
+		add_action( 'init', [ $this, 'register_connection' ] );
+	}
 
-    public function register_connection() {
-        register_graphql_connection( [
-            'fromType'      => 'RootQuery',
-            'toType'        => Entry::TYPE,
-            'fromFieldName' => self::FROM_FIELD,
-            'connectionArgs' => [
-                'formIds' => [
-                    'type'        => [ 'list_of' => 'ID' ],
-                    'description' => __( 'Array of form IDs to limit the entries to. Exclude this argument to query all forms.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to an enum.
-                'status' => [
-                    'type'        => 'String',
-                    'description' => __( 'Entry status. Possible values: "active" (default), "spam", "trash" or "all".', 'wp-graphql-gravity-forms' ),
-                ],
-                'dateFilters' => [
-                    'type'        => EntriesDateFiltersInput::TYPE,
-                    'description' => __( 'Date filters to apply.', 'wp-graphql-gravity-forms' ),
-                ],
-                'fieldFilters' => [
-                    'type'        => [ 'list_of' => EntriesFieldFiltersInput::TYPE ],
-                    'description' => __( 'Field-specific filters to apply.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to an enum.
-                'fieldFiltersMode' => [
-                    'type'        => 'String',
-                    'description' => __( 'Whether to filter by ALL or ANY of the field filters. Possible values: "all" (default) or "any".', 'wp-graphql-gravity-forms' ),
-                ],
-                'sort' => [
-                    'type'        => EntriesSortingInput::TYPE,
-                    'description' => __( 'How to sort the entries.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-            'resolve' => function( $root, array $args, AppContext $context, ResolveInfo $info ) : Deferred {
-                /**
-                 * Filter to control whether the user should be allowed to view entries.
-                 *
-                 * @param bool  Whether the current user should be allowed to view form entries.
-                 * @param array The form IDs to get entries by.
-                 */
-                $can_user_view_entries = apply_filters( 'wp_graphql_gf_can_view_entries', current_user_can( 'gravityforms_view_entries' ), $this->get_form_ids( $args ) );
+	public function register_connection() {
+		register_graphql_connection(
+			[
+				'fromType'       => 'RootQuery',
+				'toType'         => Entry::TYPE,
+				'fromFieldName'  => self::FROM_FIELD,
+				'connectionArgs' => [
+					'formIds'          => [
+						'type'        => [ 'list_of' => 'ID' ],
+						'description' => __( 'Array of form IDs to limit the entries to. Exclude this argument to query all forms.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to an enum.
+					'status'           => [
+						'type'        => 'String',
+						'description' => __( 'Entry status. Possible values: "active" (default), "spam", "trash" or "all".', 'wp-graphql-gravity-forms' ),
+					],
+					'dateFilters'      => [
+						'type'        => EntriesDateFiltersInput::TYPE,
+						'description' => __( 'Date filters to apply.', 'wp-graphql-gravity-forms' ),
+					],
+					'fieldFilters'     => [
+						'type'        => [ 'list_of' => EntriesFieldFiltersInput::TYPE ],
+						'description' => __( 'Field-specific filters to apply.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to an enum.
+					'fieldFiltersMode' => [
+						'type'        => 'String',
+						'description' => __( 'Whether to filter by ALL or ANY of the field filters. Possible values: "all" (default) or "any".', 'wp-graphql-gravity-forms' ),
+					],
+					'sort'             => [
+						'type'        => EntriesSortingInput::TYPE,
+						'description' => __( 'How to sort the entries.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+				'resolve'        => function( $root, array $args, AppContext $context, ResolveInfo $info ) : Deferred {
+					/**
+					 * Filter to control whether the user should be allowed to view entries.
+					 *
+					 * @param bool  Whether the current user should be allowed to view form entries.
+					 * @param array The form IDs to get entries by.
+					 */
+					$can_user_view_entries = apply_filters( 'wp_graphql_gf_can_view_entries', current_user_can( 'gravityforms_view_entries' ), $this->get_form_ids( $args ) );
 
-                if ( ! $can_user_view_entries ) {
-                    throw new UserError( __( 'Sorry, you are not allowed to view Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $can_user_view_entries ) {
+						throw new UserError( __( 'Sorry, you are not allowed to view Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                return ( new RootQueryEntriesConnectionResolver( $root, $args, $context, $info ) )->get_connection();
-            },
-        ] );
-    }
+					return ( new RootQueryEntriesConnectionResolver( $root, $args, $context, $info ) )->get_connection();
+				},
+			]
+		);
+	}
 
-    private function get_form_ids( array $args ) : array {
-        if ( ! empty( $args['where']['formIds'] ) && is_array( $args['where']['formIds'] ) ) {
-            return array_map( 'absint', $args['where']['formIds'] );
-        }
+	private function get_form_ids( array $args ) : array {
+		if ( ! empty( $args['where']['formIds'] ) && is_array( $args['where']['formIds'] ) ) {
+			return array_map( 'absint', $args['where']['formIds'] );
+		}
 
-        return [];
-    }
+		return [];
+	}
 }

--- a/src/Connections/RootQueryEntriesConnectionResolver.php
+++ b/src/Connections/RootQueryEntriesConnectionResolver.php
@@ -11,36 +11,36 @@ use WPGraphQLGravityForms\Data\Loader\EntriesLoader;
 use WPGraphQLGravityForms\Types\Enum\FieldFiltersOperatorInputEnum;
 
 class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
-    /**
-     * @return bool Whether query should execute.
-     */
-    public function should_execute() : bool {
-        return current_user_can( 'gravityforms_view_entries' );
-    }
+	/**
+	 * @return bool Whether query should execute.
+	 */
+	public function should_execute() : bool {
+		return current_user_can( 'gravityforms_view_entries' );
+	}
 
-    /**
+	/**
 	 * Return the name of the loader to be used with the connection resolver
 	 *
 	 * @return string
 	 */
-    public function get_loader_name() : string {
-        return EntriesLoader::NAME;
-    }
+	public function get_loader_name() : string {
+		return EntriesLoader::NAME;
+	}
 
-    /**
-     * Determine whether or not the the offset is valid, i.e the item corresponding to the offset exists.
+	/**
+	 * Determine whether or not the the offset is valid, i.e the item corresponding to the offset exists.
 	 * Offset is equivalent to WordPress ID (e.g post_id, term_id). So this function is equivalent
 	 * to checking if the WordPress object exists for the given ID.
-     *
-     * @param int $offset The offset.
-     *
-     * @return bool Whether the offset is valid.
-     */
-    public function is_valid_offset( $offset ) {
-        return true;
-    }
+	 *
+	 * @param int $offset The offset.
+	 *
+	 * @return bool Whether the offset is valid.
+	 */
+	public function is_valid_offset( $offset ) {
+		return true;
+	}
 
-    /**
+	/**
 	 * Validates Model.
 	 *
 	 * If model isn't a class with a `fields` member, this function with have be overridden in
@@ -52,45 +52,45 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 	 */
 	protected function is_valid_model( $model ) {
 		return true;
-    }
-
-    /**
-     * @return array Query arguments.
-     */
-    public function get_query_args() : array {
-        return [];
-    }
-
-    /**
-     * @return array Query to use for data fetching.
-     */
-    public function get_query() : array {
-        return [];
-    }
-
-    /**
-     * @param int $id Node ID.
-     *
-     * @return string Base-64 encoded cursor value.
-     */
-	protected function get_cursor_for_node( $id ) : string {
-        $first        = $this->args['first'] ?? 20;
-        $after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
-        $index        = array_search( $id, array_keys( $this->nodes ) );
-
-        // TODO
-        // $last  = $this->args['last'] ?? 20;
-        // $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
-
-        $cursor = [
-            'offset' => $after_cursor ? $after_cursor['offset'] + $after_cursor['index'] + 1 : 0,
-            'index'  => $index,
-        ];
-
-        return base64_encode( json_encode( $cursor ) );
 	}
 
-    /**
+	/**
+	 * @return array Query arguments.
+	 */
+	public function get_query_args() : array {
+		return [];
+	}
+
+	/**
+	 * @return array Query to use for data fetching.
+	 */
+	public function get_query() : array {
+		return [];
+	}
+
+	/**
+	 * @param int $id Node ID.
+	 *
+	 * @return string Base-64 encoded cursor value.
+	 */
+	protected function get_cursor_for_node( $id ) : string {
+		$first        = $this->args['first'] ?? 20;
+		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
+		$index        = array_search( $id, array_keys( $this->nodes ) );
+
+		// TODO
+		// $last  = $this->args['last'] ?? 20;
+		// $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
+
+		$cursor = [
+			'offset' => $after_cursor ? $after_cursor['offset'] + $after_cursor['index'] + 1 : 0,
+			'index'  => $index,
+		];
+
+		return base64_encode( json_encode( $cursor ) );
+	}
+
+	/**
 	 * get_ids
 	 *
 	 * Return an array of ids from the query
@@ -101,142 +101,151 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_ids() : array {
-        if ( isset( $this->args['last'] ) || isset( $this->args['before'] ) ) {
-            throw new UserError( __( 'Sorry, last/before pagination is currently not supported.', 'wp-graphql-gravity-forms' ) );
-        }
+		if ( isset( $this->args['last'] ) || isset( $this->args['before'] ) ) {
+			throw new UserError( __( 'Sorry, last/before pagination is currently not supported.', 'wp-graphql-gravity-forms' ) );
+		}
 
-        $entry_ids = GFAPI::get_entry_ids(
-            $this->get_form_ids(),
-            $this->get_search_criteria(),
-            $this->get_sort(),
-            $this->get_paging(),
-        );
+		$entry_ids = GFAPI::get_entry_ids(
+			$this->get_form_ids(),
+			$this->get_search_criteria(),
+			$this->get_sort(),
+			$this->get_paging(),
+		);
 
-        if ( is_wp_error( $entry_ids ) ) {
-            throw new UserError( __( 'An error occurred while trying to get Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
-        }
+		if ( is_wp_error( $entry_ids ) ) {
+			throw new UserError( __( 'An error occurred while trying to get Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
+		}
 
-        return array_map( 'absint', $entry_ids );
-    }
+		return array_map( 'absint', $entry_ids );
+	}
 
-    private function get_form_ids() {
-        if ( ! empty( $this->args['where']['formIds'] ) && is_array( $this->args['where']['formIds'] ) ) {
-            return array_map( 'absint', $this->args['where']['formIds'] );
-        }
+	private function get_form_ids() {
+		if ( ! empty( $this->args['where']['formIds'] ) && is_array( $this->args['where']['formIds'] ) ) {
+			return array_map( 'absint', $this->args['where']['formIds'] );
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    private function get_search_criteria() : array {
-        $search_criteria = $this->apply_status_to_search_criteria( [] );
+	private function get_search_criteria() : array {
+		$search_criteria = $this->apply_status_to_search_criteria( [] );
 
-        if ( ! empty( $this->args['where']['dateFilters']['startDate'] ) ) {
-            $search_criteria['start_date'] = sanitize_text_field( $this->args['where']['dateFilters']['startDate'] );
-        }
+		if ( ! empty( $this->args['where']['dateFilters']['startDate'] ) ) {
+			$search_criteria['start_date'] = sanitize_text_field( $this->args['where']['dateFilters']['startDate'] );
+		}
 
-        if ( ! empty( $this->args['where']['dateFilters']['endDate'] ) ) {
-            $search_criteria['end_date'] = sanitize_text_field( $this->args['where']['dateFilters']['endDate'] );
-        }
+		if ( ! empty( $this->args['where']['dateFilters']['endDate'] ) ) {
+			$search_criteria['end_date'] = sanitize_text_field( $this->args['where']['dateFilters']['endDate'] );
+		}
 
-        if ( ! empty( $this->args['where']['fieldFilters'] ) && is_array( $this->args['where']['fieldFilters'] ) ) {
-            $search_criteria['field_filters'] = array_merge(
-                [ 'mode' => $this->args['where']['fieldFiltersMode'] ?? 'all' ],
-                $this->format_field_filters( $this->args['where']['fieldFilters'] )
-            );
-        }
+		if ( ! empty( $this->args['where']['fieldFilters'] ) && is_array( $this->args['where']['fieldFilters'] ) ) {
+			$search_criteria['field_filters'] = array_merge(
+				[ 'mode' => $this->args['where']['fieldFiltersMode'] ?? 'all' ],
+				$this->format_field_filters( $this->args['where']['fieldFilters'] )
+			);
+		}
 
-        return $search_criteria;
-    }
+		return $search_criteria;
+	}
 
-    private function apply_status_to_search_criteria( array $search_criteria ) : array {
-        $status = $this->args['where']['status'] ?? 'active'; // Default to active entries.
+	private function apply_status_to_search_criteria( array $search_criteria ) : array {
+		$status = $this->args['where']['status'] ?? 'active'; // Default to active entries.
 
-        // For all entries, don't add a 'status' value to search criteria.
-        if ( 'all' === $status ) {
-            return $search_criteria;
-        }
+		// For all entries, don't add a 'status' value to search criteria.
+		if ( 'all' === $status ) {
+			return $search_criteria;
+		}
 
-        $search_criteria['status'] = sanitize_text_field( $status );
+		$search_criteria['status'] = sanitize_text_field( $status );
 
-        return $search_criteria;
-    }
+		return $search_criteria;
+	}
 
-    private function format_field_filters( array $field_filters ) : array {
-        return array_reduce( $field_filters, function( $field_filters, $field_filter ) {
-            if ( empty( $field_filter['key'] ) ) {
-                throw new UserError( __( 'Every field filter must have a key.', 'wp-graphql-gravity-forms' ) );
-            }
+	private function format_field_filters( array $field_filters ) : array {
+		return array_reduce(
+			$field_filters,
+			function( $field_filters, $field_filter ) {
+				if ( empty( $field_filter['key'] ) ) {
+					throw new UserError( __( 'Every field filter must have a key.', 'wp-graphql-gravity-forms' ) );
+				}
 
-            $key             = sanitize_text_field( $field_filter['key'] );
-            $operator        = $field_filter['operator'] ?? FieldFiltersOperatorInputEnum::IN; // Default to "in".
-            $value           = $this->get_field_filter_value( $field_filter, $operator );
-            $field_filters[] = compact( 'key', 'operator', 'value' );
+				$key             = sanitize_text_field( $field_filter['key'] );
+				$operator        = $field_filter['operator'] ?? FieldFiltersOperatorInputEnum::IN; // Default to "in".
+				$value           = $this->get_field_filter_value( $field_filter, $operator );
+				$field_filters[] = compact( 'key', 'operator', 'value' );
 
-            return $field_filters;
-        }, [] );
-    }
+				return $field_filters;
+			},
+			[]
+		);
+	}
 
-    /**
-     * @param array  $field_filter Field filter.
-     * @param string $operator     Operator.
-     *
-     * @return mixed Filter value.
-     */
-    private function get_field_filter_value( array $field_filter, string $operator ) {
-        $value_fields = $this->get_field_filter_value_fields( $field_filter );
+	/**
+	 * @param array  $field_filter Field filter.
+	 * @param string $operator     Operator.
+	 *
+	 * @return mixed Filter value.
+	 */
+	private function get_field_filter_value( array $field_filter, string $operator ) {
+		$value_fields = $this->get_field_filter_value_fields( $field_filter );
 
-        if ( 1 !== count( $value_fields ) ) {
-            throw new UserError( __( 'Every field filter must have one value field.', 'wp-graphql-gravity-forms' ) );
-        }
+		if ( 1 !== count( $value_fields ) ) {
+			throw new UserError( __( 'Every field filter must have one value field.', 'wp-graphql-gravity-forms' ) );
+		}
 
-        $field_filter_values = array_map( 'sanitize_text_field', $field_filter[ $value_fields[0] ] );
+		$field_filter_values = array_map( 'sanitize_text_field', $field_filter[ $value_fields[0] ] );
 
-        if ( $this->should_field_filter_be_limited_to_single_value( $operator ) ) {
-            return $field_filter_values[0] ?? '';
-        }
+		if ( $this->should_field_filter_be_limited_to_single_value( $operator ) ) {
+			return $field_filter_values[0] ?? '';
+		}
 
-        return $field_filter_values;
-    }
+		return $field_filter_values;
+	}
 
-    private function should_field_filter_be_limited_to_single_value( string $operator ) : bool {
-        $operators_to_limit = [
-            FieldFiltersOperatorInputEnum::CONTAINS,
-            FieldFiltersOperatorInputEnum::GREATER_THAN,
-            FieldFiltersOperatorInputEnum::LESS_THAN,
-        ];
+	private function should_field_filter_be_limited_to_single_value( string $operator ) : bool {
+		$operators_to_limit = [
+			FieldFiltersOperatorInputEnum::CONTAINS,
+			FieldFiltersOperatorInputEnum::GREATER_THAN,
+			FieldFiltersOperatorInputEnum::LESS_THAN,
+		];
 
-        return in_array( $operator, $operators_to_limit, true );
-    }
+		return in_array( $operator, $operators_to_limit, true );
+	}
 
-    private function get_field_filter_value_fields( array $field_filter ) : array {
-        return array_values( array_filter( ['stringValues', 'intValues', 'floatValues', 'boolValues'], function( $value_field ) use ( $field_filter ) {
-            return ! empty( $field_filter[ $value_field ] );
-        } ) );
-    }
+	private function get_field_filter_value_fields( array $field_filter ) : array {
+		return array_values(
+			array_filter(
+				[ 'stringValues', 'intValues', 'floatValues', 'boolValues' ],
+				function( $value_field ) use ( $field_filter ) {
+					return ! empty( $field_filter[ $value_field ] );
+				}
+			)
+		);
+	}
 
-    private function get_sort() : array {
-        if ( ! empty( $this->args['where']['sort'] ) && is_array( $this->args['where']['sort'] ) ) {
-            return [
-                'key'        => $this->args['where']['sort']['key'] ?? '',
-                'direction'  => $this->args['where']['sort']['direction'] ?? 'ASC',
-                'is_numeric' => $this->args['where']['sort']['isNumeric'] ?? false,
-            ];
-        }
+	private function get_sort() : array {
+		if ( ! empty( $this->args['where']['sort'] ) && is_array( $this->args['where']['sort'] ) ) {
+			return [
+				'key'        => $this->args['where']['sort']['key'] ?? '',
+				'direction'  => $this->args['where']['sort']['direction'] ?? 'ASC',
+				'is_numeric' => $this->args['where']['sort']['isNumeric'] ?? false,
+			];
+		}
 
-        return [];
-    }
+		return [];
+	}
 
-    private function get_paging() : array {
-        $first = absint( $this->args['first'] ?? 20 );
-        $after_cursor  = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
+	private function get_paging() : array {
+		$first        = absint( $this->args['first'] ?? 20 );
+		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
 
-        // TODO
-        // $last  = absint( $this->args['last'] ?? 20 );
-        // $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
+		// TODO
+		// $last  = absint( $this->args['last'] ?? 20 );
+		// $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
 
-        return [
-            'offset'    => $after_cursor ? $after_cursor['offset'] + $after_cursor['index'] + 1 : 0,
-            'page_size' => $first + 1, // Fetch one more to determine if there is a next page.
-        ];
-    }
+		return [
+			'offset'    => $after_cursor ? $after_cursor['offset'] + $after_cursor['index'] + 1 : 0,
+			'page_size' => $first + 1, // Fetch one more to determine if there is a next page.
+		];
+	}
 }

--- a/src/Connections/RootQueryEntriesConnectionResolver.php
+++ b/src/Connections/RootQueryEntriesConnectionResolver.php
@@ -106,7 +106,7 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 			'index'  => $index,
 		];
 
-		return base64_encode( json_encode( $cursor ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		return base64_encode( wp_json_encode( $cursor ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	/**

--- a/src/Connections/RootQueryEntriesConnectionResolver.php
+++ b/src/Connections/RootQueryEntriesConnectionResolver.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * ConnectionResolver - RootQueryEntry
+ *
+ * Resolves connections to Entries.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -10,9 +18,14 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQLGravityForms\Data\Loader\EntriesLoader;
 use WPGraphQLGravityForms\Types\Enum\FieldFiltersOperatorInputEnum;
 
+/**
+ * Class - RootQueryEntriesConnectionResolver
+ */
 class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
-	 * @return bool Whether query should execute.
+	 * Returns whether query should execute.
+	 *
+	 * @return bool
 	 */
 	public function should_execute() : bool {
 		return current_user_can( 'gravityforms_view_entries' );
@@ -55,30 +68,36 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 	}
 
 	/**
-	 * @return array Query arguments.
+	 * Returns query arguments.
+	 *
+	 * @return array
 	 */
 	public function get_query_args() : array {
 		return [];
 	}
 
 	/**
-	 * @return array Query to use for data fetching.
+	 * Returns query to use for data fetching.
+	 *
+	 * @return array
 	 */
 	public function get_query() : array {
 		return [];
 	}
 
 	/**
+	 * Returns base-64 encoded cursor value.
+	 *
 	 * @param int $id Node ID.
 	 *
-	 * @return string Base-64 encoded cursor value.
+	 * @return string
 	 */
 	protected function get_cursor_for_node( $id ) : string {
 		$first        = $this->args['first'] ?? 20;
-		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
+		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$index        = array_search( $id, array_keys( $this->nodes ) );
 
-		// TODO
+		// @TODO: .
 		// $last  = $this->args['last'] ?? 20;
 		// $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
 
@@ -87,18 +106,18 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 			'index'  => $index,
 		];
 
-		return base64_encode( json_encode( $cursor ) );
+		return base64_encode( json_encode( $cursor ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	/**
-	 * get_ids
-	 *
 	 * Return an array of ids from the query
 	 *
 	 * Each Query class in WP and potential datasource handles this differently, so each connection
 	 * resolver should handle getting the items into a uniform array of items.
 	 *
 	 * @return array
+	 *
+	 * @throws UserError Pagination is not currently supported.
 	 */
 	public function get_ids() : array {
 		if ( isset( $this->args['last'] ) || isset( $this->args['before'] ) ) {
@@ -119,6 +138,11 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 		return array_map( 'absint', $entry_ids );
 	}
 
+	/**
+	 * Returns form ids.
+	 *
+	 * @return array|null
+	 */
 	private function get_form_ids() {
 		if ( ! empty( $this->args['where']['formIds'] ) && is_array( $this->args['where']['formIds'] ) ) {
 			return array_map( 'absint', $this->args['where']['formIds'] );
@@ -185,6 +209,8 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 	 * @param string $operator     Operator.
 	 *
 	 * @return mixed Filter value.
+	 *
+	 * @throws UserError Field filters must have one value field.
 	 */
 	private function get_field_filter_value( array $field_filter, string $operator ) {
 		$value_fields = $this->get_field_filter_value_fields( $field_filter );
@@ -237,9 +263,9 @@ class RootQueryEntriesConnectionResolver extends AbstractConnectionResolver {
 
 	private function get_paging() : array {
 		$first        = absint( $this->args['first'] ?? 20 );
-		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null;
+		$after_cursor = ! empty( $this->args['after'] ) ? json_decode( base64_decode( $this->args['after'] ), true ) : null; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 
-		// TODO
+		// @TODO: .
 		// $last  = absint( $this->args['last'] ?? 20 );
 		// $before_cursor = ! empty( $this->args['before'] ) ? json_decode( base64_decode( $this->args['before'] ), true ) : null;
 

--- a/src/Connections/RootQueryFormsConnection.php
+++ b/src/Connections/RootQueryFormsConnection.php
@@ -10,29 +10,31 @@ use WPGraphQLGravityForms\Types\Form\Form;
 use WPGraphQLGravityForms\Types\Enum\FormStatusEnum;
 
 class RootQueryFormsConnection implements Hookable, Connection {
-    /**
-     * The from field name.
-     */
-    const FROM_FIELD = 'gravityFormsForms';
+	/**
+	 * The from field name.
+	 */
+	const FROM_FIELD = 'gravityFormsForms';
 
-    public function register_hooks() {
-        add_action('init', [ $this, 'register_connection' ] );
-    }
+	public function register_hooks() {
+		add_action( 'init', [ $this, 'register_connection' ] );
+	}
 
-    public function register_connection() {
-        register_graphql_connection( [
-            'fromType'      => 'RootQuery',
-            'toType'        => Form::TYPE,
-            'fromFieldName' => self::FROM_FIELD,
-            'connectionArgs' => [
-                'status' => [
-                    'type'        => FormStatusEnum::TYPE,
-                    'description' => __( 'Status of the forms to get.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-            'resolve' => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
-                return ( new RootQueryFormsConnectionResolver() )->resolve( $root, $args, $context, $info );
-            },
-        ] );
-    }
+	public function register_connection() {
+		register_graphql_connection(
+			[
+				'fromType'       => 'RootQuery',
+				'toType'         => Form::TYPE,
+				'fromFieldName'  => self::FROM_FIELD,
+				'connectionArgs' => [
+					'status' => [
+						'type'        => FormStatusEnum::TYPE,
+						'description' => __( 'Status of the forms to get.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+				'resolve'        => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
+					return ( new RootQueryFormsConnectionResolver() )->resolve( $root, $args, $context, $info );
+				},
+			]
+		);
+	}
 }

--- a/src/Connections/RootQueryFormsConnection.php
+++ b/src/Connections/RootQueryFormsConnection.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Connection - RootQueryForms
+ * Registers connections from RootQuery.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -9,16 +16,26 @@ use WPGraphQLGravityForms\Interfaces\Connection;
 use WPGraphQLGravityForms\Types\Form\Form;
 use WPGraphQLGravityForms\Types\Enum\FormStatusEnum;
 
+/**
+ * Class - RootQueryFormsConnection
+ */
 class RootQueryFormsConnection implements Hookable, Connection {
 	/**
 	 * The from field name.
 	 */
 	const FROM_FIELD = 'gravityFormsForms';
 
+
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'init', [ $this, 'register_connection' ] );
 	}
 
+	/**
+	 * Register connection from RootQuery type to GravityFormsForm type.
+	 */
 	public function register_connection() {
 		register_graphql_connection(
 			[

--- a/src/Connections/RootQueryFormsConnectionResolver.php
+++ b/src/Connections/RootQueryFormsConnectionResolver.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * ConnectionResolver - RootQueryEntry
+ *
+ * Resolves connections to Entries.
+ *
+ * @package WPGraphQLGravityForms\Connections
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Connections;
 
@@ -11,6 +19,9 @@ use WPGraphQLGravityForms\DataManipulators\FieldsDataManipulator;
 use WPGraphQLGravityForms\DataManipulators\FormDataManipulator;
 use WPGraphQLGravityForms\Types\Enum\FormStatusEnum;
 
+/**
+ * Class - RootQueryEntriesConnectionResolver
+ */
 class RootQueryFormsConnectionResolver {
 	/**
 	 * Resolves queries for forms.
@@ -21,6 +32,8 @@ class RootQueryFormsConnectionResolver {
 	 * @param ResolveInfo $info    The ResolveInfo object.
 	 *
 	 * @return array|null The connection or null if no forms.
+	 *
+	 * @throws UserError .
 	 */
 	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$status = $this->get_form_status( $args );
@@ -62,6 +75,12 @@ class RootQueryFormsConnectionResolver {
 		return $connection;
 	}
 
+	/**
+	 * Gets form status from query.
+	 *
+	 * @param array $args the query arguments.
+	 * @return array
+	 */
 	private function get_form_status( array $args ) : array {
 		$status = $args['where']['status'] ?? '';
 

--- a/src/Connections/RootQueryFormsConnectionResolver.php
+++ b/src/Connections/RootQueryFormsConnectionResolver.php
@@ -12,7 +12,7 @@ use WPGraphQLGravityForms\DataManipulators\FormDataManipulator;
 use WPGraphQLGravityForms\Types\Enum\FormStatusEnum;
 
 class RootQueryFormsConnectionResolver {
-    /**
+	/**
 	 * Resolves queries for forms.
 	 *
 	 * @param mixed       $source  The query results.
@@ -22,71 +22,74 @@ class RootQueryFormsConnectionResolver {
 	 *
 	 * @return array|null The connection or null if no forms.
 	 */
-    public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
-        $status = $this->get_form_status( $args );
-        $forms  = GFAPI::get_forms( $status['active'], $status['trashed'] );
+	public function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
+		$status = $this->get_form_status( $args );
+		$forms  = GFAPI::get_forms( $status['active'], $status['trashed'] );
 
-        if ( is_wp_error( $forms ) ) {
-            throw new UserError( __( 'An error occurred while trying to get Gravity Forms forms.', 'wp-graphql-gravity-forms' ) );
-        }
+		if ( is_wp_error( $forms ) ) {
+			throw new UserError( __( 'An error occurred while trying to get Gravity Forms forms.', 'wp-graphql-gravity-forms' ) );
+		}
 
-        if ( ! $forms ) {
-            return null;
-        }
+		if ( ! $forms ) {
+			return null;
+		}
 
-        $form_data_manipulator = new FormDataManipulator( new FieldsDataManipulator() );
-        $forms = array_map( fn( $form ) => $form_data_manipulator->manipulate( $form ), $forms );
+		$form_data_manipulator = new FormDataManipulator( new FieldsDataManipulator() );
+		$forms                 = array_map( fn( $form ) => $form_data_manipulator->manipulate( $form ), $forms );
 
-        /**
-         * "wp_graphql_gf_form_object" filter
-         *
-         * Provides the ability to manipulate the form data before it is sent to the
-         * client. This hook is somewhat similar to Gravity Forms' gform_pre_render hook
-         * and can be used for dynamic field input population, among other things.
-         *
-         * @param array $form Form meta array.
-         */
-        $forms = array_map( fn( $form ) => apply_filters( 'wp_graphql_gf_form_object', $form ), $forms );
+		/**
+		 * "wp_graphql_gf_form_object" filter
+		 *
+		 * Provides the ability to manipulate the form data before it is sent to the
+		 * client. This hook is somewhat similar to Gravity Forms' gform_pre_render hook
+		 * and can be used for dynamic field input population, among other things.
+		 *
+		 * @param array $form Form meta array.
+		 */
+		$forms = array_map( fn( $form ) => apply_filters( 'wp_graphql_gf_form_object', $form ), $forms );
 
-        $connection = Relay::connectionFromArray( $forms, $args );
+		$connection = Relay::connectionFromArray( $forms, $args );
 
-        $nodes = array_map( function( $edge ) {
-            return ! empty( $edge['node'] ) ? $edge['node'] : null;
-        }, $connection['edges'] );
+		$nodes = array_map(
+			function( $edge ) {
+				return ! empty( $edge['node'] ) ? $edge['node'] : null;
+			},
+			$connection['edges']
+		);
 
-        $connection['nodes'] = $nodes ?: null;
+		$connection['nodes'] = $nodes ?: null;
 
-        return $connection;
-    }
+		return $connection;
+	}
 
-    private function get_form_status( array $args ) : array {
-        $status = $args['where']['status'] ?? '';
+	private function get_form_status( array $args ) : array {
+		$status = $args['where']['status'] ?? '';
 
-        if ( FormStatusEnum::INACTIVE === $status ) {
-            return [
-                'active'  => false,
-                'trashed' => false,
-            ];
-        }
+		if ( FormStatusEnum::INACTIVE === $status ) {
+			return [
+				'active'  => false,
+				'trashed' => false,
+			];
+		}
 
-        if ( FormStatusEnum::TRASHED === $status ) {
-            return [
-                'active'  => true,
-                'trashed' => true,
-            ];
-        }
+		if ( FormStatusEnum::TRASHED === $status ) {
+			return [
+				'active'  => true,
+				'trashed' => true,
+			];
+		}
 
-        if ( FormStatusEnum::INACTIVE_TRASHED === $status ) {
-            return [
-                'active'  => false,
-                'trashed' => true,
-            ];
-        }
+		if ( FormStatusEnum::INACTIVE_TRASHED === $status ) {
+			return [
+				'active'  => false,
+				'trashed' => true,
+			];
+		}
 
-        // Get forms that are active and not in the trash by default.
-        return [
-            'active'  => true,
-            'trashed' => false,
-        ];
-    }
+		// Get forms that are active and not in the trash by default.
+		return [
+			'active'  => true,
+			'trashed' => false,
+		];
+	}
 }

--- a/src/Data/Loader/EntriesLoader.php
+++ b/src/Data/Loader/EntriesLoader.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * DataLoader - Entries
+ *
+ * Loads Models for Gravity Forms Entries.
+ *
+ * @package WPGraphQLGravityForms\Data\Loader
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Data\Loader;
 
@@ -7,6 +15,9 @@ use GraphQL\Deferred;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
 use WPGraphQLGravityForms\DataManipulators\EntryDataManipulator;
 
+/**
+ * Class - EntriesLoader
+ */
 class EntriesLoader extends AbstractDataLoader {
 	/**
 	 * Loader name.
@@ -23,10 +34,10 @@ class EntriesLoader extends AbstractDataLoader {
 	 * For example:
 	 * loadKeys(['a', 'b', 'c']) -> ['a' => 'value1, 'b' => null, 'c' => 'value3']
 	 *
-	 * @param array $keys
+	 * @param array $keys .
 	 *
 	 * @return array
-	 * @throws \Exception
+	 * @throws \Exception .
 	 */
 	public function loadKeys( array $keys ) {
 		if ( empty( $keys ) ) {

--- a/src/Data/Loader/LoadersRegistrar.php
+++ b/src/Data/Loader/LoadersRegistrar.php
@@ -1,16 +1,32 @@
 <?php
+/**
+ * DataLoader - Loaders Registrar
+ *
+ * Adds data loaders to AppContext.
+ *
+ * @package WPGraphQLGravityForms\Data\Loader
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Data\Loader;
 
 use WPGraphQL\AppContext;
 use WPGraphQLGravityForms\Interfaces\Hookable;
 
+/**
+ * Class - LoadersRegistrar
+ */
 class LoadersRegistrar implements Hookable {
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
 	}
 
 	/**
+	 * Registers loaders to AppContext.
+	 *
 	 * @param array      $loaders Data loaders.
 	 * @param AppContext $context App context.
 	 *

--- a/src/Data/Loader/LoadersRegistrar.php
+++ b/src/Data/Loader/LoadersRegistrar.php
@@ -6,19 +6,19 @@ use WPGraphQL\AppContext;
 use WPGraphQLGravityForms\Interfaces\Hookable;
 
 class LoadersRegistrar implements Hookable {
-    public function register_hooks() {
-        add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
-    }
+	public function register_hooks() {
+		add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
+	}
 
-    /**
-     * @param array      $loaders Data loaders.
-     * @param AppContext $context App context.
-     *
-     * @return array Data loaders, with new ones added.
-     */
-    public function register_loaders( array $loaders, AppContext $context ) : array {
-        $loaders[ EntriesLoader::NAME ] = new EntriesLoader( $context );
+	/**
+	 * @param array      $loaders Data loaders.
+	 * @param AppContext $context App context.
+	 *
+	 * @return array Data loaders, with new ones added.
+	 */
+	public function register_loaders( array $loaders, AppContext $context ) : array {
+		$loaders[ EntriesLoader::NAME ] = new EntriesLoader( $context );
 
-        return $loaders;
-    }
+		return $loaders;
+	}
 }

--- a/src/DataManipulators/DraftEntryDataManipulator.php
+++ b/src/DataManipulators/DraftEntryDataManipulator.php
@@ -1,13 +1,31 @@
 <?php
+/**
+ * DataManipulators - DraftEntryData
+ *
+ * Manipulates draft entry data.
+ *
+ * @package WPGraphQLGravityForms\DataManipulators
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\DataManipulators;
 
+/**
+ * Class - DraftEntryDataManipulator
+ */
 class DraftEntryDataManipulator {
 	/**
 	 * EntryDataManipulator instance.
+	 *
+	 * @var EntryDataManipulator
 	 */
 	private $entry_data_manipulator;
 
+	/**
+	 * Constructor
+	 *
+	 * @param EntryDataManipulator $entry_data_manipulator .
+	 */
 	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
 		$this->entry_data_manipulator = $entry_data_manipulator;
 	}
@@ -27,6 +45,14 @@ class DraftEntryDataManipulator {
 		return $draft_entry;
 	}
 
+	/**
+	 * Sets resume token for the draft entry.
+	 *
+	 * @param array  $draft_entry  The draft entry data to be manipulated.
+	 * @param string $resume_token The resume token for the draft entry.
+	 *
+	 * @return array Manipulated entry data.
+	 */
 	private function set_resume_token_value( array $draft_entry, string $resume_token ) : array {
 		$draft_entry['resumeToken'] = $resume_token;
 		return $draft_entry;

--- a/src/DataManipulators/DraftEntryDataManipulator.php
+++ b/src/DataManipulators/DraftEntryDataManipulator.php
@@ -3,32 +3,32 @@
 namespace WPGraphQLGravityForms\DataManipulators;
 
 class DraftEntryDataManipulator {
-    /**
-     * EntryDataManipulator instance.
-     */
-    private $entry_data_manipulator;
+	/**
+	 * EntryDataManipulator instance.
+	 */
+	private $entry_data_manipulator;
 
-    public function __construct( EntryDataManipulator $entry_data_manipulator ) {
-        $this->entry_data_manipulator = $entry_data_manipulator;
-    }
+	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
+		$this->entry_data_manipulator = $entry_data_manipulator;
+	}
 
-    /**
-     * Manipulate draft entry data.
-     *
-     * @param array  $draft_entry  The draft entry data to be manipulated.
-     * @param string $resume_token The resume token for the draft entry.
-     *
-     * @return array Manipulated entry data.
-     */
-    public function manipulate( array $draft_entry, string $resume_token ) : array {
-        $draft_entry = $this->set_resume_token_value( $draft_entry, $resume_token );
-        $draft_entry = $this->entry_data_manipulator->manipulate( $draft_entry );
+	/**
+	 * Manipulate draft entry data.
+	 *
+	 * @param array  $draft_entry  The draft entry data to be manipulated.
+	 * @param string $resume_token The resume token for the draft entry.
+	 *
+	 * @return array Manipulated entry data.
+	 */
+	public function manipulate( array $draft_entry, string $resume_token ) : array {
+		$draft_entry = $this->set_resume_token_value( $draft_entry, $resume_token );
+		$draft_entry = $this->entry_data_manipulator->manipulate( $draft_entry );
 
-        return $draft_entry;
-    }
+		return $draft_entry;
+	}
 
-    private function set_resume_token_value( array $draft_entry, string $resume_token ) : array {
-        $draft_entry['resumeToken'] = $resume_token;
-        return $draft_entry;
-    }
+	private function set_resume_token_value( array $draft_entry, string $resume_token ) : array {
+		$draft_entry['resumeToken'] = $resume_token;
+		return $draft_entry;
+	}
 }

--- a/src/DataManipulators/EntryDataManipulator.php
+++ b/src/DataManipulators/EntryDataManipulator.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * DataManipulators - EntryData
+ *
+ * Manipulates entry data.
+ *
+ * @package WPGraphQLGravityForms\DataManipulators
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\DataManipulators;
 
@@ -6,6 +14,9 @@ use GraphQLRelay\Relay;
 use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Entry\Entry;
 
+/**
+ * Class - EntryDataManipulator
+ */
 class EntryDataManipulator implements DataManipulator {
 	/**
 	 * Manipulate entry data.
@@ -23,6 +34,8 @@ class EntryDataManipulator implements DataManipulator {
 	}
 
 	/**
+	 * Returns Entry data, with the isDraft value set.
+	 *
 	 * @param array $entry Entry data.
 	 *
 	 * @return array $entry Entry data, with the isDraft value set.
@@ -37,7 +50,7 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @param array $entry Entry data.
 	 *
-	 * @return array $entry Entry data, with the entry ID and global Relay ID set.
+	 * @return array
 	 */
 	private function set_global_and_entry_ids( array $entry ) : array {
 		$entry['entryId'] = $entry['id'];
@@ -47,18 +60,22 @@ class EntryDataManipulator implements DataManipulator {
 	}
 
 	/**
+	 * Returns the ID to be used to generate the Relay global ID.
+	 *
 	 * @param array $entry Entry data.
 	 *
-	 * @return string The ID to be used to generate the Relay global ID.
+	 * @return string
 	 */
 	private function get_id_for_global_id_generation( array $entry ) : string {
 		return $entry['isDraft'] ? $entry['resumeToken'] : $entry['entryId'];
 	}
 
 	/**
+	 * Returns Entry data with keys converted to camelCase.
+	 *
 	 * @param array $entry Entry data.
 	 *
-	 * @return array $entry Entry data with keys converted to camelCase.
+	 * @return array
 	 */
 	private function convert_keys_to_camelcase( array $entry ) : array {
 		foreach ( $this->get_key_mappings() as $snake_case_key => $camel_case_key ) {
@@ -74,7 +91,9 @@ class EntryDataManipulator implements DataManipulator {
 	}
 
 	/**
-	 * @return array Gravity Forms Entry meta keys and their camelCase equivalents.
+	 * Returns an array of Gravity Forms Entry meta keys and their camelCase equivalents.
+	 *
+	 * @return array
 	 */
 	private function get_key_mappings() : array {
 		return [

--- a/src/DataManipulators/EntryDataManipulator.php
+++ b/src/DataManipulators/EntryDataManipulator.php
@@ -7,93 +7,93 @@ use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Entry\Entry;
 
 class EntryDataManipulator implements DataManipulator {
-    /**
-     * Manipulate entry data.
-     *
-     * @param array $data The entry data to be manipulated.
-     *
-     * @return array Manipulated entry data.
-     */
-    public function manipulate( array $data ) : array {
-        $data = $this->set_is_draft_value( $data );
-        $data = $this->set_global_and_entry_ids( $data );
-        $data = $this->convert_keys_to_camelcase( $data );
+	/**
+	 * Manipulate entry data.
+	 *
+	 * @param array $data The entry data to be manipulated.
+	 *
+	 * @return array Manipulated entry data.
+	 */
+	public function manipulate( array $data ) : array {
+		$data = $this->set_is_draft_value( $data );
+		$data = $this->set_global_and_entry_ids( $data );
+		$data = $this->convert_keys_to_camelcase( $data );
 
-        return $data;
-    }
+		return $data;
+	}
 
-    /**
-     * @param array $entry Entry data.
-     *
-     * @return array $entry Entry data, with the isDraft value set.
-     */
-    private function set_is_draft_value( array $entry ) : array {
-        $entry['isDraft'] = ! empty( $entry['resumeToken'] );
-        return $entry;
-    }
+	/**
+	 * @param array $entry Entry data.
+	 *
+	 * @return array $entry Entry data, with the isDraft value set.
+	 */
+	private function set_is_draft_value( array $entry ) : array {
+		$entry['isDraft'] = ! empty( $entry['resumeToken'] );
+		return $entry;
+	}
 
-    /**
-     * Set 'entryId' to be the entry ID and 'id' to be the global Relay ID.
-     *
-     * @param array $entry Entry data.
-     *
-     * @return array $entry Entry data, with the entry ID and global Relay ID set.
-     */
-    private function set_global_and_entry_ids( array $entry ) : array {
-        $entry['entryId'] = $entry['id'];
-        $entry['id']      = Relay::toGlobalId( Entry::TYPE, $this->get_id_for_global_id_generation( $entry ) );
+	/**
+	 * Set 'entryId' to be the entry ID and 'id' to be the global Relay ID.
+	 *
+	 * @param array $entry Entry data.
+	 *
+	 * @return array $entry Entry data, with the entry ID and global Relay ID set.
+	 */
+	private function set_global_and_entry_ids( array $entry ) : array {
+		$entry['entryId'] = $entry['id'];
+		$entry['id']      = Relay::toGlobalId( Entry::TYPE, $this->get_id_for_global_id_generation( $entry ) );
 
-        return $entry;
-    }
+		return $entry;
+	}
 
-    /**
-     * @param array $entry Entry data.
-     *
-     * @return string The ID to be used to generate the Relay global ID.
-     */
-    private function get_id_for_global_id_generation( array $entry ) : string {
-        return $entry['isDraft'] ? $entry['resumeToken'] : $entry['entryId'];
-    }
+	/**
+	 * @param array $entry Entry data.
+	 *
+	 * @return string The ID to be used to generate the Relay global ID.
+	 */
+	private function get_id_for_global_id_generation( array $entry ) : string {
+		return $entry['isDraft'] ? $entry['resumeToken'] : $entry['entryId'];
+	}
 
-    /**
-     * @param array $entry Entry data.
-     *
-     * @return array $entry Entry data with keys converted to camelCase.
-     */
-    private function convert_keys_to_camelcase( array $entry ) : array {
-        foreach ( $this->get_key_mappings() as $snake_case_key => $camel_case_key ) {
-            if ( ! isset( $entry[ $snake_case_key ] ) ) {
-                continue;
-            }
+	/**
+	 * @param array $entry Entry data.
+	 *
+	 * @return array $entry Entry data with keys converted to camelCase.
+	 */
+	private function convert_keys_to_camelcase( array $entry ) : array {
+		foreach ( $this->get_key_mappings() as $snake_case_key => $camel_case_key ) {
+			if ( ! isset( $entry[ $snake_case_key ] ) ) {
+				continue;
+			}
 
-            $entry[ $camel_case_key ] = $entry[ $snake_case_key ];
-            unset( $entry[ $snake_case_key ] );
-        }
+			$entry[ $camel_case_key ] = $entry[ $snake_case_key ];
+			unset( $entry[ $snake_case_key ] );
+		}
 
-        return $entry;
-    }
+		return $entry;
+	}
 
-    /**
-     * @return array Gravity Forms Entry meta keys and their camelCase equivalents.
-     */
-    private function get_key_mappings() : array {
-        return [
-            'form_id'          => 'formId',
-            'post_id'          => 'postId',
-            'date_created'     => 'dateCreated',
-            'date_updated'     => 'dateUpdated',
-            'is_starred'       => 'isStarred',
-            'is_read'          => 'isRead',
-            'source_url'       => 'sourceUrl',
-            'user_agent'       => 'userAgent',
-            'payment_status'   => 'paymentStatus',
-            'payment_date'     => 'paymentDate',
-            'payment_amount'   => 'paymentAmount',
-            'payment_method'   => 'paymentMethod',
-            'transaction_id'   => 'transactionId',
-            'is_fulfilled'     => 'isFulfilled',
-            'created_by'       => 'createdById',
-            'transaction_type' => 'transactionType',
-        ];
-    }
+	/**
+	 * @return array Gravity Forms Entry meta keys and their camelCase equivalents.
+	 */
+	private function get_key_mappings() : array {
+		return [
+			'form_id'          => 'formId',
+			'post_id'          => 'postId',
+			'date_created'     => 'dateCreated',
+			'date_updated'     => 'dateUpdated',
+			'is_starred'       => 'isStarred',
+			'is_read'          => 'isRead',
+			'source_url'       => 'sourceUrl',
+			'user_agent'       => 'userAgent',
+			'payment_status'   => 'paymentStatus',
+			'payment_date'     => 'paymentDate',
+			'payment_amount'   => 'paymentAmount',
+			'payment_method'   => 'paymentMethod',
+			'transaction_id'   => 'transactionId',
+			'is_fulfilled'     => 'isFulfilled',
+			'created_by'       => 'createdById',
+			'transaction_type' => 'transactionType',
+		];
+	}
 }

--- a/src/DataManipulators/FieldsDataManipulator.php
+++ b/src/DataManipulators/FieldsDataManipulator.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * DataManipulators - FieldsData
+ *
+ * Manipulates Fields data.
+ *
+ * @package WPGraphQLGravityForms\DataManipulators
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\DataManipulators;
 
@@ -7,6 +15,9 @@ use GraphQLRelay\Relay;
 use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Form\Form;
 
+/**
+ * Class - FieldsDataManipulator
+ */
 class FieldsDataManipulator implements DataManipulator {
 	/**
 	 * Manipulate form fields data.
@@ -25,9 +36,11 @@ class FieldsDataManipulator implements DataManipulator {
 	}
 
 	/**
+	 * Returns Form field with its cssClassList value set.
+	 *
 	 * @param GF_Field $field Form field.
 	 *
-	 * @return GF_Field $field Form field with its cssClassList value set.
+	 * @return GF_Field
 	 */
 	private function set_css_class_list_for_field( GF_Field $field ) : GF_Field {
 		$field->cssClassList = array_filter(
@@ -110,6 +123,11 @@ class FieldsDataManipulator implements DataManipulator {
 		return $this->get_name_input_keys();
 	}
 
+	/**
+	 * Returns input keys for Address field.
+	 *
+	 * @return array
+	 */
 	private function get_address_input_keys() {
 		return [
 			'street',
@@ -121,6 +139,11 @@ class FieldsDataManipulator implements DataManipulator {
 		];
 	}
 
+	/**
+	 * Returns input keys for Name field.
+	 *
+	 * @return array
+	 */
 	private function get_name_input_keys() {
 		return [
 			'prefix',

--- a/src/DataManipulators/FieldsDataManipulator.php
+++ b/src/DataManipulators/FieldsDataManipulator.php
@@ -8,117 +8,126 @@ use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Form\Form;
 
 class FieldsDataManipulator implements DataManipulator {
-    /**
-     * Manipulate form fields data.
-     *
-     * @param array $data The form fields data to be manipulated.
-     *
-     * @return array Manipulated form fields data.
-     */
-    public function manipulate( array $data ) : array {
-        $data = array_map( [ $this, 'set_css_class_list_for_field' ], $data );
-        $data = $this->set_is_hidden_values( $data );
-        $data = $this->add_keys_to_inputs( $data, 'address' );
-        $data = $this->add_keys_to_inputs( $data, 'name' );
+	/**
+	 * Manipulate form fields data.
+	 *
+	 * @param array $data The form fields data to be manipulated.
+	 *
+	 * @return array Manipulated form fields data.
+	 */
+	public function manipulate( array $data ) : array {
+		$data = array_map( [ $this, 'set_css_class_list_for_field' ], $data );
+		$data = $this->set_is_hidden_values( $data );
+		$data = $this->add_keys_to_inputs( $data, 'address' );
+		$data = $this->add_keys_to_inputs( $data, 'name' );
 
-        return $data;
-    }
+		return $data;
+	}
 
-    /**
-     * @param GF_Field $field Form field.
-     *
-     * @return GF_Field $field Form field with its cssClassList value set.
-     */
-    private function set_css_class_list_for_field( GF_Field $field ) : GF_Field {
-        $field->cssClassList = array_filter( explode( ' ', $field->cssClass ), function( $css_class ) {
-            return '' !== $css_class;
-        } );
+	/**
+	 * @param GF_Field $field Form field.
+	 *
+	 * @return GF_Field $field Form field with its cssClassList value set.
+	 */
+	private function set_css_class_list_for_field( GF_Field $field ) : GF_Field {
+		$field->cssClassList = array_filter(
+			explode( ' ', $field->cssClass ),
+			function( $css_class ) {
+				return '' !== $css_class;
+			}
+		);
 
-        return $field;
-    }
+		return $field;
+	}
 
-    /**
-     * Some field inputs don't always have their 'isHidden' keys set.
-     * This makes sure they're always set to true or false.
-     *
-     * @param array $fields Form fields.
-     *
-     * @return array $fields Form fields with address 'isHidden' values coerced to booleans.
-     */
-    private function set_is_hidden_values( array $fields ) : array {
-        $fields_to_modify = array_filter( $fields, function( $field ) {
-            return 'address' === $field['type'] || 'name' === $field['type'];
-        });
+	/**
+	 * Some field inputs don't always have their 'isHidden' keys set.
+	 * This makes sure they're always set to true or false.
+	 *
+	 * @param array $fields Form fields.
+	 *
+	 * @return array $fields Form fields with address 'isHidden' values coerced to booleans.
+	 */
+	private function set_is_hidden_values( array $fields ) : array {
+		$fields_to_modify = array_filter(
+			$fields,
+			function( $field ) {
+				return 'address' === $field['type'] || 'name' === $field['type'];
+			}
+		);
 
-        foreach ( $fields_to_modify as $field_index => $field ) {
-            /**
-             * The inputs are copied, modified, then used to overwrite the original inputs
-             * to avoid this error that occurs when trying to modify input keys directly:
-             * "indirect modification of overloaded element of <field object>"
-             */
-            $inputs = $field['inputs'];
+		foreach ( $fields_to_modify as $field_index => $field ) {
+			/**
+			 * The inputs are copied, modified, then used to overwrite the original inputs
+			 * to avoid this error that occurs when trying to modify input keys directly:
+			 * "indirect modification of overloaded element of <field object>"
+			 */
+			$inputs = $field['inputs'];
 
-            foreach ( $inputs as $input_index => $input ) {
-                $inputs[ $input_index ]['isHidden'] = (bool) ( $inputs[ $input_index ]['isHidden'] ?? false );
-            }
+			foreach ( $inputs as $input_index => $input ) {
+				$inputs[ $input_index ]['isHidden'] = (bool) ( $inputs[ $input_index ]['isHidden'] ?? false );
+			}
 
-            $fields[ $field_index ]['inputs'] = $inputs;
-        }
+			$fields[ $field_index ]['inputs'] = $inputs;
+		}
 
-        return $fields;
-    }
+		return $fields;
+	}
 
-    private function add_keys_to_inputs( array $fields, string $type ) : array {
-        $input_keys = $this->get_input_keys( $type );
+	private function add_keys_to_inputs( array $fields, string $type ) : array {
+		$input_keys = $this->get_input_keys( $type );
 
-        $fields_to_modify = array_filter( $fields, function( $field ) use ( $type ) {
-            return $type === $field['type'];
-        });
+		$fields_to_modify = array_filter(
+			$fields,
+			function( $field ) use ( $type ) {
+				return $type === $field['type'];
+			}
+		);
 
-        foreach ( $fields_to_modify as $field_index => $field ) {
-            /**
-             * The inputs are copied, modified, then used to overwrite the original inputs
-             * to avoid this error that occurs when trying to modify input keys directly:
-             * "indirect modification of overloaded element of <field object>"
-             */
-            $inputs = $field['inputs'];
+		foreach ( $fields_to_modify as $field_index => $field ) {
+			/**
+			 * The inputs are copied, modified, then used to overwrite the original inputs
+			 * to avoid this error that occurs when trying to modify input keys directly:
+			 * "indirect modification of overloaded element of <field object>"
+			 */
+			$inputs = $field['inputs'];
 
-            foreach ( $inputs as $input_index => $input ) {
-                $inputs[ $input_index ]['key'] = $input_keys[ $input_index ];
-            }
+			foreach ( $inputs as $input_index => $input ) {
+				$inputs[ $input_index ]['key'] = $input_keys[ $input_index ];
+			}
 
-            $fields[ $field_index ]['inputs'] = $inputs;
-        }
+			$fields[ $field_index ]['inputs'] = $inputs;
+		}
 
-        return $fields;
-    }
+		return $fields;
+	}
 
-    private function get_input_keys( string $type ) : array {
-        if ( 'address' === $type ) {
-            return $this->get_address_input_keys();
-        }
+	private function get_input_keys( string $type ) : array {
+		if ( 'address' === $type ) {
+			return $this->get_address_input_keys();
+		}
 
-        return $this->get_name_input_keys();
-    }
+		return $this->get_name_input_keys();
+	}
 
-    private function get_address_input_keys() {
-        return [
-            'street',
-            'lineTwo',
-            'city',
-            'state',
-            'zip',
-            'country',
-        ];
-    }
+	private function get_address_input_keys() {
+		return [
+			'street',
+			'lineTwo',
+			'city',
+			'state',
+			'zip',
+			'country',
+		];
+	}
 
-    private function get_name_input_keys() {
-        return [
-            'prefix',
-            'first',
-            'middle',
-            'last',
-            'suffix',
-        ];
-    }
+	private function get_name_input_keys() {
+		return [
+			'prefix',
+			'first',
+			'middle',
+			'last',
+			'suffix',
+		];
+	}
 }

--- a/src/DataManipulators/FormDataManipulator.php
+++ b/src/DataManipulators/FormDataManipulator.php
@@ -7,126 +7,132 @@ use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Form\Form;
 
 class FormDataManipulator implements DataManipulator {
-    /**
-     * FieldsDataManipulator instance.
-     */
-    private $fields_data_manipulator;
+	/**
+	 * FieldsDataManipulator instance.
+	 */
+	private $fields_data_manipulator;
 
-    public function __construct( FieldsDataManipulator $fields_data_manipulator ) {
-        $this->fields_data_manipulator = $fields_data_manipulator;
-    }
+	public function __construct( FieldsDataManipulator $fields_data_manipulator ) {
+		$this->fields_data_manipulator = $fields_data_manipulator;
+	}
 
-    /**
-     * Manipulate form data.
-     *
-     * @param array $data The form data to be manipulated.
-     *
-     * @return array Manipulated form data.
-     */
-    public function manipulate( array $data ) : array {
-        $data = $this->set_global_and_form_ids( $data );
-        $data = $this->set_css_class_list( $data );
-        $data = $this->convert_form_keys_to_camelcase( $data );
-        $data = $this->prevent_missing_values( $data );
+	/**
+	 * Manipulate form data.
+	 *
+	 * @param array $data The form data to be manipulated.
+	 *
+	 * @return array Manipulated form data.
+	 */
+	public function manipulate( array $data ) : array {
+		$data = $this->set_global_and_form_ids( $data );
+		$data = $this->set_css_class_list( $data );
+		$data = $this->convert_form_keys_to_camelcase( $data );
+		$data = $this->prevent_missing_values( $data );
 
-        $data['fields'] = $this->fields_data_manipulator->manipulate( $data['fields'] );
+		$data['fields'] = $this->fields_data_manipulator->manipulate( $data['fields'] );
 
-        return $data;
-    }
+		return $data;
+	}
 
-    /**
-     * Set 'formId' to be the form ID and 'id' to be the global Relay ID.
-     *
-     * @param array $form Form meta array.
-     *
-     * @return array $form Form meta array with the form ID and global Relay ID set.
-     */
-    private function set_global_and_form_ids( array $form ) : array {
-        $form['formId'] = $form['id'];
-        $form['id']     = Relay::toGlobalId( Form::TYPE, $form['formId'] );
+	/**
+	 * Set 'formId' to be the form ID and 'id' to be the global Relay ID.
+	 *
+	 * @param array $form Form meta array.
+	 *
+	 * @return array $form Form meta array with the form ID and global Relay ID set.
+	 */
+	private function set_global_and_form_ids( array $form ) : array {
+		$form['formId'] = $form['id'];
+		$form['id']     = Relay::toGlobalId( Form::TYPE, $form['formId'] );
 
-        return $form;
-    }
+		return $form;
+	}
 
-    /**
-     * @param array $form Form meta array.
-     *
-     * @return array $form Form meta array with the cssClassList value set.
-     */
-    private function set_css_class_list( array $form ) : array {
-        if ( empty( $form['cssClass'] ) ) {
-            $form['cssClassList'] = null;
-            return $form;
-        }
+	/**
+	 * @param array $form Form meta array.
+	 *
+	 * @return array $form Form meta array with the cssClassList value set.
+	 */
+	private function set_css_class_list( array $form ) : array {
+		if ( empty( $form['cssClass'] ) ) {
+			$form['cssClassList'] = null;
+			return $form;
+		}
 
-        $form['cssClassList'] = array_filter( explode( ' ', $form['cssClass'] ), function( $css_class ) {
-            return '' !== $css_class;
-        } );
+		$form['cssClassList'] = array_filter(
+			explode( ' ', $form['cssClass'] ),
+			function( $css_class ) {
+				return '' !== $css_class;
+			}
+		);
 
-        return $form;
-    }
+		return $form;
+	}
 
-    /**
-     * Ensure that keys are present and set to the appropriate values. This is especially
-     * important for Integer fields, since graphql-php does not coerce then to int values,
-     * and an error will be thrown otherwise.
-     *
-     * @param array $form Form meta array.
-     *
-     * @return array $form Form meta array with some values converted to null.
-     */
-    private function prevent_missing_values( array $form ) : array {
-        $form['limitEntriesCount']   = isset( $form['limitEntriesCount'] ) ? (bool) $form['limitEntriesCount'] : false;
-        $form['scheduleStartHour']   = isset( $form['scheduleStartHour'] ) ? (int) $form['scheduleStartHour'] : null;
-        $form['scheduleStartMinute'] = isset( $form['scheduleStartMinute'] ) ? (int) $form['scheduleStartMinute'] : null;
-        $form['scheduleEndHour']     = isset( $form['scheduleEndHour'] ) ? (bool) $form['scheduleEndHour'] : null;
-        $form['scheduleEndMinute']   = isset( $form['scheduleEndMinute'] ) ? (bool) $form['scheduleEndMinute'] : null;
+	/**
+	 * Ensure that keys are present and set to the appropriate values. This is especially
+	 * important for Integer fields, since graphql-php does not coerce then to int values,
+	 * and an error will be thrown otherwise.
+	 *
+	 * @param array $form Form meta array.
+	 *
+	 * @return array $form Form meta array with some values converted to null.
+	 */
+	private function prevent_missing_values( array $form ) : array {
+		$form['limitEntriesCount']   = isset( $form['limitEntriesCount'] ) ? (bool) $form['limitEntriesCount'] : false;
+		$form['scheduleStartHour']   = isset( $form['scheduleStartHour'] ) ? (int) $form['scheduleStartHour'] : null;
+		$form['scheduleStartMinute'] = isset( $form['scheduleStartMinute'] ) ? (int) $form['scheduleStartMinute'] : null;
+		$form['scheduleEndHour']     = isset( $form['scheduleEndHour'] ) ? (bool) $form['scheduleEndHour'] : null;
+		$form['scheduleEndMinute']   = isset( $form['scheduleEndMinute'] ) ? (bool) $form['scheduleEndMinute'] : null;
 
-        if ( ! empty( $form['confirmations'] ) ) {
-            $form['confirmations'] = $this->nullify_confirmation_page_id_empty_strings( $form['confirmations'] );
-        }
+		if ( ! empty( $form['confirmations'] ) ) {
+			$form['confirmations'] = $this->nullify_confirmation_page_id_empty_strings( $form['confirmations'] );
+		}
 
-        return $form;
-    }
+		return $form;
+	}
 
-    /**
-     * @param array $confirmations Form confirmations.
-     *
-     * @return array Form confirmations with empty string pageId values converted to null.
-     */
-    private function nullify_confirmation_page_id_empty_strings( array $confirmations ) : array {
-        return array_map( function( $confirmation ) {
-            $confirmation['pageId'] = $confirmation['pageId'] ?: null;
-            return $confirmation;
-        }, $confirmations );
-    }
+	/**
+	 * @param array $confirmations Form confirmations.
+	 *
+	 * @return array Form confirmations with empty string pageId values converted to null.
+	 */
+	private function nullify_confirmation_page_id_empty_strings( array $confirmations ) : array {
+		return array_map(
+			function( $confirmation ) {
+				$confirmation['pageId'] = $confirmation['pageId'] ?: null;
+				return $confirmation;
+			},
+			$confirmations
+		);
+	}
 
-    /**
-     * @param array $form Form meta array.
-     *
-     * @return array $form Form meta array with keys converted to camelCase.
-     */
-    private function convert_form_keys_to_camelcase( array $form ) : array {
-        $form['isActive']    = $form['is_active'];
-        $form['dateCreated'] = $form['date_created'];
-        $form['isTrash']     = $form['is_trash'];
+	/**
+	 * @param array $form Form meta array.
+	 *
+	 * @return array $form Form meta array with keys converted to camelCase.
+	 */
+	private function convert_form_keys_to_camelcase( array $form ) : array {
+		$form['isActive']    = $form['is_active'];
+		$form['dateCreated'] = $form['date_created'];
+		$form['isTrash']     = $form['is_trash'];
 
-        if ( isset( $form['pagination']['display_progressbar_on_confirmation'] ) ) {
-            $form['pagination']['displayProgressbarOnConfirmation'] = $form['pagination']['display_progressbar_on_confirmation'];
-        }
+		if ( isset( $form['pagination']['display_progressbar_on_confirmation'] ) ) {
+			$form['pagination']['displayProgressbarOnConfirmation'] = $form['pagination']['display_progressbar_on_confirmation'];
+		}
 
-        if ( isset( $form['pagination']['progressbar_completion_text'] ) ) {
-            $form['pagination']['progressbarCompletionText'] = $form['pagination']['progressbar_completion_text'];
-        }
+		if ( isset( $form['pagination']['progressbar_completion_text'] ) ) {
+			$form['pagination']['progressbarCompletionText'] = $form['pagination']['progressbar_completion_text'];
+		}
 
-        unset(
-            $form['is_active'],
-            $form['date_created'],
-            $form['is_trash'],
-            $form['pagination']['display_progressbar_on_confirmation'],
-            $form['pagination']['progressbar_completion_text']
-        );
+		unset(
+			$form['is_active'],
+			$form['date_created'],
+			$form['is_trash'],
+			$form['pagination']['display_progressbar_on_confirmation'],
+			$form['pagination']['progressbar_completion_text']
+		);
 
-        return $form;
-    }
+		return $form;
+	}
 }

--- a/src/DataManipulators/FormDataManipulator.php
+++ b/src/DataManipulators/FormDataManipulator.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * DataManipulators - FormData
+ *
+ * Manipulates Form data.
+ *
+ * @package WPGraphQLGravityForms\DataManipulators
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\DataManipulators;
 
@@ -6,12 +14,22 @@ use GraphQLRelay\Relay;
 use WPGraphQLGravityForms\Interfaces\DataManipulator;
 use WPGraphQLGravityForms\Types\Form\Form;
 
+/**
+ * Class - FormDataManipulator
+ */
 class FormDataManipulator implements DataManipulator {
 	/**
 	 * FieldsDataManipulator instance.
+	 *
+	 * @var FieldsDataManipulator
 	 */
 	private $fields_data_manipulator;
 
+	/**
+	 * Constructor
+	 *
+	 * @param FieldsDataManipulator $fields_data_manipulator .
+	 */
 	public function __construct( FieldsDataManipulator $fields_data_manipulator ) {
 		$this->fields_data_manipulator = $fields_data_manipulator;
 	}
@@ -49,9 +67,11 @@ class FormDataManipulator implements DataManipulator {
 	}
 
 	/**
+	 * Returns form meta array with the cssClassList value set.
+	 *
 	 * @param array $form Form meta array.
 	 *
-	 * @return array $form Form meta array with the cssClassList value set.
+	 * @return array
 	 */
 	private function set_css_class_list( array $form ) : array {
 		if ( empty( $form['cssClass'] ) ) {
@@ -108,9 +128,11 @@ class FormDataManipulator implements DataManipulator {
 	}
 
 	/**
+	 * Returns Form meta array with keys converted to camelCase.
+	 *
 	 * @param array $form Form meta array.
 	 *
-	 * @return array $form Form meta array with keys converted to camelCase.
+	 * @return array
 	 */
 	private function convert_form_keys_to_camelcase( array $form ) : array {
 		$form['isActive']    = $form['is_active'];

--- a/src/Interfaces/Connection.php
+++ b/src/Interfaces/Connection.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for classes that register GraphQL Connections.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for classes that register GraphQL Connections.
+ * Interface - Connection
  */
 interface Connection {
 	/**

--- a/src/Interfaces/DataManipulator.php
+++ b/src/Interfaces/DataManipulator.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for classes that perform data manipulation.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for classes that perform data manipulation.
+ * Interface - DataManipulator
  */
 interface DataManipulator {
 	/**

--- a/src/Interfaces/DataManipulator.php
+++ b/src/Interfaces/DataManipulator.php
@@ -6,12 +6,12 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for classes that perform data manipulation.
  */
 interface DataManipulator {
-    /**
-     * Manipulate data.
-     *
-     * @param array $data The data to be manipulated.
-     *
-     * @return array Manipulated data.
-     */
-    public function manipulate( array $data ) : array;
+	/**
+	 * Manipulate data.
+	 *
+	 * @param array $data The data to be manipulated.
+	 *
+	 * @return array Manipulated data.
+	 */
+	public function manipulate( array $data ) : array;
 }

--- a/src/Interfaces/Enum.php
+++ b/src/Interfaces/Enum.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for a GraphQL Enum.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface Enum
+ * Interface  - Enum
  */
 interface Enum {
 	/**

--- a/src/Interfaces/Field.php
+++ b/src/Interfaces/Field.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for a GraphQL Field.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for a GraphQL Field.
+ * Interface - Field
  */
 interface Field {
 	/**

--- a/src/Interfaces/Field.php
+++ b/src/Interfaces/Field.php
@@ -6,8 +6,8 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for a GraphQL Field.
  */
 interface Field {
-    /**
-     * Register field in GraphQL schema.
-     */
-    public function register_field();
+	/**
+	 * Register field in GraphQL schema.
+	 */
+	public function register_field();
 }

--- a/src/Interfaces/FieldProperty.php
+++ b/src/Interfaces/FieldProperty.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for Gravity Forms field properties.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for Gravity Forms field properties.
+ * Interface - FieldProperty
  */
 interface FieldProperty {
 	/**

--- a/src/Interfaces/FieldProperty.php
+++ b/src/Interfaces/FieldProperty.php
@@ -6,10 +6,10 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for Gravity Forms field properties.
  */
 interface FieldProperty {
-    /**
-     * Get the field property.
-     *
-     * @return array Field property data.
-     */
-    public static function get() : array ;
+	/**
+	 * Get the field property.
+	 *
+	 * @return array Field property data.
+	 */
+	public static function get() : array;
 }

--- a/src/Interfaces/FieldValue.php
+++ b/src/Interfaces/FieldValue.php
@@ -8,13 +8,13 @@ use GF_Field;
  * Interface for Gravity Forms field values.
  */
 interface FieldValue {
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array;
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array;
 }

--- a/src/Interfaces/FieldValue.php
+++ b/src/Interfaces/FieldValue.php
@@ -1,11 +1,17 @@
 <?php
+/**
+ * Interface for Gravity Forms field values.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 use GF_Field;
 
 /**
- * Interface for Gravity Forms field values.
+ * Interface - FieldValue
  */
 interface FieldValue {
 	/**

--- a/src/Interfaces/Hookable.php
+++ b/src/Interfaces/Hookable.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for classes containing WordPress action/filter hooks.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for classes containing WordPress action/filter hooks.
+ * Interface - Hookable
  */
 interface Hookable {
 	/**

--- a/src/Interfaces/InputType.php
+++ b/src/Interfaces/InputType.php
@@ -6,8 +6,8 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for a GraphQL Input Type.
  */
 interface InputType {
-    /**
-     * Register input type in GraphQL schema.
-     */
-    public function register_input_type();
+	/**
+	 * Register input type in GraphQL schema.
+	 */
+	public function register_input_type();
 }

--- a/src/Interfaces/InputType.php
+++ b/src/Interfaces/InputType.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for a GraphQL Input Type.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for a GraphQL Input Type.
+ * Interface - InputType
  */
 interface InputType {
 	/**

--- a/src/Interfaces/Mutation.php
+++ b/src/Interfaces/Mutation.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for a GraphQL Mutation.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for a GraphQL Mutation.
+ * Interface - Mutation.
  */
 interface Mutation {
 	/**

--- a/src/Interfaces/Mutation.php
+++ b/src/Interfaces/Mutation.php
@@ -6,8 +6,8 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for a GraphQL Mutation.
  */
 interface Mutation {
-    /**
-     * Register mutation in GraphQL schema.
-     */
-    public function register_mutation();
+	/**
+	 * Register mutation in GraphQL schema.
+	 */
+	public function register_mutation();
 }

--- a/src/Interfaces/Type.php
+++ b/src/Interfaces/Type.php
@@ -6,11 +6,11 @@ namespace WPGraphQLGravityForms\Interfaces;
  * Interface for a GraphQL Type.
  */
 interface Type {
-    /**
-     * Register type in GraphQL schema.
-     */
-    // TODO: Determine best way to re-implement this
-    // now that Types\Union\ObjectFieldUnion::register_type()
-    // requires an argument.
-    // public function register_type();
+	/**
+	 * Register type in GraphQL schema.
+	 */
+	// TODO: Determine best way to re-implement this
+	// now that Types\Union\ObjectFieldUnion::register_type()
+	// requires an argument.
+	// public function register_type();
 }

--- a/src/Interfaces/Type.php
+++ b/src/Interfaces/Type.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Interface for a GraphQL Type.
+ *
+ * @package WPGraphQLGravityForms\Interfaces
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Interfaces;
 
 /**
- * Interface for a GraphQL Type.
+ * Interface - Type.
  */
 interface Type {
 	/**

--- a/src/Mutations/CreateDraftEntry.php
+++ b/src/Mutations/CreateDraftEntry.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - createGravityFormsDraftEntry
+ *
+ * Registers mutation to create a Gravity Forms draft entry.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -11,7 +19,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Mutation;
 
 /**
- * Create a Gravity Forms draft entry.
+ * Class - CreateDraftEntry
  */
 class CreateDraftEntry implements Hookable, Mutation {
 	/**
@@ -19,10 +27,16 @@ class CreateDraftEntry implements Hookable, Mutation {
 	 */
 	const NAME = 'createGravityFormsDraftEntry';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
+	/**
+	 * Registers mutation.
+	 */
 	public function register_mutation() {
 		register_graphql_mutation(
 			self::NAME,

--- a/src/Mutations/DeleteDraftEntry.php
+++ b/src/Mutations/DeleteDraftEntry.php
@@ -11,21 +11,24 @@ use WPGraphQLGravityForms\Interfaces\Mutation;
  * Delete a draft Gravity Forms entry.
  */
 class DeleteDraftEntry implements Hookable, Mutation {
-    /**
-     * Mutation name.
-     */
-    const NAME = 'deleteGravityFormsDraftEntry';
+	/**
+	 * Mutation name.
+	 */
+	const NAME = 'deleteGravityFormsDraftEntry';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
 	public function register_mutation() {
-		register_graphql_mutation( self::NAME, [
-            'inputFields'         => $this->get_input_fields(),
-			'outputFields'        => $this->get_output_fields(),
-			'mutateAndGetPayload' => $this->mutate_and_get_payload(),
-        ] );
+		register_graphql_mutation(
+			self::NAME,
+			[
+				'inputFields'         => $this->get_input_fields(),
+				'outputFields'        => $this->get_output_fields(),
+				'mutateAndGetPayload' => $this->mutate_and_get_payload(),
+			]
+		);
 	}
 
 	/**
@@ -40,7 +43,7 @@ class DeleteDraftEntry implements Hookable, Mutation {
 				'description' => __( 'Resume token of the draft to delete.', 'wp-graphql-gravity-forms' ),
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the mutation output field configuration.
@@ -54,7 +57,7 @@ class DeleteDraftEntry implements Hookable, Mutation {
 				'description' => __( 'Resume token of the draft that was deleted.', 'wp-graphql-gravity-forms' ),
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the mutation data modification closure.
@@ -65,13 +68,13 @@ class DeleteDraftEntry implements Hookable, Mutation {
 		return function( $input ) : array {
 			if ( empty( $input ) || ! is_array( $input ) || ! isset( $input['resumeToken'] ) ) {
 				throw new UserError( __( 'Mutation not processed. The input data was missing or invalid.', 'wp-graphql-gravity-forms' ) );
-            }
+			}
 
-            $resume_token = sanitize_text_field( $input['resumeToken'] );
-            $result       = GFFormsModel::delete_draft_submission( $resume_token );
+			$resume_token = sanitize_text_field( $input['resumeToken'] );
+			$result       = GFFormsModel::delete_draft_submission( $resume_token );
 
-            if ( ! $result ) {
-                throw new UserError( __( 'An error occurred while trying to delete the draft entry.', 'wp-graphql-gravity-forms' ) );
+			if ( ! $result ) {
+				throw new UserError( __( 'An error occurred while trying to delete the draft entry.', 'wp-graphql-gravity-forms' ) );
 			}
 
 			return [

--- a/src/Mutations/DeleteDraftEntry.php
+++ b/src/Mutations/DeleteDraftEntry.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - deleteGravityFormsDraftEntry
+ *
+ * Registers mutation to delete a Gravity Forms draft entry.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -8,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Mutation;
 
 /**
- * Delete a draft Gravity Forms entry.
+ * Class - DeleteDraftEntry
  */
 class DeleteDraftEntry implements Hookable, Mutation {
 	/**
@@ -16,10 +24,16 @@ class DeleteDraftEntry implements Hookable, Mutation {
 	 */
 	const NAME = 'deleteGravityFormsDraftEntry';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
+	/**
+	 * Registers mutation.
+	 */
 	public function register_mutation() {
 		register_graphql_mutation(
 			self::NAME,

--- a/src/Mutations/DeleteEntry.php
+++ b/src/Mutations/DeleteEntry.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - deleteGravityFormsEntry
+ *
+ * Registers mutation to delete a Gravity Forms entry.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -10,7 +18,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Mutation;
 
 /**
- * Delete a Gravity Forms entry.
+ * Class - DeleteEntry
  */
 class DeleteEntry implements Hookable, Mutation {
 	/**
@@ -18,10 +26,16 @@ class DeleteEntry implements Hookable, Mutation {
 	 */
 	const NAME = 'deleteGravityFormsEntry';
 
+	/**
+	 * Mutation name.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
+	/**
+	 * Registers mutation.
+	 */
 	public function register_mutation() {
 		register_graphql_mutation(
 			self::NAME,

--- a/src/Mutations/DeleteEntry.php
+++ b/src/Mutations/DeleteEntry.php
@@ -13,21 +13,24 @@ use WPGraphQLGravityForms\Interfaces\Mutation;
  * Delete a Gravity Forms entry.
  */
 class DeleteEntry implements Hookable, Mutation {
-    /**
-     * Mutation name.
-     */
-    const NAME = 'deleteGravityFormsEntry';
+	/**
+	 * Mutation name.
+	 */
+	const NAME = 'deleteGravityFormsEntry';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
 	public function register_mutation() {
-		register_graphql_mutation( self::NAME, [
-            'inputFields'         => $this->get_input_fields(),
-			'outputFields'        => $this->get_output_fields(),
-			'mutateAndGetPayload' => $this->mutate_and_get_payload(),
-        ] );
+		register_graphql_mutation(
+			self::NAME,
+			[
+				'inputFields'         => $this->get_input_fields(),
+				'outputFields'        => $this->get_output_fields(),
+				'mutateAndGetPayload' => $this->mutate_and_get_payload(),
+			]
+		);
 	}
 
 	/**
@@ -37,12 +40,12 @@ class DeleteEntry implements Hookable, Mutation {
 	 */
 	public static function get_input_fields() : array {
 		return [
-            'entryId' => [
+			'entryId' => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => __( 'ID of the entry to delete', 'wp-graphql-gravity-forms' ),
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the output field configuration.
@@ -54,9 +57,9 @@ class DeleteEntry implements Hookable, Mutation {
 			'entryId' => [
 				'type'        => 'Integer',
 				'description' => __( 'The ID of the entry that was deleted.', 'wp-graphql-gravity-forms' ),
-            ],
+			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the data modification closure.
@@ -72,7 +75,7 @@ class DeleteEntry implements Hookable, Mutation {
 				throw new UserError( __( 'An invalid entry ID was provided.', 'wp-graphql-gravity-forms' ) );
 			}
 
-            $result = GFAPI::delete_entry( $entry_id );
+			$result = GFAPI::delete_entry( $entry_id );
 
 			if ( is_wp_error( $result ) ) {
 				throw new UserError( __( 'An error occurred while deleting the entry', 'wp-graphql-gravity-forms' ) );

--- a/src/Mutations/DraftEntryUpdater.php
+++ b/src/Mutations/DraftEntryUpdater.php
@@ -37,7 +37,7 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	/**
 	 * The field whose value is being updated.
 	 *
-	 * @var int
+	 * @var GF_Field
 	 */
 	protected $field = null;
 

--- a/src/Mutations/DraftEntryUpdater.php
+++ b/src/Mutations/DraftEntryUpdater.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Abstract class for updating a draft Gravity Forms entry with a new value
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -15,14 +21,21 @@ use WPGraphQLGravityForms\Types\Entry\Entry;
 use WPGraphQLGravityForms\DataManipulators\DraftEntryDataManipulator;
 
 /**
- * Update a draft Gravity Forms entry with a new value.
+ * Class - DraftEntryUpdator
  */
 abstract class DraftEntryUpdater implements Hookable, Mutation {
 	/**
 	 * DraftEntryDataManipulator instance.
+	 *
+	 * @var DraftEntryDataManipulator
 	 */
 	private $draft_entry_data_manipulator;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param DraftEntryDataManipulator $draft_entry_data_manipulator .
+	 */
 	public function __construct( DraftEntryDataManipulator $draft_entry_data_manipulator ) {
 		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
 	}
@@ -48,10 +61,17 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 */
 	private $value = null;
 
+
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
+	/**
+	 * Registers mutation.
+	 */
 	public function register_mutation() {
 		register_graphql_mutation(
 			static::NAME,
@@ -83,7 +103,9 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	}
 
 	/**
-	 * @return array The input field value.
+	 * Returns the input field value.
+	 *
+	 * @return array
 	 */
 	abstract protected function get_value_input_field() : array;
 
@@ -153,9 +175,13 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	}
 
 	/**
+	 * Returns draft entry submittion data.
+	 *
 	 * @param string $resume_token Draft entry resume token.
 	 *
-	 * @return array $submission Draft entry submission data.
+	 * @return array
+	 *
+	 * @throws UserError .
 	 */
 	private function get_draft_submission( string $resume_token ) : array {
 		$draft_entry = GFFormsModel::get_draft_submission_values( $resume_token );
@@ -174,7 +200,10 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	}
 
 	/**
-	 * @return array Gravity Form associated with the draft entry.
+	 * Returns Gravity Form associated with the draft entry.
+	 *
+	 * @return array Form Object array.
+	 * @throws UserError .
 	 */
 	private function get_draft_form() : array {
 		$form = GFAPI::get_form( $this->submission['partial_entry']['form_id'] );
@@ -196,10 +225,14 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	// abstract protected function prepare_field_value( $value );
 
 	/**
+	 * Returns Gravity Forms Field object for given field id.
+	 *
 	 * @param array $form     The form.
 	 * @param int   $field_id Field ID.
 	 *
-	 * @return GF_Field The field object.
+	 * @return GF_Field
+	 *
+	 * @throws UserError .
 	 */
 	private function get_field_by_id( array $form, int $field_id ) : GF_Field {
 		$matching_fields = array_values(
@@ -225,14 +258,16 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 * @param string $resume_token Resume token.
 	 *
 	 * @return string The resume token, or empty string on failure.
+	 *
+	 * @throws UserError .
 	 */
 	private function save_draft_submission( int $form_id, string $resume_token ) : string {
 		$new_resume_token = GFFormsModel::save_draft_submission(
 			GFFormsModel::get_form_meta( $form_id ),
 			$this->add_field_value_to_partial_entry( $this->submission['partial_entry'] ),
 			$this->submission['field_values'] ?? '',
-			$this->submission['page_number'] ?? 1, // TODO: Maybe get from request
-			$this->submission['files'] ?? [], // TODO: Maybe get from request
+			$this->submission['page_number'] ?? 1, // TODO: Maybe get from request.
+			$this->submission['files'] ?? [], // TODO: Maybe get from request.
 			$this->submission['gform_unique_id'] ?? $this->get_form_unique_id( $draft_entry['form_id'] ),
 			$this->submission['partial_entry']['ip'] ?? '',
 			$this->submission['partial_entry']['source_url'] ?? '',
@@ -262,9 +297,11 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	}
 
 	/**
+	 * Returns partial entry, with new value added.
+	 *
 	 * @param array $partial_entry Partial form entry.
 	 *
-	 * @return array Partial entry, with new value added.
+	 * @return array
 	 */
 	public function add_field_value_to_partial_entry( array $partial_entry ) : array {
 		if ( ! isset( $this->field, $this->value ) ) {
@@ -287,9 +324,9 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	}
 
 	/**
-	 * @param array $submitted_values Submitted form values.
+	 * Returns submitted values, with new value added.
 	 *
-	 * @return array Submitted values, with new value added.
+	 * @return array
 	 */
 	public function add_field_value_to_submitted_values() : array {
 		if ( isset( $this->field, $this->value ) ) {

--- a/src/Mutations/DraftEntryUpdater.php
+++ b/src/Mutations/DraftEntryUpdater.php
@@ -18,13 +18,13 @@ use WPGraphQLGravityForms\DataManipulators\DraftEntryDataManipulator;
  * Update a draft Gravity Forms entry with a new value.
  */
 abstract class DraftEntryUpdater implements Hookable, Mutation {
-    /**
-     * DraftEntryDataManipulator instance.
-     */
-    private $draft_entry_data_manipulator;
+	/**
+	 * DraftEntryDataManipulator instance.
+	 */
+	private $draft_entry_data_manipulator;
 
-    public function __construct( DraftEntryDataManipulator $draft_entry_data_manipulator ) {
-        $this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
+	public function __construct( DraftEntryDataManipulator $draft_entry_data_manipulator ) {
+		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
 	}
 
 	/**
@@ -43,21 +43,24 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 
 	/**
 	 * The value to update the field with.
-     *
-     * @var mixed
+	 *
+	 * @var mixed
 	 */
 	private $value = null;
 
-    public function register_hooks() {
+	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 	}
 
 	public function register_mutation() {
-		register_graphql_mutation( static::NAME, [
-            'inputFields'         => $this->get_input_fields(),
-			'outputFields'        => $this->get_output_fields(),
-			'mutateAndGetPayload' => $this->mutate_and_get_payload(),
-        ] );
+		register_graphql_mutation(
+			static::NAME,
+			[
+				'inputFields'         => $this->get_input_fields(),
+				'outputFields'        => $this->get_output_fields(),
+				'mutateAndGetPayload' => $this->mutate_and_get_payload(),
+			]
+		);
 	}
 
 	/**
@@ -71,18 +74,18 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 				'type'        => 'String',
 				'description' => __( 'Draft resume token.', 'wp-graphql-gravity-forms' ),
 			],
-			'fieldId' => [
+			'fieldId'     => [
 				'type'        => 'Integer',
 				'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
-            ],
-            'value' => $this->get_value_input_field(),
+			],
+			'value'       => $this->get_value_input_field(),
 		];
-    }
+	}
 
-    /**
-     * @return array The input field value.
-     */
-    abstract protected function get_value_input_field() : array;
+	/**
+	 * @return array The input field value.
+	 */
+	abstract protected function get_value_input_field() : array;
 
 	/**
 	 * Defines the output field configuration.
@@ -95,20 +98,20 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 				'type'        => 'String',
 				'description' => __( 'Draft entry resume token.', 'wp-graphql-gravity-forms' ),
 			],
-			'entry' => [
+			'entry'       => [
 				'type'        => Entry::TYPE,
 				'description' => __( 'The draft entry after the update mutation has been applied. If a validation error occurred, the draft entry will NOT have been updated with the invalid value provided.', 'wp-graphql-gravity-forms' ),
-				'resolve' => function( array $payload ) : array {
+				'resolve'     => function( array $payload ) : array {
 					$submission = $this->get_draft_submission( $payload['resumeToken'] );
 					return $this->draft_entry_data_manipulator->manipulate( $submission['partial_entry'], $payload['resumeToken'] );
-				}
+				},
 			],
-			'errors' => [
+			'errors'      => [
 				'type'        => [ 'list_of' => FieldError::TYPE ],
 				'description' => __( 'Field errors.', 'wp-graphql-gravity-forms' ),
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the data modification closure.
@@ -145,8 +148,8 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 
 			remove_filter( 'gform_submission_values_pre_save', [ $this, 'add_field_value_to_submitted_values' ] );
 
-            return [ 'resumeToken' => $resume_token ];
-        };
+			return [ 'resumeToken' => $resume_token ];
+		};
 	}
 
 	/**
@@ -183,14 +186,14 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 		return $form;
 	}
 
-    /**
+	/**
 	 * Implement this method in child classes.
 	 *
-     * @param mixed $value The field value.
-     *
-     * @return mixed The prepared and sanitized field value.
-     */
-    // abstract protected function prepare_field_value( $value );
+	 * @param mixed $value The field value.
+	 *
+	 * @return mixed The prepared and sanitized field value.
+	 */
+	// abstract protected function prepare_field_value( $value );
 
 	/**
 	 * @param array $form     The form.
@@ -199,9 +202,14 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 * @return GF_Field The field object.
 	 */
 	private function get_field_by_id( array $form, int $field_id ) : GF_Field {
-		$matching_fields = array_values( array_filter( $form['fields'], function( GF_Field $field ) use ( $field_id ) : bool {
-			return $field['id'] === $field_id;
-		} ) );
+		$matching_fields = array_values(
+			array_filter(
+				$form['fields'],
+				function( GF_Field $field ) use ( $field_id ) : bool {
+					return $field['id'] === $field_id;
+				}
+			)
+		);
 
 		if ( ! $matching_fields ) {
 			throw new UserError( __( 'The form associated with this entry does not contain a field with the field ID provided.', 'wp-graphql-gravity-forms' ) );
@@ -213,22 +221,22 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	/**
 	 * Mimics Gravity Forms' GFFormsModel::save_draft_submission() method.
 	 *
-     * @param int    $form_id      Form ID.
+	 * @param int    $form_id      Form ID.
 	 * @param string $resume_token Resume token.
 	 *
 	 * @return string The resume token, or empty string on failure.
 	 */
 	private function save_draft_submission( int $form_id, string $resume_token ) : string {
-        $new_resume_token = GFFormsModel::save_draft_submission(
+		$new_resume_token = GFFormsModel::save_draft_submission(
 			GFFormsModel::get_form_meta( $form_id ),
-            $this->add_field_value_to_partial_entry( $this->submission['partial_entry'] ),
-            $this->submission['field_values'] ?? '',
-            $this->submission['page_number'] ?? 1, // TODO: Maybe get from request
-            $this->submission['files'] ?? [], // TODO: Maybe get from request
-            $this->submission['gform_unique_id'] ?? $this->get_form_unique_id( $draft_entry['form_id'] ),
-            $this->submission['partial_entry']['ip'] ?? '',
-            $this->submission['partial_entry']['source_url'] ?? '',
-            $resume_token
+			$this->add_field_value_to_partial_entry( $this->submission['partial_entry'] ),
+			$this->submission['field_values'] ?? '',
+			$this->submission['page_number'] ?? 1, // TODO: Maybe get from request
+			$this->submission['files'] ?? [], // TODO: Maybe get from request
+			$this->submission['gform_unique_id'] ?? $this->get_form_unique_id( $draft_entry['form_id'] ),
+			$this->submission['partial_entry']['ip'] ?? '',
+			$this->submission['partial_entry']['source_url'] ?? '',
+			$resume_token
 		);
 
 		if ( ! $new_resume_token ) {
@@ -236,7 +244,7 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 		}
 
 		return $new_resume_token;
-    }
+	}
 
 	/**
 	 * Mimics Gravity Forms' GFFormsModel::get_form_unique_id() method.
@@ -245,13 +253,13 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 *
 	 * @return string Unique ID.
 	 */
-	private function get_form_unique_id( int $form_id ) : string {		
+	private function get_form_unique_id( int $form_id ) : string {
 		if ( ! isset( GFFormsModel::$unique_ids[ $form_id ] ) ) {
 			GFFormsModel::$unique_ids[ $form_id ] = uniqid();
 		}
 
 		return GFFormsModel::$unique_ids[ $form_id ];
-    }
+	}
 
 	/**
 	 * @param array $partial_entry Partial form entry.
@@ -260,7 +268,7 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 */
 	public function add_field_value_to_partial_entry( array $partial_entry ) : array {
 		if ( ! isset( $this->field, $this->value ) ) {
-            return $partial_entry;
+			return $partial_entry;
 		}
 
 		// For an array of sub-values, add each to the partial entry individually.
@@ -284,9 +292,9 @@ abstract class DraftEntryUpdater implements Hookable, Mutation {
 	 * @return array Submitted values, with new value added.
 	 */
 	public function add_field_value_to_submitted_values() : array {
-        if ( isset( $this->field, $this->value ) ) {
+		if ( isset( $this->field, $this->value ) ) {
 			$this->submission['submitted_values'][ $this->field->id ] = $this->value;
-        }
+		}
 
 		return $this->submission['submitted_values'];
 	}

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -242,7 +242,7 @@ class SubmitDraftEntry implements Hookable, Mutation {
 		$fields           = $form['fields'];
 
 		foreach ( $fields as $field ) {
-			if ( $field['type'] !== 'captcha' ) {
+			if ( 'captcha' === $field['type'] ) {
 				$field_id          = absint( $field['id'] );
 				$field_to_validate = $this->get_field_by_id( $form, $field_id );
 				$field_value       = $submitted_values[ $field_id ];

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -18,31 +18,34 @@ use WPGraphQLGravityForms\Types\FieldError\FieldError;
  * Submit a Gravity Forms draft entry so that it becomes a permanent entry.
  */
 class SubmitDraftEntry implements Hookable, Mutation {
-    /**
-     * Mutation name.
-     */
-    const NAME = 'submitGravityFormsDraftEntry';
+	/**
+	 * Mutation name.
+	 */
+	const NAME = 'submitGravityFormsDraftEntry';
 
-    /**
-     * EntryDataManipulator instance.
-     */
-    private $entry_data_manipulator;
+	/**
+	 * EntryDataManipulator instance.
+	 */
+	private $entry_data_manipulator;
 
-    public function __construct( EntryDataManipulator $entry_data_manipulator ) {
-        $this->entry_data_manipulator = $entry_data_manipulator;
-    }
+	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
+		$this->entry_data_manipulator = $entry_data_manipulator;
+	}
 
-    public function register_hooks() {
-		add_action( 'graphql_register_types',       [ $this, 'register_mutation' ] );
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
 		add_action( 'graphql_before_resolve_field', [ $this, 'ensure_required_fields_are_set' ], 10, 7 );
 	}
 
 	public function register_mutation() {
-		register_graphql_mutation( self::NAME, [
-            'inputFields'         => $this->get_input_fields(),
-			'outputFields'        => $this->get_output_fields(),
-			'mutateAndGetPayload' => $this->mutate_and_get_payload(),
-        ] );
+		register_graphql_mutation(
+			self::NAME,
+			[
+				'inputFields'         => $this->get_input_fields(),
+				'outputFields'        => $this->get_output_fields(),
+				'mutateAndGetPayload' => $this->mutate_and_get_payload(),
+			]
+		);
 	}
 
 	/**
@@ -52,12 +55,12 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	 */
 	public static function get_input_fields() : array {
 		return [
-            'resumeToken' => [
+			'resumeToken' => [
 				'type'        => 'String',
 				'description' => __( 'Draft resume token.', 'wp-graphql-gravity-forms' ),
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the output field configuration.
@@ -69,16 +72,16 @@ class SubmitDraftEntry implements Hookable, Mutation {
 			'entryId' => [
 				'type'        => 'Integer',
 				'description' => __( 'The ID of the entry that was created.', 'wp-graphql-gravity-forms' ),
-            ],
-            'entry' => [
+			],
+			'entry'   => [
 				'type'        => Entry::TYPE,
 				'description' => __( 'The entry that was created.', 'wp-graphql-gravity-forms' ),
-				'resolve' => function( array $payload ) : array {
+				'resolve'     => function( array $payload ) : array {
 					return $this->entry_data_manipulator->manipulate( GFAPI::get_entry( $payload['entryId'] ) );
-				}
+				},
 			],
 		];
-    }
+	}
 
 	/**
 	 * Defines the data modification closure.
@@ -89,11 +92,11 @@ class SubmitDraftEntry implements Hookable, Mutation {
 		return function( $input, AppContext $context, ResolveInfo $info ) : array {
 			if ( empty( $input ) || ! is_array( $input ) || ! isset( $input['resumeToken'] ) ) {
 				throw new UserError( __( 'Mutation not processed. The input data was missing or invalid.', 'wp-graphql-gravity-forms' ) );
-            }
+			}
 
 			$resume_token = sanitize_text_field( $input['resumeToken'] );
 			$draft_entry  = $this->get_draft_entry( $resume_token );
-			$form_id = $draft_entry['form_id'];
+			$form_id      = $draft_entry['form_id'];
 
 			$this->validate_form_id( $form_id );
 
@@ -101,15 +104,15 @@ class SubmitDraftEntry implements Hookable, Mutation {
 
 			$this->send_notifications( $form_id, $entry_id );
 
-            GFFormsModel::delete_draft_submission( $resume_token );
-            GFFormsModel::purge_expired_draft_submissions();
+			GFFormsModel::delete_draft_submission( $resume_token );
+			GFFormsModel::purge_expired_draft_submissions();
 
 			return [ 'entryId' => $entry_id ];
 		};
 	}
 
 	private function get_draft_entry( string $resume_token ) : array {
-		$draft_entry  = GFFormsModel::get_draft_submission_values( $resume_token );
+		$draft_entry = GFFormsModel::get_draft_submission_values( $resume_token );
 
 		if ( ! is_array( $draft_entry ) || empty( $draft_entry['form_id'] ) ) {
 			throw new UserError( __( 'A draft with this resume token could not be found.', 'wp-graphql-gravity-forms' ) );
@@ -138,7 +141,7 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	}
 
 	private function send_notifications( int $form_id, int $entry_id ) {
-		$form = GFAPI::get_form( $form_id );
+		$form  = GFAPI::get_form( $form_id );
 		$entry = GFAPI::get_entry( $entry_id );
 
 		if ( ! $form || ! $entry ) {
@@ -159,19 +162,19 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	}
 
 	/**
-     * Fire an action BEFORE the field resolves
-     *
-     * @param mixed           $source         Source passed down the Resolve Tree.
-     * @param array           $args           Args for the field.
-     * @param AppContext      $context        AppContext passed down the ResolveTree.
-     * @param ResolveInfo     $info           ResolveInfo passed down the ResolveTree.
-     * @param mixed           $field_resolver Field resolver.
-     * @param string          $type_name      Name of the type the fields belong to.
-     * @param string          $field_key      Name of the field.
-     * @param FieldDefinition $field          Field Definition for the resolving field.
-     */
+	 * Fire an action BEFORE the field resolves
+	 *
+	 * @param mixed           $source         Source passed down the Resolve Tree.
+	 * @param array           $args           Args for the field.
+	 * @param AppContext      $context        AppContext passed down the ResolveTree.
+	 * @param ResolveInfo     $info           ResolveInfo passed down the ResolveTree.
+	 * @param mixed           $field_resolver Field resolver.
+	 * @param string          $type_name      Name of the type the fields belong to.
+	 * @param string          $field_key      Name of the field.
+	 * @param FieldDefinition $field          Field Definition for the resolving field.
+	 */
 	public function ensure_required_fields_are_set( $source, array $args, AppContext $context, ResolveInfo $info, $field_resolver, string $type_name, string $field_key ) : void {
-		//Make sure this is the submitGravityFormsDraftEntry field on the RootMutation.
+		// Make sure this is the submitGravityFormsDraftEntry field on the RootMutation.
 		if ( 'RootMutation' !== $type_name || self::NAME !== $field_key ) {
 			return;
 		}
@@ -180,16 +183,16 @@ class SubmitDraftEntry implements Hookable, Mutation {
 		$submitted_values = $submission['submitted_values'];
 		$form             = GFAPI::get_form( $submission['partial_entry']['form_id'] );
 		$fields           = $form['fields'];
-		
-		foreach( $fields as $field ) {
-			if ($field['type'] !== 'captcha') {
+
+		foreach ( $fields as $field ) {
+			if ( $field['type'] !== 'captcha' ) {
 				$field_id          = absint( $field['id'] );
 				$field_to_validate = $this->get_field_by_id( $form, $field_id );
-				$field_value       = $submitted_values[$field_id];
+				$field_value       = $submitted_values[ $field_id ];
 
 				$field_to_validate->validate( $field_value, $form );
 
-				if( $field->isRequired && empty( $submitted_values[$field_id] ) ){
+				if ( $field->isRequired && empty( $submitted_values[ $field_id ] ) ) {
 					$field->failed_validation = true;
 				}
 
@@ -198,7 +201,7 @@ class SubmitDraftEntry implements Hookable, Mutation {
 				}
 			}
 		}
-	}	
+	}
 
 	/**
 	 * @param array $form     The form.
@@ -207,9 +210,14 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	 * @return GF_Field The field object.
 	 */
 	private function get_field_by_id( array $form, int $field_id ) : GF_Field {
-		$matching_fields = array_values( array_filter( $form['fields'], function( GF_Field $field ) use ( $field_id ) : bool {
-			return $field['id'] === $field_id;
-		} ) );
+		$matching_fields = array_values(
+			array_filter(
+				$form['fields'],
+				function( GF_Field $field ) use ( $field_id ) : bool {
+					return $field['id'] === $field_id;
+				}
+			)
+		);
 
 		if ( ! $matching_fields ) {
 			throw new UserError( __( 'The form associated with this entry does not contain a field with the field ID provided.', 'wp-graphql-gravity-forms' ) );

--- a/src/Mutations/UpdateDraftEntryAddressFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryAddressFieldValue.php
@@ -31,11 +31,11 @@ class UpdateDraftEntryAddressFieldValue extends DraftEntryUpdater {
 	protected function prepare_field_value( array $value ) : array {
 		return [
 			$this->field['inputs'][0]['id'] => array_key_exists( 'street', $value ) ? sanitize_text_field( $value['street'] ) : null,
-			$this->field['inputs'][1]['id']  => array_key_exists( 'lineTwo', $value ) ? sanitize_text_field( $value['lineTwo'] ) : null,
+			$this->field['inputs'][1]['id'] => array_key_exists( 'lineTwo', $value ) ? sanitize_text_field( $value['lineTwo'] ) : null,
 			$this->field['inputs'][2]['id'] => array_key_exists( 'city', $value ) ? sanitize_text_field( $value['city'] ) : null,
-			$this->field['inputs'][3]['id']  => array_key_exists( 'state', $value ) ? sanitize_text_field( $value['state'] ) : null,
-			$this->field['inputs'][4]['id']  => array_key_exists( 'zip', $value ) ? sanitize_text_field( $value['zip'] ) : null,
-			$this->field['inputs'][5]['id']  => array_key_exists( 'country', $value ) ? sanitize_text_field( $value['country'] ) : null,
+			$this->field['inputs'][3]['id'] => array_key_exists( 'state', $value ) ? sanitize_text_field( $value['state'] ) : null,
+			$this->field['inputs'][4]['id'] => array_key_exists( 'zip', $value ) ? sanitize_text_field( $value['zip'] ) : null,
+			$this->field['inputs'][5]['id'] => array_key_exists( 'country', $value ) ? sanitize_text_field( $value['country'] ) : null,
 		];
 	}
 }

--- a/src/Mutations/UpdateDraftEntryAddressFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryAddressFieldValue.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Mutation - updateDraftEntryAddressFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry address field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 use WPGraphQLGravityForms\Types\Input\AddressInput;
 
 /**
- * Update a Gravity Forms draft entry address field value.
+ * Class - UpdateDraftEntryAddressFieldValue
  */
 class UpdateDraftEntryAddressFieldValue extends DraftEntryUpdater {
 	/**
@@ -14,7 +22,9 @@ class UpdateDraftEntryAddressFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryAddressFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -24,9 +34,11 @@ class UpdateDraftEntryAddressFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the address field values.
 	 *
-	 * @return array The sanitized field value.
+	 * @param array $value The field value.
+	 *
+	 * @return array
 	 */
 	protected function prepare_field_value( array $value ) : array {
 		return [

--- a/src/Mutations/UpdateDraftEntryCheckboxFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryCheckboxFieldValue.php
@@ -8,14 +8,14 @@ use WPGraphQLGravityForms\Types\Input\CheckboxInput;
  * Update a Gravity Forms draft entry checkbox field value.
  */
 class UpdateDraftEntryCheckboxFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryCheckboxFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => [ 'list_of' => CheckboxInput::TYPE ],
@@ -23,16 +23,20 @@ class UpdateDraftEntryCheckboxFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param array $value The field value.
-     *
-     * @return array Field value to save.
-     */
+	/**
+	 * @param array $value The field value.
+	 *
+	 * @return array Field value to save.
+	 */
 	protected function prepare_field_value( array $value ) : array {
-		$values_to_save = array_reduce( $this->field->inputs, function( array $values_to_save, array $input ) : array {
-			$values_to_save[ $input['id'] ] = ''; // Initialize all inputs to an empty string.
-			return $values_to_save;
-		}, [] );
+		$values_to_save = array_reduce(
+			$this->field->inputs,
+			function( array $values_to_save, array $input ) : array {
+				$values_to_save[ $input['id'] ] = ''; // Initialize all inputs to an empty string.
+				return $values_to_save;
+			},
+			[]
+		);
 
 		foreach ( $value as $single_value ) {
 			$input_id    = sanitize_text_field( $single_value['inputId'] );

--- a/src/Mutations/UpdateDraftEntryCheckboxFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryCheckboxFieldValue.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Mutation - updateDraftEntryCheckboxFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry checkbox field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 use WPGraphQLGravityForms\Types\Input\CheckboxInput;
 
 /**
- * Update a Gravity Forms draft entry checkbox field value.
+ * Class - UpdateDraftEntryCheckboxFieldValue
  */
 class UpdateDraftEntryCheckboxFieldValue extends DraftEntryUpdater {
 	/**
@@ -14,7 +22,9 @@ class UpdateDraftEntryCheckboxFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryCheckboxFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -24,9 +34,11 @@ class UpdateDraftEntryCheckboxFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
+	 * Sanitizes the checkbox field values.
+	 *
 	 * @param array $value The field value.
 	 *
-	 * @return array Field value to save.
+	 * @return array
 	 */
 	protected function prepare_field_value( array $value ) : array {
 		$values_to_save = array_reduce(

--- a/src/Mutations/UpdateDraftEntryDateFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryDateFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryDateFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry date field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry date field value.
+ * Class - UpdateDraftEntryDateFieldValue
  */
 class UpdateDraftEntryDateFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryDateFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryDateFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryDateFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field value.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryDateFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryDateFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry date field value.
  */
 class UpdateDraftEntryDateFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryDateFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryDateFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryEmailFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryEmailFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry email field value.
  */
 class UpdateDraftEntryEmailFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryEmailFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryEmailFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_email( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryEmailFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryEmailFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryEmailFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry email field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry email field value.
+ * Class - UpdateDraftEntryEmailFieldValue
  */
 class UpdateDraftEntryEmailFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryEmailFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryEmailFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryEmailFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_email( $value );

--- a/src/Mutations/UpdateDraftEntryListFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryListFieldValue.php
@@ -30,24 +30,26 @@ class UpdateDraftEntryListFieldValue extends DraftEntryUpdater {
 	 * @return string Sanitized and JSON encoded field values.
 	 */
 	protected function prepare_field_value( array $value ) : string {
-		$values_to_save = array_map( function( $row ) {
-			$row_values = []; // Initializes array.
+		$values_to_save = array_map(
+			function( $row ) {
+				$row_values = []; // Initializes array.
 
-			// If columns are enabled, save each choice => value pair.
-			if( $this->field->enableColumns){
+				// If columns are enabled, save each choice => value pair.
+				if ( $this->field->enableColumns ) {
+					foreach ( $this->field->choices as $choice_key => $choice ) {
+						$row_values[] = [
+							$choice['value'] => isset( $row['values'][ $choice_key ] ) ? sanitize_text_field( $row['values'][ $choice_key ] ) : null,
+						];
+					}
 
-				foreach( $this->field->choices as $choice_key => $choice ){
-					$row_values[] = [
-						$choice['value'] => isset($row['values'][$choice_key]) ? sanitize_text_field($row['values'][$choice_key]) : null,
-					];
+					return $row_values;
 				}
 
-				return $row_values;
-			}
-
-			// If no columns, values can be saved directly to the array.
-			return isset( $row['values'][0]) ? sanitize_text_field($row['values'][0]) : null;
-		}, $value);
+				// If no columns, values can be saved directly to the array.
+				return isset( $row['values'][0] ) ? sanitize_text_field( $row['values'][0] ) : null;
+			},
+			$value
+		);
 
 		return (string) serialize( $values_to_save );
 	}

--- a/src/Mutations/UpdateDraftEntryListFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryListFieldValue.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - updateDraftEntryListFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry list field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -6,7 +14,7 @@ use WPGraphQLGravityForms\Types\Input\ListInput;
 
 
 /**
- * Update a Gravity Forms draft entry with a List value.
+ * Class - UpdateDraftEntryListFieldValue
  */
 class UpdateDraftEntryListFieldValue extends DraftEntryUpdater {
 	/**
@@ -15,7 +23,9 @@ class UpdateDraftEntryListFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryListFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -25,9 +35,11 @@ class UpdateDraftEntryListFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param array The field values.
+	 * Sanitizes and serialize the field values.
 	 *
-	 * @return string Sanitized and JSON encoded field values.
+	 * @param array $value The field values.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( array $value ) : string {
 		$values_to_save = array_map(

--- a/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry with a multi-select value.
  */
 class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryMultiSelectFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => [ 'list_of' => 'String' ],
@@ -21,11 +21,11 @@ class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param array The field values.
-     *
-     * @return string Sanitized and JSON encoded field values.
-     */
+	/**
+	 * @param array The field values.
+	 *
+	 * @return string Sanitized and JSON encoded field values.
+	 */
 	protected function prepare_field_value( array $value ) : string {
 		return (string) json_encode( array_map( 'sanitize_text_field', $value ) );
 	}

--- a/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryMultiSelectFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry multi-select field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry with a multi-select value.
+ * Class - UpdateDraftEntryMultiSelectFieldValue
  */
 class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryMultiSelectFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param array The field values.
+	 * Sanitizes and JSON encode the field values.
 	 *
-	 * @return string Sanitized and JSON encoded field values.
+	 * @param array $value The field values.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( array $value ) : string {
 		return (string) json_encode( array_map( 'sanitize_text_field', $value ) );

--- a/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryMultiSelectFieldValue.php
@@ -39,6 +39,6 @@ class UpdateDraftEntryMultiSelectFieldValue extends DraftEntryUpdater {
 	 * @return string
 	 */
 	protected function prepare_field_value( array $value ) : string {
-		return (string) json_encode( array_map( 'sanitize_text_field', $value ) );
+		return (string) wp_json_encode( array_map( 'sanitize_text_field', $value ) );
 	}
 }

--- a/src/Mutations/UpdateDraftEntryNameFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNameFieldValue.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Mutation - updateDraftEntryNameFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry name field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 use WPGraphQLGravityForms\Types\Input\NameInput;
 
 /**
- * Update a Gravity Forms draft entry name field value.
+ * Class - UpdateDraftEntryNameFieldValue
  */
 class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 	/**
@@ -14,7 +22,9 @@ class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryNameFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -24,9 +34,11 @@ class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return array The sanitized field value.
+	 * @param array $value The field values.
+	 *
+	 * @return array
 	 */
 	protected function prepare_field_value( array $value ) : array {
 		return [

--- a/src/Mutations/UpdateDraftEntryNameFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNameFieldValue.php
@@ -29,13 +29,12 @@ class UpdateDraftEntryNameFieldValue extends DraftEntryUpdater {
 	 * @return array The sanitized field value.
 	 */
 	protected function prepare_field_value( array $value ) : array {
-		return 
-			[
-				$this->field['inputs'][0]['id'] => array_key_exists( 'prefix', $value ) ? sanitize_text_field( $value['prefix'] ) : null,
-				$this->field['inputs'][1]['id']  => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
-				$this->field['inputs'][2]['id'] => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
-				$this->field['inputs'][3]['id']  => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
-				$this->field['inputs'][4]['id']  => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
-			];
+		return [
+			$this->field['inputs'][0]['id'] => array_key_exists( 'prefix', $value ) ? sanitize_text_field( $value['prefix'] ) : null,
+			$this->field['inputs'][1]['id'] => array_key_exists( 'first', $value ) ? sanitize_text_field( $value['first'] ) : null,
+			$this->field['inputs'][2]['id'] => array_key_exists( 'middle', $value ) ? sanitize_text_field( $value['middle'] ) : null,
+			$this->field['inputs'][3]['id'] => array_key_exists( 'last', $value ) ? sanitize_text_field( $value['last'] ) : null,
+			$this->field['inputs'][4]['id'] => array_key_exists( 'suffix', $value ) ? sanitize_text_field( $value['suffix'] ) : null,
+		];
 	}
 }

--- a/src/Mutations/UpdateDraftEntryNumberFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNumberFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry number field value.
  */
 class UpdateDraftEntryNumberFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryNumberFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryNumberFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryNumberFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryNumberFieldValue.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - updateDraftEntryNumberFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry number field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -12,7 +20,9 @@ class UpdateDraftEntryNumberFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryNumberFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryNumberFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryPhoneFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryPhoneFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryPhoneFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry phone field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry phone field value.
+ * Class - UpdateDraftEntryPhoneFieldValue
  */
 class UpdateDraftEntryPhoneFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryPhoneFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryPhoneFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryPhoneFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryPhoneFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryPhoneFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry phone field value.
  */
 class UpdateDraftEntryPhoneFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryPhoneFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryPhoneFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryRadioFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryRadioFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryRadioFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry radio field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry radio field value.
+ * Class - UpdateDraftEntryRadioFieldValue
  */
 class UpdateDraftEntryRadioFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryRadioFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryRadioFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryRadioFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryRadioFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryRadioFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry radio field value.
  */
 class UpdateDraftEntryRadioFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryRadioFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryRadioFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntrySelectFieldValue.php
+++ b/src/Mutations/UpdateDraftEntrySelectFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry select field value.
  */
 class UpdateDraftEntrySelectFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntrySelectFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntrySelectFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntrySelectFieldValue.php
+++ b/src/Mutations/UpdateDraftEntrySelectFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntrySelectFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry select field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry select field value.
+ * Class - UpdateDraftEntrySelectFieldValue
  */
 class UpdateDraftEntrySelectFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntrySelectFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntrySelectFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntrySelectFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field values.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntrySignatureFieldValue.php
+++ b/src/Mutations/UpdateDraftEntrySignatureFieldValue.php
@@ -10,14 +10,14 @@ use GraphQL\Error\UserError;
  * Update a Gravity Forms draft entry with a signature value.
  */
 class UpdateDraftEntrySignatureFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntrySignatureFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -25,11 +25,11 @@ class UpdateDraftEntrySignatureFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string $value Base-64 encoded png signature image value.
-     *
-     * @return string The filename of the saved signature image file.
-     */
+	/**
+	 * @param string $value Base-64 encoded png signature image value.
+	 *
+	 * @return string The filename of the saved signature image file.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		$this->ensure_signature_plugin_is_active();
 		$this->ensure_signatures_folder_exists();
@@ -79,7 +79,9 @@ class UpdateDraftEntrySignatureFieldValue extends DraftEntryUpdater {
 	 * @return string $filename The filename of the saved signature image file.
 	 */
 	private function save_signature( string $signature ) : string {
-		if ( '' === $signature ) return '';
+		if ( '' === $signature ) {
+			return '';
+		}
 
 		$signature_decoded = $this->get_decoded_image_data( $signature );
 
@@ -92,8 +94,8 @@ class UpdateDraftEntrySignatureFieldValue extends DraftEntryUpdater {
 		$path            = $folder . $filename;
 		$number_of_bytes = file_put_contents( $path, $signature_decoded );
 
-        if ( false === $number_of_bytes ) {
-            throw new UserError( __( 'An error occurred while saving the signature image.', 'wp-graphql-gravity-forms' ) );
+		if ( false === $number_of_bytes ) {
+			throw new UserError( __( 'An error occurred while saving the signature image.', 'wp-graphql-gravity-forms' ) );
 		}
 
 		return $filename;

--- a/src/Mutations/UpdateDraftEntryTextAreaFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTextAreaFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryTextAreaFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry textarea field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry Textarea field value.
+ * Class - UpdateDraftEntryTextAreaFieldValue
  */
 class UpdateDraftEntryTextAreaFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryTextAreaFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryTextAreaFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryTextAreaFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field value.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryTextAreaFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTextAreaFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry Textarea field value.
  */
 class UpdateDraftEntryTextAreaFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryTextAreaFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryTextAreaFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryTextFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTextFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryTextFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry text field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry text field value.
+ * Class - UpdateDraftEntryTextFieldValue
  */
 class UpdateDraftEntryTextFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryTextFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryTextFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryTextFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field value.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryTextFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTextFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry text field value.
  */
 class UpdateDraftEntryTextFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryTextFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryTextFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryTimeFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTimeFieldValue.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Mutation - updateDraftEntryTimeFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry time field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
 /**
- * Update a Gravity Forms draft entry time field value.
+ * Class - UpdateDraftEntryTimeFieldValue
  */
 class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
 	/**
@@ -12,7 +20,9 @@ class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryTimeFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field value.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );

--- a/src/Mutations/UpdateDraftEntryTimeFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryTimeFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry time field value.
  */
 class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryTimeFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryTimeFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return sanitize_text_field( $value );
 	}

--- a/src/Mutations/UpdateDraftEntryWebsiteFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryWebsiteFieldValue.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mutation - updateDraftEntryWebsiteFieldValue
+ *
+ * Registers mutation to update a Gravity Forms draft entry website field value.
+ *
+ * @package WPGraphQLGravityForms\Mutation
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Mutations;
 
@@ -12,7 +20,9 @@ class UpdateDraftEntryWebsiteFieldValue extends DraftEntryUpdater {
 	const NAME = 'updateDraftEntryWebsiteFieldValue';
 
 	/**
-	 * @return array The input field value.
+	 * Defines the input field value configuration.
+	 *
+	 * @return array
 	 */
 	protected function get_value_input_field() : array {
 		return [
@@ -22,9 +32,11 @@ class UpdateDraftEntryWebsiteFieldValue extends DraftEntryUpdater {
 	}
 
 	/**
-	 * @param string The field value.
+	 * Sanitizes the field value.
 	 *
-	 * @return string The sanitized field value.
+	 * @param string $value The field value.
+	 *
+	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
 		return esc_url_raw( $value );

--- a/src/Mutations/UpdateDraftEntryWebsiteFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryWebsiteFieldValue.php
@@ -6,14 +6,14 @@ namespace WPGraphQLGravityForms\Mutations;
  * Update a Gravity Forms draft entry Website field value.
  */
 class UpdateDraftEntryWebsiteFieldValue extends DraftEntryUpdater {
-    /**
-     * Mutation name.
-     */
+	/**
+	 * Mutation name.
+	 */
 	const NAME = 'updateDraftEntryWebsiteFieldValue';
 
 	/**
-     * @return array The input field value.
-     */
+	 * @return array The input field value.
+	 */
 	protected function get_value_input_field() : array {
 		return [
 			'type'        => 'String',
@@ -21,11 +21,11 @@ class UpdateDraftEntryWebsiteFieldValue extends DraftEntryUpdater {
 		];
 	}
 
-    /**
-     * @param string The field value.
-     *
-     * @return string The sanitized field value.
-     */
+	/**
+	 * @param string The field value.
+	 *
+	 * @return string The sanitized field value.
+	 */
 	protected function prepare_field_value( string $value ) : string {
 		return esc_url_raw( $value );
 	}

--- a/src/Settings/WPGraphQLSettings.php
+++ b/src/Settings/WPGraphQLSettings.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Settings - WPGraphQL Settings
+ *
+ * @package WPGraphQLGravityForms\Settings
+ * @since 0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Settings;
 
@@ -8,6 +14,13 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
  * WPGraphQL Settings.
  */
 class WPGraphQLSettings implements Hookable {
+	/**
+	 * Register hooks to WordPress.
+	 *
+	 * @TODO: This should be a filter.
+	 *
+	 * @see: https://www.wpgraphql.com/filters/graphql_connection_max_query_amount/
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_connection_max_query_amount', [ $this, 'set_max_query_amount' ], 11 );
 	}

--- a/src/Settings/WPGraphQLSettings.php
+++ b/src/Settings/WPGraphQLSettings.php
@@ -8,7 +8,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
  * WPGraphQL Settings.
  */
 class WPGraphQLSettings implements Hookable {
-    public function register_hooks() {
+	public function register_hooks() {
 		add_action( 'graphql_connection_max_query_amount', [ $this, 'set_max_query_amount' ], 11 );
 	}
 

--- a/src/Types/Button/Button.php
+++ b/src/Types/Button/Button.php
@@ -12,34 +12,37 @@ use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
  * @see https://docs.gravityforms.com/button/
  */
 class Button implements Hookable, Type {
-    const TYPE = 'Button';
+	const TYPE = 'Button';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms button.', 'wp-graphql-gravity-forms' ),
-            'fields' => [
-                // @TODO: Convert to an enum.
-                'type'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Specifies the type of button to be displayed. Possible values: text, image.', 'wp-graphql-gravity-forms' ),
-                ],
-                'text' => [
-                    'type'        => 'String',
-                    'description' => __( 'Contains the button text. Only applicable when type is set to text.', 'wp-graphql-gravity-forms' ),
-                ],
-                'imageUrl' => [
-                    'type'        => 'String',
-                    'description' => __( 'Contains the URL for the image button. Only applicable when type is set to image.', 'wp-graphql-gravity-forms' ),
-                ],
-                'conditionalLogic' => [
-                    'type'        => ConditionalLogic::TYPE,
-                    'description' => __( 'Controls when the form button should be visible based on values selected on the form.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms button.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					// @TODO: Convert to an enum.
+					'type'             => [
+						'type'        => 'String',
+						'description' => __( 'Specifies the type of button to be displayed. Possible values: text, image.', 'wp-graphql-gravity-forms' ),
+					],
+					'text'             => [
+						'type'        => 'String',
+						'description' => __( 'Contains the button text. Only applicable when type is set to text.', 'wp-graphql-gravity-forms' ),
+					],
+					'imageUrl'         => [
+						'type'        => 'String',
+						'description' => __( 'Contains the URL for the image button. Only applicable when type is set to image.', 'wp-graphql-gravity-forms' ),
+					],
+					'conditionalLogic' => [
+						'type'        => ConditionalLogic::TYPE,
+						'description' => __( 'Controls when the form button should be visible based on values selected on the form.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Button/Button.php
+++ b/src/Types/Button/Button.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Button
+ *
+ * @see https://docs.gravityforms.com/button/
+ *
+ * @package WPGraphQLGravityForms\Types\Button
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Button;
 
@@ -7,17 +15,21 @@ use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
 
 /**
- *  Button.
- *
- * @see https://docs.gravityforms.com/button/
+ * Class - Button
  */
 class Button implements Hookable, Type {
 	const TYPE = 'Button';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/ConditionalLogic/ConditionalLogic.php
+++ b/src/Types/ConditionalLogic/ConditionalLogic.php
@@ -11,31 +11,34 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/conditional-logic/
  */
 class ConditionalLogic implements Hookable, Type {
-    const TYPE = 'ConditionalLogic';
+	const TYPE = 'ConditionalLogic';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms conditional logic.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                // TODO: convert type to enum
-                'actionType'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The type of action the conditional logic will perform. Possible values: show, hide.', 'wp-graphql-gravity-forms' ),
-                ],
-                 // TODO: convert type to enum
-                'logicType'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Determines how to the rules should be evaluated. Possible values: any, all.', 'wp-graphql-gravity-forms' ),
-                ],
-                'rules'   => [
-                    'type'        => [ 'list_of' => ConditionalLogicRule::TYPE ],
-                    'description' => __( 'Conditional logic rules.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms conditional logic.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					// TODO: convert type to enum
+					'actionType' => [
+						'type'        => 'String',
+						'description' => __( 'The type of action the conditional logic will perform. Possible values: show, hide.', 'wp-graphql-gravity-forms' ),
+					],
+					// TODO: convert type to enum
+					'logicType'  => [
+						'type'        => 'String',
+						'description' => __( 'Determines how to the rules should be evaluated. Possible values: any, all.', 'wp-graphql-gravity-forms' ),
+					],
+					'rules'      => [
+						'type'        => [ 'list_of' => ConditionalLogicRule::TYPE ],
+						'description' => __( 'Conditional logic rules.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/ConditionalLogic/ConditionalLogic.php
+++ b/src/Types/ConditionalLogic/ConditionalLogic.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Button
+ *
+ * @see https://docs.gravityforms.com/conditional-logic/
+ *
+ * @package WPGraphQLGravityForms\Types\ConditionalLogic
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\ConditionalLogic;
 
@@ -6,29 +14,33 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- *  Conditional Logic.
- *
- * @see https://docs.gravityforms.com/conditional-logic/
+ * Class - ConditionalLogic
  */
 class ConditionalLogic implements Hookable, Type {
 	const TYPE = 'ConditionalLogic';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,
 			[
 				'description' => __( 'Gravity Forms conditional logic.', 'wp-graphql-gravity-forms' ),
 				'fields'      => [
-					// TODO: convert type to enum
+					// TODO: convert type to enum.
 					'actionType' => [
 						'type'        => 'String',
 						'description' => __( 'The type of action the conditional logic will perform. Possible values: show, hide.', 'wp-graphql-gravity-forms' ),
 					],
-					// TODO: convert type to enum
+					// TODO: convert type to enum.
 					'logicType'  => [
 						'type'        => 'String',
 						'description' => __( 'Determines how to the rules should be evaluated. Possible values: any, all.', 'wp-graphql-gravity-forms' ),

--- a/src/Types/ConditionalLogic/ConditionalLogicRule.php
+++ b/src/Types/ConditionalLogic/ConditionalLogicRule.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Conditional Logic rule property
+ *
+ * @see https://docs.gravityforms.com/conditional-logic/#rule-properties
+ *
+ * @package WPGraphQLGravityForms\Types\ConditionalLogic
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\ConditionalLogic;
 
@@ -6,17 +14,21 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- *  Conditional Logic rule property.
- *
- * @see https://docs.gravityforms.com/conditional-logic/#rule-properties
+ * Class - ConditionalLogicRule
  */
 class ConditionalLogicRule implements Hookable, Type {
 	const TYPE = 'ConditionalLogicRule';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/ConditionalLogic/ConditionalLogicRule.php
+++ b/src/Types/ConditionalLogic/ConditionalLogicRule.php
@@ -11,30 +11,33 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/conditional-logic/#rule-properties
  */
 class ConditionalLogicRule implements Hookable, Type {
-    const TYPE = 'ConditionalLogicRule';
+	const TYPE = 'ConditionalLogicRule';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms conditional logic rule.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'fieldId'   => [
-                    'type'        => 'Float',
-                    'description' => __( 'Target field Id. Field that will have it’s value compared with the value property to determine if this rule is a match.', 'wp-graphql-gravity-forms' ),
-                ],
-                // TODO: convert to enum.
-                'operator'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Operator to be used when evaluating this rule. Possible values: is, isnot, >, <, contains, starts_with, or ends_with.', 'wp-graphql-gravity-forms' ),
-                ],
-                'value'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The value to compare with field specified by fieldId.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms conditional logic rule.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'fieldId'  => [
+						'type'        => 'Float',
+						'description' => __( 'Target field Id. Field that will have it’s value compared with the value property to determine if this rule is a match.', 'wp-graphql-gravity-forms' ),
+					],
+					// TODO: convert to enum.
+					'operator' => [
+						'type'        => 'String',
+						'description' => __( 'Operator to be used when evaluating this rule. Possible values: is, isnot, >, <, contains, starts_with, or ends_with.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'    => [
+						'type'        => 'String',
+						'description' => __( 'The value to compare with field specified by fieldId.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Entry/Entry.php
+++ b/src/Types/Entry/Entry.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms Form Entry
+ *
+ * @see https://docs.gravityforms.com/entry-object/
+ *
+ * @package WPGraphQLGravityForms\Types\Entry
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Entry;
 
@@ -17,9 +25,7 @@ use WPGraphQLGravityForms\Types\Union\ObjectFieldUnion;
 use WPGraphQLGravityForms\Types\Form\Form;
 
 /**
- * Gravity Forms form entry.
- *
- * @see https://docs.gravityforms.com/entry-object/
+ * Class - Entry
  */
 class Entry implements Hookable, Type, Field {
 	/**
@@ -34,14 +40,24 @@ class Entry implements Hookable, Type, Field {
 
 	/**
 	 * EntryDataManipulator instance.
+	 *
+	 * @var EntryDataManipulator
 	 */
 	private $entry_data_manipulator;
 
 	/**
 	 * DraftEntryDataManipulator instance.
+	 *
+	 * @var DraftEntryDataManipulator
 	 */
 	private $draft_entry_data_manipulator;
 
+	/**
+	 * Constructor
+	 *
+	 * @param EntryDataManipulator      $entry_data_manipulator .
+	 * @param DraftEntryDataManipulator $draft_entry_data_manipulator .
+	 */
 	public function __construct(
 		EntryDataManipulator $entry_data_manipulator,
 		DraftEntryDataManipulator $draft_entry_data_manipulator
@@ -50,11 +66,17 @@ class Entry implements Hookable, Type, Field {
 		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,
@@ -128,7 +150,7 @@ class Entry implements Hookable, Type, Field {
 						'description' => __( 'The resume token. Only applies to draft entries.', 'wp-graphql-gravity-forms' ),
 					],
 					/**
-					 * @TODO: Add support for these pricing properties that are only relevant
+					 * TODO: Add support for these pricing properties that are only relevant
 					 * when a Gravity Forms payment gateway add-on is being used:
 					 * https://docs.gravityforms.com/entry-object/#pricing-properties
 					 */
@@ -137,6 +159,9 @@ class Entry implements Hookable, Type, Field {
 		);
 	}
 
+	/**
+	 * Register entry query.
+	 */
 	public function register_field() {
 		register_graphql_field(
 			'RootQuery',

--- a/src/Types/Entry/Entry.php
+++ b/src/Types/Entry/Entry.php
@@ -22,160 +22,167 @@ use WPGraphQLGravityForms\Types\Form\Form;
  * @see https://docs.gravityforms.com/entry-object/
  */
 class Entry implements Hookable, Type, Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'GravityFormsEntry';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'GravityFormsEntry';
 
-    /**
-     * Field registered in WPGraphQL.
-     */
-    const FIELD = 'gravityFormsEntry';
+	/**
+	 * Field registered in WPGraphQL.
+	 */
+	const FIELD = 'gravityFormsEntry';
 
-    /**
-     * EntryDataManipulator instance.
-     */
-    private $entry_data_manipulator;
+	/**
+	 * EntryDataManipulator instance.
+	 */
+	private $entry_data_manipulator;
 
-    /**
-     * DraftEntryDataManipulator instance.
-     */
-    private $draft_entry_data_manipulator;
+	/**
+	 * DraftEntryDataManipulator instance.
+	 */
+	private $draft_entry_data_manipulator;
 
-    public function __construct(
-        EntryDataManipulator $entry_data_manipulator,
-        DraftEntryDataManipulator $draft_entry_data_manipulator
-    ) {
-        $this->entry_data_manipulator       = $entry_data_manipulator;
-        $this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
-    }
+	public function __construct(
+		EntryDataManipulator $entry_data_manipulator,
+		DraftEntryDataManipulator $draft_entry_data_manipulator
+	) {
+		$this->entry_data_manipulator       = $entry_data_manipulator;
+		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
+	}
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-        add_action( 'graphql_register_types', [ $this, 'register_field' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms entry.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'id' => [
-                    'type'        => [ 'non_null' => 'ID' ],
-                    'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),
-                ],
-                'entryId' => [
-                    'type'        => 'Integer',
-                    'description' => __( 'The entry ID. Returns null for draft entries.', 'wp-graphql-gravity-forms' ),
-                ],
-                'formId' => [
-                    'type'        => 'Integer',
-                    'description' => __( 'The ID of the form that was submitted to generate this entry.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Add field to get post data.
-                'postId' => [
-                    'type'        => 'Integer',
-                    'description' => __( 'For forms with Post fields, this property contains the Id of the Post that was created.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Gravity Forms stores and returns the dateCreated and dateUpdated in UTC time.
-                // Change the fields below to be in the blog's local time, and add new ones for
-                // dateCreatedUTC and dateUpdatedUTC.
-                'dateCreated' => [
-                    'type'        => 'String',
-                    'description' => __( 'The date and time that the entry was created, in the format "yyyy-mm-dd hh:mi:ss" (i.e. 2010-07-15 17:26:58).', 'wp-graphql-gravity-forms' ),
-                ],
-                'dateUpdated' => [
-                    'type'        => 'String',
-                    'description' => __( 'The date and time that the entry was updated, in the format "yyyy-mm-dd hh:mi:ss" (i.e. 2010-07-15 17:26:58).', 'wp-graphql-gravity-forms' ),
-                ],
-                'isStarred' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Indicates if the entry has been starred (i.e marked with a star). 1 for entries that are starred and 0 for entries that are not starred.', 'wp-graphql-gravity-forms' ),
-                ],
-                'isRead' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Indicates if the entry has been read. 1 for entries that are read and 0 for entries that have not been read.', 'wp-graphql-gravity-forms' ),
-                ],
-                'ip' => [
-                    'type'        => 'String',
-                    'description' => __( 'Client IP of user who submitted the form.', 'wp-graphql-gravity-forms' ),
-                ],
-                'sourceUrl' => [
-                    'type'        => 'String',
-                    'description' => __( 'Source URL of page that contained the form when it was submitted.', 'wp-graphql-gravity-forms' ),
-                ],
-                'userAgent' => [
-                    'type'        => 'String',
-                    'description' => __( 'Provides the name and version of both the browser and operating system from which the entry was submitted.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Add field to get user data.
-                'createdById' => [
-                    'type'        => 'Integer',
-                    'description' => __( 'ID of the user that submitted of the form if a logged in user submitted the form.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to an enum.
-                'status' => [
-                    'type'        => 'String',
-                    'description' => __( 'The current status of the entry; "active", "spam", or "trash".', 'wp-graphql-gravity-forms' ),
-                ],
-                'isDraft' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether the entry is a draft.', 'wp-graphql-gravity-forms' ),
-                ],
-                'resumeToken' => [
-                    'type'        => 'String',
-                    'description' => __( 'The resume token. Only applies to draft entries.', 'wp-graphql-gravity-forms' ),
-                ],
-                /**
-                 * @TODO: Add support for these pricing properties that are only relevant
-                 * when a Gravity Forms payment gateway add-on is being used:
-                 * https://docs.gravityforms.com/entry-object/#pricing-properties
-                 */
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms entry.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'          => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),
+					],
+					'entryId'     => [
+						'type'        => 'Integer',
+						'description' => __( 'The entry ID. Returns null for draft entries.', 'wp-graphql-gravity-forms' ),
+					],
+					'formId'      => [
+						'type'        => 'Integer',
+						'description' => __( 'The ID of the form that was submitted to generate this entry.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Add field to get post data.
+					'postId'      => [
+						'type'        => 'Integer',
+						'description' => __( 'For forms with Post fields, this property contains the Id of the Post that was created.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Gravity Forms stores and returns the dateCreated and dateUpdated in UTC time.
+					// Change the fields below to be in the blog's local time, and add new ones for
+					// dateCreatedUTC and dateUpdatedUTC.
+					'dateCreated' => [
+						'type'        => 'String',
+						'description' => __( 'The date and time that the entry was created, in the format "yyyy-mm-dd hh:mi:ss" (i.e. 2010-07-15 17:26:58).', 'wp-graphql-gravity-forms' ),
+					],
+					'dateUpdated' => [
+						'type'        => 'String',
+						'description' => __( 'The date and time that the entry was updated, in the format "yyyy-mm-dd hh:mi:ss" (i.e. 2010-07-15 17:26:58).', 'wp-graphql-gravity-forms' ),
+					],
+					'isStarred'   => [
+						'type'        => 'Boolean',
+						'description' => __( 'Indicates if the entry has been starred (i.e marked with a star). 1 for entries that are starred and 0 for entries that are not starred.', 'wp-graphql-gravity-forms' ),
+					],
+					'isRead'      => [
+						'type'        => 'Boolean',
+						'description' => __( 'Indicates if the entry has been read. 1 for entries that are read and 0 for entries that have not been read.', 'wp-graphql-gravity-forms' ),
+					],
+					'ip'          => [
+						'type'        => 'String',
+						'description' => __( 'Client IP of user who submitted the form.', 'wp-graphql-gravity-forms' ),
+					],
+					'sourceUrl'   => [
+						'type'        => 'String',
+						'description' => __( 'Source URL of page that contained the form when it was submitted.', 'wp-graphql-gravity-forms' ),
+					],
+					'userAgent'   => [
+						'type'        => 'String',
+						'description' => __( 'Provides the name and version of both the browser and operating system from which the entry was submitted.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Add field to get user data.
+					'createdById' => [
+						'type'        => 'Integer',
+						'description' => __( 'ID of the user that submitted of the form if a logged in user submitted the form.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to an enum.
+					'status'      => [
+						'type'        => 'String',
+						'description' => __( 'The current status of the entry; "active", "spam", or "trash".', 'wp-graphql-gravity-forms' ),
+					],
+					'isDraft'     => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the entry is a draft.', 'wp-graphql-gravity-forms' ),
+					],
+					'resumeToken' => [
+						'type'        => 'String',
+						'description' => __( 'The resume token. Only applies to draft entries.', 'wp-graphql-gravity-forms' ),
+					],
+					/**
+					 * @TODO: Add support for these pricing properties that are only relevant
+					 * when a Gravity Forms payment gateway add-on is being used:
+					 * https://docs.gravityforms.com/entry-object/#pricing-properties
+					 */
+				],
+			]
+		);
+	}
 
-    public function register_field() {
-        register_graphql_field( 'RootQuery', self::FIELD, [
-            'description' => __( 'Get a Gravity Forms entry.', 'wp-graphql-gravity-forms' ),
-            'type' => self::TYPE,
-            'args' => [
-                'id' => [
-                    'type'        => [ 'non_null' => 'ID' ],
-                    'description' => __( "Unique global ID for the object. Base-64 encode a string like this, where '123' is the entry ID (or the resume token for a draft entry): '{self::TYPE}:123'.", 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-            'resolve' => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
-                if ( ! current_user_can( 'gravityforms_view_entries' ) ) {
-                    throw new UserError( __( 'Sorry, you are not allowed to view Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
-                }
+	public function register_field() {
+		register_graphql_field(
+			'RootQuery',
+			self::FIELD,
+			[
+				'description' => __( 'Get a Gravity Forms entry.', 'wp-graphql-gravity-forms' ),
+				'type'        => self::TYPE,
+				'args'        => [
+					'id' => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( "Unique global ID for the object. Base-64 encode a string like this, where '123' is the entry ID (or the resume token for a draft entry): '{self::TYPE}:123'.", 'wp-graphql-gravity-forms' ),
+					],
+				],
+				'resolve'     => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
+					if ( ! current_user_can( 'gravityforms_view_entries' ) ) {
+						throw new UserError( __( 'Sorry, you are not allowed to view Gravity Forms entries.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $id_parts = Relay::fromGlobalId( $args['id'] );
+					$id_parts = Relay::fromGlobalId( $args['id'] );
 
-                if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
-                    throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
+						throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $id    = sanitize_text_field( $id_parts['id'] );
-                $entry = GFAPI::get_entry( $id );
+					$id    = sanitize_text_field( $id_parts['id'] );
+					$entry = GFAPI::get_entry( $id );
 
-                if ( ! is_wp_error( $entry ) ) {
-                    return $this->entry_data_manipulator->manipulate( $entry );
-                }
+					if ( ! is_wp_error( $entry ) ) {
+						return $this->entry_data_manipulator->manipulate( $entry );
+					}
 
-                $draft_entry = GFFormsModel::get_draft_submission_values( $id );
+					$draft_entry = GFFormsModel::get_draft_submission_values( $id );
 
-                if ( ! $draft_entry || ! is_array( $draft_entry ) ) {
-                    throw new UserError( __( 'An entry with this ID was not found.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $draft_entry || ! is_array( $draft_entry ) ) {
+						throw new UserError( __( 'An entry with this ID was not found.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $submission = json_decode( $draft_entry['submission'], true );
+					$submission = json_decode( $draft_entry['submission'], true );
 
-                if ( ! $submission ) {
-                    throw new UserError( __( 'The submission data for this draft entry could not be read.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $submission ) {
+						throw new UserError( __( 'The submission data for this draft entry could not be read.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                return $this->draft_entry_data_manipulator->manipulate( $submission['partial_entry'], $id );                
-            }
-        ] );
-    }
+					return $this->draft_entry_data_manipulator->manipulate( $submission['partial_entry'], $id );
+				},
+			]
+		);
+	}
 }

--- a/src/Types/Entry/EntryForm.php
+++ b/src/Types/Entry/EntryForm.php
@@ -15,60 +15,67 @@ use WPGraphQLGravityForms\Types\Form\Form;
  * Creates a 1:1 relationship between an Entry and the Form associated with it.
  */
 class EntryForm implements Hookable, Type, Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'EntryForm';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EntryForm';
 
-    /**
-     * Field registered in WPGraphQL.
-     */
-    const FIELD = 'form';
+	/**
+	 * Field registered in WPGraphQL.
+	 */
+	const FIELD = 'form';
 
-    /**
-     * FormDataManipulator instance.
-     */
-    private $form_data_manipulator;
+	/**
+	 * FormDataManipulator instance.
+	 */
+	private $form_data_manipulator;
 
-    public function __construct( FormDataManipulator $form_data_manipulator ) {
-        $this->form_data_manipulator = $form_data_manipulator;
-    }
+	public function __construct( FormDataManipulator $form_data_manipulator ) {
+		$this->form_data_manipulator = $form_data_manipulator;
+	}
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-        add_action( 'graphql_register_types', [ $this, 'register_field' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+	}
 
-    /**
-     * Register new edge type.
-     */
-    public function register_type() {
-        register_graphql_type( self::TYPE, [
-            'description' => __('The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'node' => [
-                    'type'        => Form::TYPE,
-                    'description' => __( 'The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	/**
+	 * Register new edge type.
+	 */
+	public function register_type() {
+		register_graphql_type(
+			self::TYPE,
+			[
+				'description' => __( 'The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'node' => [
+						'type'        => Form::TYPE,
+						'description' => __( 'The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    public function register_field() {
-        register_graphql_field( Entry::TYPE, self::FIELD, [
-            'type'        => self::TYPE,
-            'description' => __( 'The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms' ),
-            'resolve'     => function( array $entry ) : array {
-                $form = GFAPI::get_form( $entry['formId'] );
+	public function register_field() {
+		register_graphql_field(
+			Entry::TYPE,
+			self::FIELD,
+			[
+				'type'        => self::TYPE,
+				'description' => __( 'The Gravity Forms form associated with the entry.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => function( array $entry ) : array {
+					$form = GFAPI::get_form( $entry['formId'] );
 
-                if ( ! $form ) {
-                    throw new UserError( __( 'The form used to generate this entry was not found.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $form ) {
+						throw new UserError( __( 'The form used to generate this entry was not found.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                return [
-                    'node' => $this->form_data_manipulator->manipulate( $form ),
-                ];
-            }
-        ] );
-    }
+					return [
+						'node' => $this->form_data_manipulator->manipulate( $form ),
+					];
+				},
+			]
+		);
+	}
 }

--- a/src/Types/Entry/EntryForm.php
+++ b/src/Types/Entry/EntryForm.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Edge Type - EntryForm
+ * Creates a 1:1 relationship between an Entry and the Form associated with it.
+ *
+ * @package WPGraphQLGravityForms\Types\Entry
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Entry;
 
@@ -27,13 +34,23 @@ class EntryForm implements Hookable, Type, Field {
 
 	/**
 	 * FormDataManipulator instance.
+	 *
+	 * @var FormDataManipulator
 	 */
 	private $form_data_manipulator;
 
+	/**
+	 * Constructor
+	 *
+	 * @param FormDataManipulator $form_data_manipulator .
+	 */
 	public function __construct( FormDataManipulator $form_data_manipulator ) {
 		$this->form_data_manipulator = $form_data_manipulator;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
@@ -57,6 +74,9 @@ class EntryForm implements Hookable, Type, Field {
 		);
 	}
 
+	/**
+	 * Register form query.
+	 */
 	public function register_field() {
 		register_graphql_field(
 			Entry::TYPE,

--- a/src/Types/Entry/EntryUser.php
+++ b/src/Types/Entry/EntryUser.php
@@ -14,51 +14,58 @@ use WPGraphQLGravityForms\Types\Entry\Entry;
  * Creates a 1:1 relationship between an Entry and the User who created it.
  */
 class EntryUser implements Hookable, Type, Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'EntryUser';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EntryUser';
 
-    /**
-     * Field registered in WPGraphQL.
-     */
-    const FIELD = 'createdBy';
+	/**
+	 * Field registered in WPGraphQL.
+	 */
+	const FIELD = 'createdBy';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-        add_action( 'graphql_register_types', [ $this, 'register_field' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+	}
 
-    /**
-     * Register new edge type.
-     */
-    public function register_type() {
-        register_graphql_type( self::TYPE, [
-            'description' => __('The user who created the entry.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'node' => [
-                    'type'        => 'User',
-                    'description' => __( 'The user who created the entry.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	/**
+	 * Register new edge type.
+	 */
+	public function register_type() {
+		register_graphql_type(
+			self::TYPE,
+			[
+				'description' => __( 'The user who created the entry.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'node' => [
+						'type'        => 'User',
+						'description' => __( 'The user who created the entry.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    public function register_field() {
-        register_graphql_field( Entry::TYPE, self::FIELD, [
-            'type'        => self::TYPE,
-            'description' => __( 'The user who created the entry.', 'wp-graphql-gravity-forms' ),
-            'resolve'     => function( array $entry ) : array {
-                $user = get_userdata( $entry['createdById'] );
+	public function register_field() {
+		register_graphql_field(
+			Entry::TYPE,
+			self::FIELD,
+			[
+				'type'        => self::TYPE,
+				'description' => __( 'The user who created the entry.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => function( array $entry ) : array {
+					$user = get_userdata( $entry['createdById'] );
 
-                if ( ! $user instanceof WP_User ) {
-                    throw new UserError( __( 'The user who created this entry could not be found.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $user instanceof WP_User ) {
+						throw new UserError( __( 'The user who created this entry could not be found.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                return [
-                    'node' => new User( $user ),
-                ];
-            }
-        ] );
-    }
+					return [
+						'node' => new User( $user ),
+					];
+				},
+			]
+		);
+	}
 }

--- a/src/Types/Entry/EntryUser.php
+++ b/src/Types/Entry/EntryUser.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Edge Type - EntryUser
+ * Creates a 1:1 relationship between an Entry and the User who created it.
+ *
+ * @package WPGraphQLGravityForms\Types\Entry
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Entry;
 
@@ -24,6 +31,9 @@ class EntryUser implements Hookable, Type, Field {
 	 */
 	const FIELD = 'createdBy';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
@@ -47,6 +57,9 @@ class EntryUser implements Hookable, Type, Field {
 		);
 	}
 
+	/**
+	 * Register EntryUser query.
+	 */
 	public function register_field() {
 		register_graphql_field(
 			Entry::TYPE,

--- a/src/Types/Enum/FieldFiltersOperatorInputEnum.php
+++ b/src/Types/Enum/FieldFiltersOperatorInputEnum.php
@@ -6,47 +6,47 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Enum;
 
 class FieldFiltersOperatorInputEnum implements Hookable, Enum {
-    const TYPE = 'FieldFiltersOperatorInputEnum';
+	const TYPE = 'FieldFiltersOperatorInputEnum';
 
-    // Individual elements.
-    const IN           = 'in';
-    const NOT_IN       = 'not in';
-    const CONTAINS     = 'contains';
-    const GREATER_THAN = '>';
-    const LESS_THAN    = '<';
+	// Individual elements.
+	const IN           = 'in';
+	const NOT_IN       = 'not in';
+	const CONTAINS     = 'contains';
+	const GREATER_THAN = '>';
+	const LESS_THAN    = '<';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register' ] );
+	}
 
-    public function register() {
-        register_graphql_enum_type(
-            self::TYPE,
-            [
-                'description' => __( 'The operator to use for filtering.', 'harness' ),
-                'values'      => [
-                    'IN' => [
-                        'description' => __( 'Find field values that match those in the values array (default).', 'harness' ),
-                        'value'       => self::IN,
-                    ],
-                    'NOT_IN' => [
-                        'description' => __( 'Find field values that do NOT match those in the values array.', 'harness' ),
-                        'value'       => self::NOT_IN,
-                    ],
-                    'CONTAINS' => [
-                        'description' => __( 'Find field values that contain the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
-                        'value'       => self::CONTAINS,
-                    ],
-                    'GREATER_THAN' => [
-                        'description' => __( 'Find field values that are greater than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
-                        'value'       => self::GREATER_THAN,
-                    ],
-                    'LESS_THAN' => [
-                        'description' => __( 'Find field values that are less than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
-                        'value'       => self::LESS_THAN,
-                    ],
-                ],
-            ]
-        );
-    }
+	public function register() {
+		register_graphql_enum_type(
+			self::TYPE,
+			[
+				'description' => __( 'The operator to use for filtering.', 'harness' ),
+				'values'      => [
+					'IN'           => [
+						'description' => __( 'Find field values that match those in the values array (default).', 'harness' ),
+						'value'       => self::IN,
+					],
+					'NOT_IN'       => [
+						'description' => __( 'Find field values that do NOT match those in the values array.', 'harness' ),
+						'value'       => self::NOT_IN,
+					],
+					'CONTAINS'     => [
+						'description' => __( 'Find field values that contain the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'value'       => self::CONTAINS,
+					],
+					'GREATER_THAN' => [
+						'description' => __( 'Find field values that are greater than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'value'       => self::GREATER_THAN,
+					],
+					'LESS_THAN'    => [
+						'description' => __( 'Find field values that are less than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'value'       => self::LESS_THAN,
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Enum/FieldFiltersOperatorInputEnum.php
+++ b/src/Types/Enum/FieldFiltersOperatorInputEnum.php
@@ -38,26 +38,26 @@ class FieldFiltersOperatorInputEnum implements Hookable, Enum {
 		register_graphql_enum_type(
 			self::TYPE,
 			[
-				'description' => __( 'The operator to use for filtering.', 'harness' ),
+				'description' => __( 'The operator to use for filtering.', 'wp-graphql-gravity-forms' ),
 				'values'      => [
 					'IN'           => [
-						'description' => __( 'Find field values that match those in the values array (default).', 'harness' ),
+						'description' => __( 'Find field values that match those in the values array (default).', 'wp-graphql-gravity-forms' ),
 						'value'       => self::IN,
 					],
 					'NOT_IN'       => [
-						'description' => __( 'Find field values that do NOT match those in the values array.', 'harness' ),
+						'description' => __( 'Find field values that do NOT match those in the values array.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::NOT_IN,
 					],
 					'CONTAINS'     => [
-						'description' => __( 'Find field values that contain the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'description' => __( 'Find field values that contain the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::CONTAINS,
 					],
 					'GREATER_THAN' => [
-						'description' => __( 'Find field values that are greater than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'description' => __( 'Find field values that are greater than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::GREATER_THAN,
 					],
 					'LESS_THAN'    => [
-						'description' => __( 'Find field values that are less than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'harness' ),
+						'description' => __( 'Find field values that are less than the value in the values array. Only the first value in the values array will be used; any others will be disregarded.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::LESS_THAN,
 					],
 				],

--- a/src/Types/Enum/FieldFiltersOperatorInputEnum.php
+++ b/src/Types/Enum/FieldFiltersOperatorInputEnum.php
@@ -1,10 +1,19 @@
 <?php
+/**
+ * Enum Type - FieldFiltersOperatorInputEnum
+ *
+ * @package WPGraphQLGravityForms\Types\Enum,
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Enum;
 
 use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Enum;
 
+/**
+ * Class - FieldFiltersOperatorInputEnum
+ */
 class FieldFiltersOperatorInputEnum implements Hookable, Enum {
 	const TYPE = 'FieldFiltersOperatorInputEnum';
 
@@ -15,10 +24,16 @@ class FieldFiltersOperatorInputEnum implements Hookable, Enum {
 	const GREATER_THAN = '>';
 	const LESS_THAN    = '<';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register' ] );
 	}
 
+	/**
+	 * Registers Enum type.
+	 */
 	public function register() {
 		register_graphql_enum_type(
 			self::TYPE,

--- a/src/Types/Enum/FormStatusEnum.php
+++ b/src/Types/Enum/FormStatusEnum.php
@@ -37,22 +37,22 @@ class FormStatusEnum implements Hookable, Enum {
 		register_graphql_enum_type(
 			self::TYPE,
 			[
-				'description' => __( 'Status of forms to get. Default is ACTIVE.', 'harness' ),
+				'description' => __( 'Status of forms to get. Default is ACTIVE.', 'wp-graphql-gravity-forms' ),
 				'values'      => [
 					self::ACTIVE           => [
-						'description' => __( 'Active forms (default).', 'harness' ),
+						'description' => __( 'Active forms (default).', 'wp-graphql-gravity-forms' ),
 						'value'       => self::ACTIVE,
 					],
 					self::INACTIVE         => [
-						'description' => __( 'Inactive forms', 'harness' ),
+						'description' => __( 'Inactive forms', 'wp-graphql-gravity-forms' ),
 						'value'       => self::INACTIVE,
 					],
 					self::TRASHED          => [
-						'description' => __( 'Active forms in the trash.', 'harness' ),
+						'description' => __( 'Active forms in the trash.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::TRASHED,
 					],
 					self::INACTIVE_TRASHED => [
-						'description' => __( 'Inactive forms in the trash.', 'harness' ),
+						'description' => __( 'Inactive forms in the trash.', 'wp-graphql-gravity-forms' ),
 						'value'       => self::INACTIVE_TRASHED,
 					],
 				],

--- a/src/Types/Enum/FormStatusEnum.php
+++ b/src/Types/Enum/FormStatusEnum.php
@@ -6,42 +6,42 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Enum;
 
 class FormStatusEnum implements Hookable, Enum {
-    const TYPE = 'FormStatusEnum';
+	const TYPE = 'FormStatusEnum';
 
-    // Individual elements.
-    const ACTIVE           = 'ACTIVE';
-    const INACTIVE         = 'INACTIVE';
-    const TRASHED          = 'TRASHED';
-    const INACTIVE_TRASHED = 'INACTIVE_TRASHED';
+	// Individual elements.
+	const ACTIVE           = 'ACTIVE';
+	const INACTIVE         = 'INACTIVE';
+	const TRASHED          = 'TRASHED';
+	const INACTIVE_TRASHED = 'INACTIVE_TRASHED';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register' ] );
+	}
 
-    public function register() {
-        register_graphql_enum_type(
-            self::TYPE,
-            [
-                'description' => __( 'Status of forms to get. Default is ACTIVE.', 'harness' ),
-                'values'      => [
-                    self::ACTIVE => [
-                        'description' => __( 'Active forms (default).', 'harness' ),
-                        'value'       => self::ACTIVE,
-                    ],
-                    self::INACTIVE => [
-                        'description' => __( 'Inactive forms', 'harness' ),
-                        'value'       => self::INACTIVE,
-                    ],
-                    self::TRASHED => [
-                        'description' => __( 'Active forms in the trash.', 'harness' ),
-                        'value'       => self::TRASHED,
-                    ],
-                    self::INACTIVE_TRASHED => [
-                        'description' => __( 'Inactive forms in the trash.', 'harness' ),
-                        'value'       => self::INACTIVE_TRASHED,
-                    ],
-                ],
-            ]
-        );
-    }
+	public function register() {
+		register_graphql_enum_type(
+			self::TYPE,
+			[
+				'description' => __( 'Status of forms to get. Default is ACTIVE.', 'harness' ),
+				'values'      => [
+					self::ACTIVE           => [
+						'description' => __( 'Active forms (default).', 'harness' ),
+						'value'       => self::ACTIVE,
+					],
+					self::INACTIVE         => [
+						'description' => __( 'Inactive forms', 'harness' ),
+						'value'       => self::INACTIVE,
+					],
+					self::TRASHED          => [
+						'description' => __( 'Active forms in the trash.', 'harness' ),
+						'value'       => self::TRASHED,
+					],
+					self::INACTIVE_TRASHED => [
+						'description' => __( 'Inactive forms in the trash.', 'harness' ),
+						'value'       => self::INACTIVE_TRASHED,
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Enum/FormStatusEnum.php
+++ b/src/Types/Enum/FormStatusEnum.php
@@ -1,10 +1,19 @@
 <?php
+/**
+ * Enum Type - FormStatusEnum
+ *
+ * @package WPGraphQLGravityForms\Types\Enum,
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Enum;
 
 use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Enum;
 
+/**
+ * Class - FormStatusEnum
+ */
 class FormStatusEnum implements Hookable, Enum {
 	const TYPE = 'FormStatusEnum';
 
@@ -14,10 +23,16 @@ class FormStatusEnum implements Hookable, Enum {
 	const TRASHED          = 'TRASHED';
 	const INACTIVE_TRASHED = 'INACTIVE_TRASHED';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register' ] );
 	}
 
+	/**
+	 * Registers Enum type.
+	 */
 	public function register() {
 		register_graphql_enum_type(
 			self::TYPE,

--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -10,58 +10,61 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_address/
  */
 class AddressField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'AddressField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'AddressField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'address';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'address';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Address field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\InputsProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\LabelPlacementProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    // @TODO - Convert to an enum. Possible values: international, us, canadian
-                    'addressType' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the type of address to be displayed.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'defaultCountry' => [
-                        'type'        => 'String',
-                        'description' => __('Contains the country that will be selected by default. Only applicable when "addressType" is set to "international".', 'wp-graphql-gravity-forms'),
-                    ],
-                    'defaultProvince' => [
-                        'type'        => 'String',
-                        'description' => __('Contains the province that will be selected by default. Only applicable when "addressType" is set to "canadian".', 'wp-graphql-gravity-forms'),
-                    ],
-                    'defaultState' => [
-                        'type'        => 'String',
-                        'description' => __('Contains the state that will be selected by default. Only applicable when "addressType" is set to "us".', 'wp-graphql-gravity-forms'),
-                    ],
-                    'subLabelPlacement'   => [
-                        'type'        => 'String',
-                        'description' => __( 'The placement of the labels for the fields (street, city, zip/postal code, etc.) within the address group. This setting controls all of the address pieces, they cannot be set individually. They may be aligned above or below the inputs. If this property is not set, the “Sub-Label Placement” setting on the Form Settings->Form Layout page is used. If no setting is specified, the default is above inputs.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    // @TODO - add placeholders.
-                ],
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Address field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\InputsProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelPlacementProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						// @TODO - Convert to an enum. Possible values: international, us, canadian
+						'addressType'       => [
+							'type'        => 'String',
+							'description' => __( 'Determines the type of address to be displayed.', 'wp-graphql-gravity-forms' ),
+						],
+						'defaultCountry'    => [
+							'type'        => 'String',
+							'description' => __( 'Contains the country that will be selected by default. Only applicable when "addressType" is set to "international".', 'wp-graphql-gravity-forms' ),
+						],
+						'defaultProvince'   => [
+							'type'        => 'String',
+							'description' => __( 'Contains the province that will be selected by default. Only applicable when "addressType" is set to "canadian".', 'wp-graphql-gravity-forms' ),
+						],
+						'defaultState'      => [
+							'type'        => 'String',
+							'description' => __( 'Contains the state that will be selected by default. Only applicable when "addressType" is set to "us".', 'wp-graphql-gravity-forms' ),
+						],
+						'subLabelPlacement' => [
+							'type'        => 'String',
+							'description' => __( 'The placement of the labels for the fields (street, city, zip/postal code, etc.) within the address group. This setting controls all of the address pieces, they cannot be set individually. They may be aligned above or below the inputs. If this property is not set, the “Sub-Label Placement” setting on the Form Settings->Form Layout page is used. If no setting is specified, the default is above inputs.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO - add placeholders.
+					],
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - AddressField
+ *
+ * @see https://docs.gravityforms.com/gf_field_address/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Address field.
- *
- * @see https://docs.gravityforms.com/gf_field_address/
+ * Class - AddressField
  */
 class AddressField extends Field {
 	/**
@@ -20,10 +26,16 @@ class AddressField extends Field {
 	 */
 	const GF_TYPE = 'address';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/CaptchaField.php
+++ b/src/Types/Field/CaptchaField.php
@@ -10,59 +10,62 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_captcha/
  */
 class CaptchaField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'CaptchaField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'CaptchaField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'captcha';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'captcha';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms CAPTCHA field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\ErrorMessageProperty::get(),
-                [
-                    /**
-                     * Possible values: recaptcha, simple_captcha, math
-                     */
-                    'captchaType' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the type of CAPTCHA field to be used.', 'wp-graphql-gravity-forms'),
-                    ],
-                    /**
-                     * Possible values: red, white, blackglass, clean
-                     */
-                    'captchaTheme' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the theme to be used for the reCAPTCHA field. Only applicable to the recaptcha captcha type.', 'wp-graphql-gravity-forms'),
-                    ],
-                    /**
-                     * Possible values: small, medium, large
-                     */
-                    'simpleCaptchaSize' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the CAPTCHA image size. Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'simpleCaptchaFontColor' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the image’s font color, in HEX format (i.e. #CCCCCC). Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'simpleCaptchaBackgroundColor' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the image’s background color, in HEX format (i.e. #CCCCCC). Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms CAPTCHA field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\ErrorMessageProperty::get(),
+					[
+						/**
+						 * Possible values: recaptcha, simple_captcha, math
+						 */
+						'captchaType'                  => [
+							'type'        => 'String',
+							'description' => __( 'Determines the type of CAPTCHA field to be used.', 'wp-graphql-gravity-forms' ),
+						],
+						/**
+						 * Possible values: red, white, blackglass, clean
+						 */
+						'captchaTheme'                 => [
+							'type'        => 'String',
+							'description' => __( 'Determines the theme to be used for the reCAPTCHA field. Only applicable to the recaptcha captcha type.', 'wp-graphql-gravity-forms' ),
+						],
+						/**
+						 * Possible values: small, medium, large
+						 */
+						'simpleCaptchaSize'            => [
+							'type'        => 'String',
+							'description' => __( 'Determines the CAPTCHA image size. Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms' ),
+						],
+						'simpleCaptchaFontColor'       => [
+							'type'        => 'String',
+							'description' => __( 'Determines the image’s font color, in HEX format (i.e. #CCCCCC). Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms' ),
+						],
+						'simpleCaptchaBackgroundColor' => [
+							'type'        => 'String',
+							'description' => __( 'Determines the image’s background color, in HEX format (i.e. #CCCCCC). Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/CaptchaField.php
+++ b/src/Types/Field/CaptchaField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - CaptchaField
+ *
+ * @see https://docs.gravityforms.com/gf_field_captcha/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * CAPTCHA field.
- *
- * @see https://docs.gravityforms.com/gf_field_captcha/
+ * Class - CaptchaField
  */
 class CaptchaField extends Field {
 	/**
@@ -20,10 +26,16 @@ class CaptchaField extends Field {
 	 */
 	const GF_TYPE = 'captcha';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/ChainedSelectField.php
+++ b/src/Types/Field/ChainedSelectField.php
@@ -1,14 +1,20 @@
 <?php
+/**
+ * GraphQL Object Type - ChainedSelectField
+ *
+ * @see https://www.gravityforms.com/add-ons/chained-selects/
+ * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/chained-selects/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Chained Select field.
- *
- * @see https://www.gravityforms.com/add-ons/chained-selects/
- * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/chained-selects/
+ * Class - ChainedSelectField
  */
 class ChainedSelectField extends Field {
 	/**
@@ -21,10 +27,16 @@ class ChainedSelectField extends Field {
 	 */
 	const GF_TYPE = 'chainedselect';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/ChainedSelectField.php
+++ b/src/Types/Field/ChainedSelectField.php
@@ -11,47 +11,50 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/chained-selects/
  */
 class ChainedSelectField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ChainedSelectField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ChainedSelectField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'chainedselect';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'chainedselect';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Chained Select field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputsProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'choices' => [
-                        'type'        => [ 'list_of' => FieldProperty\ChainedSelectChoiceProperty::TYPE ],
-                        'description' => __('Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms'),
-                    ],
-                    // @TODO: Convert to an enum.
-                    'chainedSelectsAlignment' => [
-                        'type'        => 'String',
-                        'description' => __('Alignment of the dropdown fields. Possible values: "horizontal" (in a row) or "vertical" (in a column).', 'wp-graphql-gravity-forms'),
-                    ],
-                    'chainedSelectsHideInactive' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Whether inactive dropdowns should be hidden.', 'wp-graphql-gravity-forms'),
-                    ],
-                ],
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Chained Select field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputsProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'choices'                    => [
+							'type'        => [ 'list_of' => FieldProperty\ChainedSelectChoiceProperty::TYPE ],
+							'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO: Convert to an enum.
+						'chainedSelectsAlignment'    => [
+							'type'        => 'String',
+							'description' => __( 'Alignment of the dropdown fields. Possible values: "horizontal" (in a row) or "vertical" (in a column).', 'wp-graphql-gravity-forms' ),
+						],
+						'chainedSelectsHideInactive' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Whether inactive dropdowns should be hidden.', 'wp-graphql-gravity-forms' ),
+						],
+					],
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/CheckboxField.php
+++ b/src/Types/Field/CheckboxField.php
@@ -10,44 +10,47 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_checkbox/
  */
 class CheckboxField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'CheckboxField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'CheckboxField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'checkbox';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'checkbox';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Checkbox field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\ChoicesProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\EnableChoiceValueProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'inputs' => [
-                        'type'        => [ 'list_of' => FieldProperty\CheckboxInputProperty::TYPE ],
-                        'description' => __( 'List of inputs. Checkboxes are treated as multi-input fields, since each checkbox item is stored separately.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'enableSelectAll' => [
-                        'type'        => 'Boolean',
-                        'description' => __( 'Whether the "select all" choice should be displayed.', 'wp-graphql-gravity-forms' ),
-                    ]
-                ],
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Checkbox field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\ChoicesProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\EnableChoiceValueProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'inputs'          => [
+							'type'        => [ 'list_of' => FieldProperty\CheckboxInputProperty::TYPE ],
+							'description' => __( 'List of inputs. Checkboxes are treated as multi-input fields, since each checkbox item is stored separately.', 'wp-graphql-gravity-forms' ),
+						],
+						'enableSelectAll' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Whether the "select all" choice should be displayed.', 'wp-graphql-gravity-forms' ),
+						],
+					],
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/CheckboxField.php
+++ b/src/Types/Field/CheckboxField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - CheckboxField
+ *
+ * @see https://docs.gravityforms.com/gf_field_checkbox/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Checkbox field.
- *
- * @see https://docs.gravityforms.com/gf_field_checkbox/
+ * Class - CheckboxField
  */
 class CheckboxField extends Field {
 	/**
@@ -20,10 +26,16 @@ class CheckboxField extends Field {
 	 */
 	const GF_TYPE = 'checkbox';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/DateField.php
+++ b/src/Types/Field/DateField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - AddressField
+ *
+ * @see https://docs.gravityforms.com/gf_field_date/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Date field.
- *
- * @see https://docs.gravityforms.com/gf_field_date/
+ * Class - DateField
  */
 class DateField extends Field {
 	/**
@@ -20,10 +26,16 @@ class DateField extends Field {
 	 */
 	const GF_TYPE = 'date';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/DateField.php
+++ b/src/Types/Field/DateField.php
@@ -10,55 +10,58 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_date/
  */
 class DateField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'DateField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'DateField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'date';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'date';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Date field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    /**
-                     * Possible values: Possible values: calendar, custom, none
-                     */
-                    'calendarIconType' => [
-                        'type'        => 'String',
-                        'description' => __('Determines how the date field displays it’s calendar icon.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'calendarIconUrl' => [
-                        'type'        => 'String',
-                        'description' => __('Contains the URL to the custom calendar icon. Only applicable when calendarIconType is set to custom.', 'wp-graphql-gravity-forms'),
-                    ],
-                    /**
-                     * Possible values: mdy, dmy
-                     */
-                    'dateFormat' => [
-                        'type'        => 'String',
-                        'description' => __('Determines how the date is displayed.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Date field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						/**
+						 * Possible values: Possible values: calendar, custom, none
+						 */
+						'calendarIconType' => [
+							'type'        => 'String',
+							'description' => __( 'Determines how the date field displays it’s calendar icon.', 'wp-graphql-gravity-forms' ),
+						],
+						'calendarIconUrl'  => [
+							'type'        => 'String',
+							'description' => __( 'Contains the URL to the custom calendar icon. Only applicable when calendarIconType is set to custom.', 'wp-graphql-gravity-forms' ),
+						],
+						/**
+						 * Possible values: mdy, dmy
+						 */
+						'dateFormat'       => [
+							'type'        => 'String',
+							'description' => __( 'Determines how the date is displayed.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/EmailField.php
+++ b/src/Types/Field/EmailField.php
@@ -10,35 +10,38 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_email/
  */
 class EmailField extends Field {
-    /**
-     * Type registred in WPGraphQL.
-     */
-    const TYPE = 'EmailField';
+	/**
+	 * Type registred in WPGraphQL.
+	 */
+	const TYPE = 'EmailField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'email';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'email';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Email field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Email field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/EmailField.php
+++ b/src/Types/Field/EmailField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - EmailField
+ *
+ * @see https://docs.gravityforms.com/gf_field_email/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Email field.
- *
- * @see https://docs.gravityforms.com/gf_field_email/
+ * Class - EmailField
  */
 class EmailField extends Field {
 	/**
@@ -20,10 +26,16 @@ class EmailField extends Field {
 	 */
 	const GF_TYPE = 'email';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/Field.php
+++ b/src/Types/Field/Field.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Gravity Forms field.
+ *
+ * @see https://docs.gravityforms.com/field-object/
+ * @see https://docs.gravityforms.com/gf_field/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
@@ -8,14 +17,13 @@ use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
 use WPGraphQLGravityForms\Types\Enum\FieldVisibilityEnum;
 
 /**
- * Gravity Forms field.
- *
- * @see https://docs.gravityforms.com/field-object/
- * @see https://docs.gravityforms.com/gf_field/
+ * Class - Field
  */
 abstract class Field implements Hookable, Type {
 	/**
 	 * Get the global properties that apply to all GF field types.
+	 *
+	 * @return array
 	 */
 	protected function get_global_properties() : array {
 		return [
@@ -66,6 +74,11 @@ abstract class Field implements Hookable, Type {
 		];
 	}
 
+	/**
+	 * Get the custom properties.
+	 *
+	 * @return array
+	 */
 	protected function get_custom_properties() : array {
 		/**
 		 * Add GraphQL fields for custom field properties.

--- a/src/Types/Field/Field.php
+++ b/src/Types/Field/Field.php
@@ -14,65 +14,65 @@ use WPGraphQLGravityForms\Types\Enum\FieldVisibilityEnum;
  * @see https://docs.gravityforms.com/gf_field/
  */
 abstract class Field implements Hookable, Type {
-    /**
-     * Get the global properties that apply to all GF field types.
-     */
-    protected function get_global_properties() : array {
-        return [
-            'adminLabel' => [
-                'type'        => 'String',
-                'description' => __( 'When specified, the value of this property will be used on the admin pages instead of the label. It is useful for fields with long labels.', 'wp-graphql-gravity-forms' ),
-            ],
-            'adminOnly' => [
-                'type'        => 'Boolean',
-                'description' => __( 'Determines if this field should only visible on the administration pages. A value of 1 will mark the field as admin only and will hide it from the public form. Useful for fields such as “status” that help with managing entries, but don’t apply to users filling out the form.', 'wp-graphql-gravity-forms' ),
-            ],
-            'allowsPrepopulate' => [
-                'type'        => 'Boolean',
-                'description' => __( 'Determines if the field’s value can be pre-populated dynamically. 1 to allow field to be pre-populated, 0 otherwise.', 'wp-graphql-gravity-forms' ),
-            ],
-            'conditionalLogic' => [
-                'type'        => ConditionalLogic::TYPE,
-                'description' => __( 'Controls the visibility of the field based on values selected by the user.', 'wp-graphql-gravity-forms' ),
-            ],
-            'cssClass' => [
-                'type'        => 'String',
-                'description' => __( 'String containing the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
-            ],
-            'cssClassList' => [
-                'type'        => [ 'list_of' => 'String' ],
-                'description' => __( 'Array of the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
-            ],
-            'id' => [
-                'type'        => 'Integer',
-                'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
-            ],
-            'label' => [
-                'type'        => 'String',
-                'description' => __( 'Field label that will be displayed on the form and on the admin pages.', 'wp-graphql-gravity-forms' ),
-            ],
-            'type' => [
-                'type'        => 'String',
-                'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),
-            ],
-            'formId' => [
-                'type'        => 'Integer',
-                'description' => __( 'The ID of the form this field belongs to.', 'wp-graphql-gravity-forms' ),
-            ],
-            'visibility' => [
-                'type'        => 'String',
-                'description' => __( 'Field visibility. Possible values: visible, hidden, or administrative.', 'wp-graphql-gravity-forms' ),
-            ],
-        ];
-    }
+	/**
+	 * Get the global properties that apply to all GF field types.
+	 */
+	protected function get_global_properties() : array {
+		return [
+			'adminLabel'        => [
+				'type'        => 'String',
+				'description' => __( 'When specified, the value of this property will be used on the admin pages instead of the label. It is useful for fields with long labels.', 'wp-graphql-gravity-forms' ),
+			],
+			'adminOnly'         => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if this field should only visible on the administration pages. A value of 1 will mark the field as admin only and will hide it from the public form. Useful for fields such as “status” that help with managing entries, but don’t apply to users filling out the form.', 'wp-graphql-gravity-forms' ),
+			],
+			'allowsPrepopulate' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if the field’s value can be pre-populated dynamically. 1 to allow field to be pre-populated, 0 otherwise.', 'wp-graphql-gravity-forms' ),
+			],
+			'conditionalLogic'  => [
+				'type'        => ConditionalLogic::TYPE,
+				'description' => __( 'Controls the visibility of the field based on values selected by the user.', 'wp-graphql-gravity-forms' ),
+			],
+			'cssClass'          => [
+				'type'        => 'String',
+				'description' => __( 'String containing the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
+			],
+			'cssClassList'      => [
+				'type'        => [ 'list_of' => 'String' ],
+				'description' => __( 'Array of the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
+			],
+			'id'                => [
+				'type'        => 'Integer',
+				'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
+			],
+			'label'             => [
+				'type'        => 'String',
+				'description' => __( 'Field label that will be displayed on the form and on the admin pages.', 'wp-graphql-gravity-forms' ),
+			],
+			'type'              => [
+				'type'        => 'String',
+				'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),
+			],
+			'formId'            => [
+				'type'        => 'Integer',
+				'description' => __( 'The ID of the form this field belongs to.', 'wp-graphql-gravity-forms' ),
+			],
+			'visibility'        => [
+				'type'        => 'String',
+				'description' => __( 'Field visibility. Possible values: visible, hidden, or administrative.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 
-    protected function get_custom_properties() : array {
-        /**
-         * Add GraphQL fields for custom field properties.
-         *
-         * @param array Additional GraphQL field definitions.
-         * @param array The type of Gravity Forms field.
-         */
-        return apply_filters( 'wp_graphql_gf_custom_properties', [], static::GF_TYPE );
-    }
+	protected function get_custom_properties() : array {
+		/**
+		 * Add GraphQL fields for custom field properties.
+		 *
+		 * @param array Additional GraphQL field definitions.
+		 * @param array The type of Gravity Forms field.
+		 */
+		return apply_filters( 'wp_graphql_gf_custom_properties', [], static::GF_TYPE );
+	}
 }

--- a/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
@@ -9,36 +9,39 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * An individual property for the 'choices' Chained Select field property.
  */
 class ChainedSelectChoiceProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ChainedSelectChoiceProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ChainedSelectChoiceProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'text' => [
-                    'type'        => 'String',
-                    'description' => __('The text to be displayed to the user when displaying this choice.', 'wp-graphql-gravity-forms'),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __('The value to be stored in the database when this choice is selected.', 'wp-graphql-gravity-forms'),
-                ],
-                'isSelected' => [
-                    'type'        => 'Boolean',
-                    'description' => __('Determines if this choice should be selected by default when displayed. The value true will select the choice, whereas false will display it unselected.', 'wp-graphql-gravity-forms'),
-                ],
-                'choices' => [
-                    'type'        => [ 'list_of' => self::TYPE ],
-                    'description' => __('Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'text'       => [
+						'type'        => 'String',
+						'description' => __( 'The text to be displayed to the user when displaying this choice.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'      => [
+						'type'        => 'String',
+						'description' => __( 'The value to be stored in the database when this choice is selected.', 'wp-graphql-gravity-forms' ),
+					],
+					'isSelected' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if this choice should be selected by default when displayed. The value true will select the choice, whereas false will display it unselected.', 'wp-graphql-gravity-forms' ),
+					],
+					'choices'    => [
+						'type'        => [ 'list_of' => self::TYPE ],
+						'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - ChainedSelectChoiceProperty
+ * An individual property for the 'choices' Chained Select field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual property for the 'choices' Chained Select field property.
+ * Class - ChainedSelectChoiceProperty
  */
 class ChainedSelectChoiceProperty implements Hookable, Type {
 	/**
@@ -14,10 +21,16 @@ class ChainedSelectChoiceProperty implements Hookable, Type {
 	 */
 	const TYPE = 'ChainedSelectChoiceProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/CheckboxInputProperty.php
+++ b/src/Types/Field/FieldProperty/CheckboxInputProperty.php
@@ -9,32 +9,35 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * An individual property for the 'inputs' Checkbox field property.
  */
 class CheckboxInputProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'CheckboxInputProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'CheckboxInputProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'id' => [
-                    'type'        => 'Float',
-                    'description' => __('The input id. Input Ids follow the following naming convention: “FIELDID.INPUTID” (i.e. 5.1), where FIELDID is the id of the containing field and INPUTID specifies the input field.', 'wp-graphql-gravity-forms'),
-                ],
-                'label' => [
-                    'type'        => 'String',
-                    'description' => __('Input label.', 'wp-graphql-gravity-forms'),
-                ],
-                'name' => [
-                    'type'        => 'String',
-                    'description' => __('When the field is configured with allowsPrepopulate set to 1, this property contains the parameter name to be used to populate this field (equivalent to the inputName property of single-input fields).', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'    => [
+						'type'        => 'Float',
+						'description' => __( 'The input id. Input Ids follow the following naming convention: “FIELDID.INPUTID” (i.e. 5.1), where FIELDID is the id of the containing field and INPUTID specifies the input field.', 'wp-graphql-gravity-forms' ),
+					],
+					'label' => [
+						'type'        => 'String',
+						'description' => __( 'Input label.', 'wp-graphql-gravity-forms' ),
+					],
+					'name'  => [
+						'type'        => 'String',
+						'description' => __( 'When the field is configured with allowsPrepopulate set to 1, this property contains the parameter name to be used to populate this field (equivalent to the inputName property of single-input fields).', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/CheckboxInputProperty.php
+++ b/src/Types/Field/FieldProperty/CheckboxInputProperty.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - CheckboxInputProperty
+ * An individual property for the 'inputs' Checkbox field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual property for the 'inputs' Checkbox field property.
+ * Class - CheckboxInputProperty
  */
 class CheckboxInputProperty implements Hookable, Type {
 	/**
@@ -14,10 +21,16 @@ class CheckboxInputProperty implements Hookable, Type {
 	 */
 	const TYPE = 'CheckboxInputProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/ChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty.php
@@ -11,32 +11,35 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/field-object/#basic-properties
  */
 class ChoiceProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ChoiceProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ChoiceProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms input property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'text' => [
-                    'type'        => 'String',
-                    'description' => __('The text to be displayed to the user when displaying this choice.', 'wp-graphql-gravity-forms'),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __('The value to be stored in the database when this choice is selected. Note: This property is only supported by the Drop Down and Post Category fields. Checkboxes and Radio fields will store the text property in the database regardless of the value property.', 'wp-graphql-gravity-forms'),
-                ],
-                'isSelected' => [
-                    'type'        => 'Boolean',
-                    'description' => __('Determines if this choice should be selected by default when displayed. The value true will select the choice, whereas false will display it unselected.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'text'       => [
+						'type'        => 'String',
+						'description' => __( 'The text to be displayed to the user when displaying this choice.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'      => [
+						'type'        => 'String',
+						'description' => __( 'The value to be stored in the database when this choice is selected. Note: This property is only supported by the Drop Down and Post Category fields. Checkboxes and Radio fields will store the text property in the database regardless of the value property.', 'wp-graphql-gravity-forms' ),
+					],
+					'isSelected' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if this choice should be selected by default when displayed. The value true will select the choice, whereas false will display it unselected.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/ChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - ChoiceProperty
+ * An individual property for the 'choices' field property.
+ *
+ * @see https://docs.gravityforms.com/field-object/#basic-properties
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,9 +14,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual property for the 'choices' field property.
- *
- * @see https://docs.gravityforms.com/field-object/#basic-properties
+ * Class - ChoiceProperty
  */
 class ChoiceProperty implements Hookable, Type {
 	/**
@@ -16,10 +22,16 @@ class ChoiceProperty implements Hookable, Type {
 	 */
 	const TYPE = 'ChoiceProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/ChoicesProperty.php
+++ b/src/Types/Field/FieldProperty/ChoicesProperty.php
@@ -1,19 +1,27 @@
 <?php
+/**
+ * Coices field property.
+ *
+ * @see https://docs.gravityforms.com/field-object/#basic-properties
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 /**
- * Choices field property.
- *
- * @see https://docs.gravityforms.com/field-object/#basic-properties
+ * Class - ChoicesProperty
  */
 abstract class ChoicesProperty implements FieldProperty {
 	/**
 	 * Get 'choices' property.
 	 *
 	 * Applies to: select, checkbox, radio, post_category
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/ChoicesProperty.php
+++ b/src/Types/Field/FieldProperty/ChoicesProperty.php
@@ -10,17 +10,17 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
  * @see https://docs.gravityforms.com/field-object/#basic-properties
  */
 abstract class ChoicesProperty implements FieldProperty {
-    /**
-     * Get 'choices' property.
-     *
-     * Applies to: select, checkbox, radio, post_category
-     */
-    public static function get() : array {
-        return [
-            'choices' => [
-                'type'        => [ 'list_of' => ChoiceProperty::TYPE ],
-                'description' => __('Contains the available choices for the field. For instance, drop down items and checkbox items are configured with this property.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'choices' property.
+	 *
+	 * Applies to: select, checkbox, radio, post_category
+	 */
+	public static function get() : array {
+		return [
+			'choices' => [
+				'type'        => [ 'list_of' => ChoiceProperty::TYPE ],
+				'description' => __( 'Contains the available choices for the field. For instance, drop down items and checkbox items are configured with this property.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/DefaultValueProperty.php
+++ b/src/Types/Field/FieldProperty/DefaultValueProperty.php
@@ -1,15 +1,26 @@
 <?php
+/**
+ * Default value field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - DefaultValueProperty
+ */
 abstract class DefaultValueProperty implements FieldProperty {
 	/**
 	 * Get 'defaultValue' property.
 	 *
 	 * Applies to: hidden, text, website, phone, number, date, textarea, email,
 	 * post_title, post_content, post_excerpt, post_tags, post_custom_field
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/DefaultValueProperty.php
+++ b/src/Types/Field/FieldProperty/DefaultValueProperty.php
@@ -5,18 +5,18 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class DefaultValueProperty implements FieldProperty {
-    /**
-     * Get 'defaultValue' property.
-     *
-     * Applies to: hidden, text, website, phone, number, date, textarea, email,
-     * post_title, post_content, post_excerpt, post_tags, post_custom_field
-     */
-    public static function get() : array {
-        return [
-            'defaultValue' => [
-                'type'        => 'String',
-                'description' => __( 'Contains the default value for the field. When specified, the field\'s value will be populated with the contents of this property when the form is displayed.', 'wp-graphql-gravity-forms' ),
-            ]
-        ];
-    }
+	/**
+	 * Get 'defaultValue' property.
+	 *
+	 * Applies to: hidden, text, website, phone, number, date, textarea, email,
+	 * post_title, post_content, post_excerpt, post_tags, post_custom_field
+	 */
+	public static function get() : array {
+		return [
+			'defaultValue' => [
+				'type'        => 'String',
+				'description' => __( 'Contains the default value for the field. When specified, the field\'s value will be populated with the contents of this property when the form is displayed.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
@@ -9,13 +9,13 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
  * This is different from the 'descriptionPlacement' Form field.
  */
 abstract class DescriptionPlacementProperty implements FieldProperty {
-    public static function get() : array {
-        return [
-            // @TODO - Convert to enum. Possible values: "above" or "below"
-            'choices' => [
-                'type'        => 'String',
-                'description' => __('The placement of the field description. The description may be placed “above” or “below” the field inputs. If the placement is not specified, then the description placement setting for the Form Layout is used.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	public static function get() : array {
+		return [
+			// @TODO - Convert to enum. Possible values: "above" or "below"
+			'choices' => [
+				'type'        => 'String',
+				'description' => __( 'The placement of the field description. The description may be placed “above” or “below” the field inputs. If the placement is not specified, then the description placement setting for the Form Layout is used.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
@@ -1,14 +1,27 @@
 <?php
+/**
+ * Description placement field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 /**
- * Description placement property. Applies to List and MultiSelect fields.
- * This is different from the 'descriptionPlacement' Form field.
+ * Class - DescriptionPlacementProperty
  */
 abstract class DescriptionPlacementProperty implements FieldProperty {
+	/**
+	 * Get Description placement property.
+	 * This is different from the 'descriptionPlacement' Form field.
+	 *
+	 * Applies to: list, multiselect, password
+	 *
+	 * @return array
+	 */
 	public static function get() : array {
 		return [
 			// @TODO - Convert to enum. Possible values: "above" or "below"

--- a/src/Types/Field/FieldProperty/DescriptionProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionProperty.php
@@ -5,15 +5,15 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class DescriptionProperty implements FieldProperty {
-    /**
-     * Get 'description' property.
-     */
-    public static function get() : array {
-        return [
-            'description' => [
-                'type'        => 'String',
-                'description' => __( 'Field description.', 'wp-graphql-gravity-forms' ),
-            ],
-        ];
-    }
+	/**
+	 * Get 'description' property.
+	 */
+	public static function get() : array {
+		return [
+			'description' => [
+				'type'        => 'String',
+				'description' => __( 'Field description.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/DescriptionProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionProperty.php
@@ -1,9 +1,18 @@
 <?php
+/**
+ * Description field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - DescriptionProperty
+ */
 abstract class DescriptionProperty implements FieldProperty {
 	/**
 	 * Get 'description' property.

--- a/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
+++ b/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
@@ -1,14 +1,25 @@
 <?php
+/**
+ * Enable ChoiceValue field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - DefaultValueProperty
+ */
 abstract class EnableChoiceValueProperty implements FieldProperty {
 	/**
 	 * Get 'enableChoiceValue' property.
 	 *
 	 * Applies to: checkbox, select and radio
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
+++ b/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
@@ -5,17 +5,17 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class EnableChoiceValueProperty implements FieldProperty {
-    /**
-     * Get 'enableChoiceValue' property.
-     *
-     * Applies to: checkbox, select and radio
-     */
-    public static function get() : array {
-        return [
-            'enableChoiceValue' => [
-                'type'        => 'Boolean',
-                'description' => __('Determines if the field (checkbox, select or radio) have choice values enabled, which allows the field to have choice values different from the labels that are displayed to the user.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'enableChoiceValue' property.
+	 *
+	 * Applies to: checkbox, select and radio
+	 */
+	public static function get() : array {
+		return [
+			'enableChoiceValue' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if the field (checkbox, select or radio) have choice values enabled, which allows the field to have choice values different from the labels that are displayed to the user.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
+++ b/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
@@ -10,17 +10,17 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
  * @see https://docs.gravityforms.com/field-object/#other
  */
 abstract class EnableEnhancedUiProperty implements FieldProperty {
-    /**
-     * Get 'enableEnhancedUI' property.
-     *
-     * Applies to: select, multiselect
-     */
-    public static function get() : array {
-        return [
-            'enableEnhancedUI' => [
-                'type'        => 'Boolean',
-                'description' => __('When set to true, the "Chosen" jQuery script will be applied to this field, enabling search capabilities to Drop Down fields and a more user-friendly interface for Multi Select fields.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'enableEnhancedUI' property.
+	 *
+	 * Applies to: select, multiselect
+	 */
+	public static function get() : array {
+		return [
+			'enableEnhancedUI' => [
+				'type'        => 'Boolean',
+				'description' => __( 'When set to true, the "Chosen" jQuery script will be applied to this field, enabling search capabilities to Drop Down fields and a more user-friendly interface for Multi Select fields.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
+++ b/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
@@ -1,19 +1,27 @@
 <?php
+/**
+ * Enable Enhanced UI field property.
+ *
+ * @see https://docs.gravityforms.com/field-object/#other
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 /**
- * Enable Enhanced UI field property.
- *
- * @see https://docs.gravityforms.com/field-object/#other
+ * Class - EnableEnhancedUiProperty
  */
 abstract class EnableEnhancedUiProperty implements FieldProperty {
 	/**
 	 * Get 'enableEnhancedUI' property.
 	 *
 	 * Applies to: select, multiselect
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/ErrorMessageProperty.php
+++ b/src/Types/Field/FieldProperty/ErrorMessageProperty.php
@@ -1,14 +1,25 @@
 <?php
+/**
+ * Error message field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - ErrorMessageProperty
+ */
 abstract class ErrorMessageProperty implements FieldProperty {
 	/**
 	 * Get 'errorMessage' property.
 	 *
 	 * Applies to: All fields except html, section and hidden
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/ErrorMessageProperty.php
+++ b/src/Types/Field/FieldProperty/ErrorMessageProperty.php
@@ -5,17 +5,17 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class ErrorMessageProperty implements FieldProperty {
-    /**
-     * Get 'errorMessage' property.
-     *
-     * Applies to: All fields except html, section and hidden
-     */
-    public static function get() : array {
-        return [
-            'errorMessage' => [
-                'type'        => 'String',
-                'description' => __('Contains the message that is displayed for fields that fail validation.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'errorMessage' property.
+	 *
+	 * Applies to: All fields except html, section and hidden
+	 */
+	public static function get() : array {
+		return [
+			'errorMessage' => [
+				'type'        => 'String',
+				'description' => __( 'Contains the message that is displayed for fields that fail validation.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/InputNameProperty.php
+++ b/src/Types/Field/FieldProperty/InputNameProperty.php
@@ -1,14 +1,25 @@
 <?php
+/**
+ * Input name field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - InputNameProperty
+ */
 abstract class InputNameProperty implements FieldProperty {
 	/**
 	 * Get 'inputName' property.
 	 *
 	 * Applies to: All fields except section and captcha
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/InputNameProperty.php
+++ b/src/Types/Field/FieldProperty/InputNameProperty.php
@@ -5,17 +5,17 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class InputNameProperty implements FieldProperty {
-    /**
-     * Get 'inputName' property.
-     *
-     * Applies to: All fields except section and captcha
-     */
-    public static function get() : array {
-        return [
-            'inputName' => [
-                'type'        => 'String',
-                'description' => __('Assigns a name to this field so that it can be populated dynamically via this input name. Only applicable when allowsPrepopulate is set to 1.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'inputName' property.
+	 *
+	 * Applies to: All fields except section and captcha
+	 */
+	public static function get() : array {
+		return [
+			'inputName' => [
+				'type'        => 'String',
+				'description' => __( 'Assigns a name to this field so that it can be populated dynamically via this input name. Only applicable when allowsPrepopulate is set to 1.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/InputProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty.php
@@ -9,40 +9,43 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * An individual input for the 'inputs' field property.
  */
 class InputProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'InputProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'InputProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms input property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'id' => [
-                    'type'        => 'Float',
-                    'description' => __('The input ID. Input IDs follow the following naming convention: FIELDID.INPUTID (i.e. 5.1), where FIELDID is the id of the containing field and INPUTID specifies the input field.', 'wp-graphql-gravity-forms'),
-                ],
-                'label' => [
-                    'type'        => 'String',
-                    'description' => __('Input label.', 'wp-graphql-gravity-forms'),
-                ],
-                'name' => [
-                    'type'        => 'String',
-                    'description' => __('When the field is configured with allowsPrepopulate set to 1, this property contains the parameter name to be used to populate this field (equivalent to the inputName property of single-input fields).', 'wp-graphql-gravity-forms'),
-                ],
-                'key' => [
-                    'type'        => 'String',
-                    'description' => __('Key used to identify this input.', 'wp-graphql-gravity-forms'),
-                ],
-                'isHidden' => [
-                    'type'        => 'Boolean',
-                    'description' => __('Whether or not this field should be hidden.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'       => [
+						'type'        => 'Float',
+						'description' => __( 'The input ID. Input IDs follow the following naming convention: FIELDID.INPUTID (i.e. 5.1), where FIELDID is the id of the containing field and INPUTID specifies the input field.', 'wp-graphql-gravity-forms' ),
+					],
+					'label'    => [
+						'type'        => 'String',
+						'description' => __( 'Input label.', 'wp-graphql-gravity-forms' ),
+					],
+					'name'     => [
+						'type'        => 'String',
+						'description' => __( 'When the field is configured with allowsPrepopulate set to 1, this property contains the parameter name to be used to populate this field (equivalent to the inputName property of single-input fields).', 'wp-graphql-gravity-forms' ),
+					],
+					'key'      => [
+						'type'        => 'String',
+						'description' => __( 'Key used to identify this input.', 'wp-graphql-gravity-forms' ),
+					],
+					'isHidden' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether or not this field should be hidden.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/InputProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - InputProperty
+ * An individual input for the 'inputs' field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual input for the 'inputs' field property.
+ * Class - InputProperty
  */
 class InputProperty implements Hookable, Type {
 	/**
@@ -14,10 +21,16 @@ class InputProperty implements Hookable, Type {
 	 */
 	const TYPE = 'InputProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/InputsProperty.php
+++ b/src/Types/Field/FieldProperty/InputsProperty.php
@@ -1,14 +1,25 @@
 <?php
+/**
+ * Inputs field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - InputsProperty
+ */
 abstract class InputsProperty implements FieldProperty {
 	/**
 	 * Get 'inputs' property.
 	 *
 	 * Applies to: name, address
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/InputsProperty.php
+++ b/src/Types/Field/FieldProperty/InputsProperty.php
@@ -5,17 +5,17 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class InputsProperty implements FieldProperty {
-    /**
-     * Get 'inputs' property.
-     *
-     * Applies to: name, address
-     */
-    public static function get() : array {
-        return [
-            'inputs' => [
-                'type'        => [ 'list_of' => InputProperty::TYPE ],
-                'description' => __('For fields with multiple inputs (i.e. Name, Address), this property contains a list of inputs. This property also applies to the checkbox field as checkboxes are treated as multi-input fields (since each checkbox item is stored separately).', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'inputs' property.
+	 *
+	 * Applies to: name, address
+	 */
+	public static function get() : array {
+		return [
+			'inputs' => [
+				'type'        => [ 'list_of' => InputProperty::TYPE ],
+				'description' => __( 'For fields with multiple inputs (i.e. Name, Address), this property contains a list of inputs. This property also applies to the checkbox field as checkboxes are treated as multi-input fields (since each checkbox item is stored separately).', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/IsRequiredProperty.php
+++ b/src/Types/Field/FieldProperty/IsRequiredProperty.php
@@ -5,17 +5,17 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class IsRequiredProperty implements FieldProperty {
-    /**
-     * Get 'isRequired' property.
-     *
-     * Applies to: All fields except section, html and captcha
-     */
-    public static function get() : array {
-        return [
-            'isRequired' => [
-                'type'        => 'Boolean',
-                'description' => __('Determines if the field requires the user to enter a value. 1 marks the field as required, 0 marks the field as not required. Fields marked as required will prevent the form from being submitted if the user has not entered a value in it.', 'wp-graphql-gravity-forms'),
-            ], 
-        ];
-    }
+	/**
+	 * Get 'isRequired' property.
+	 *
+	 * Applies to: All fields except section, html and captcha
+	 */
+	public static function get() : array {
+		return [
+			'isRequired' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if the field requires the user to enter a value. 1 marks the field as required, 0 marks the field as not required. Fields marked as required will prevent the form from being submitted if the user has not entered a value in it.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/IsRequiredProperty.php
+++ b/src/Types/Field/FieldProperty/IsRequiredProperty.php
@@ -1,14 +1,25 @@
 <?php
+/**
+ * Is required field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - IsRequiredProperty
+ */
 abstract class IsRequiredProperty implements FieldProperty {
 	/**
 	 * Get 'isRequired' property.
 	 *
 	 * Applies to: All fields except section, html and captcha
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/LabelPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/LabelPlacementProperty.php
@@ -8,13 +8,13 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
  * Label Placement field property.
  */
 abstract class LabelPlacementProperty implements FieldProperty {
-    public static function get() : array {
-        return [
-            // @TODO - Convert to enum. See corresponding Form 'labelPlacement' field.
-            'labelPlacement' => [
-                'type'        => 'String',
-                'description' => __( 'The field label position. Empty when using the form defaults or a value of "hidden_label".', 'wp-graphql-gravity-forms' ),
-            ],
-        ];
-    }
+	public static function get() : array {
+		return [
+			// @TODO - Convert to enum. See corresponding Form 'labelPlacement' field.
+			'labelPlacement' => [
+				'type'        => 'String',
+				'description' => __( 'The field label position. Empty when using the form defaults or a value of "hidden_label".', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/LabelPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/LabelPlacementProperty.php
@@ -1,13 +1,26 @@
 <?php
+/**
+ * Label Placement field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 /**
- * Label Placement field property.
+ * Class - LabelPlacementProperty
  */
 abstract class LabelPlacementProperty implements FieldProperty {
+	/**
+	 * Get 'labelPlacement' property.
+	 *
+	 * Applies to: address, list
+	 *
+	 * @return array
+	 */
 	public static function get() : array {
 		return [
 			// @TODO - Convert to enum. See corresponding Form 'labelPlacement' field.

--- a/src/Types/Field/FieldProperty/ListChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ListChoiceProperty.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * GraphQL Object Type - ListChoiceProperty
+ * An individual property for the 'choices' field property of the List field.
+ *
+ * @see https://docs.gravityforms.com/gf_field_list/#highlighter_635805
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,9 +15,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual property for the 'choices' field property of the List field.
- *
- * @see https://docs.gravityforms.com/gf_field_list/#highlighter_635805
+ * Class - ListChoiceProperty
  */
 class ListChoiceProperty implements Hookable, Type {
 	/**
@@ -16,10 +23,16 @@ class ListChoiceProperty implements Hookable, Type {
 	 */
 	const TYPE = 'ListChoiceProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/ListChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ListChoiceProperty.php
@@ -11,28 +11,31 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/gf_field_list/#highlighter_635805
  */
 class ListChoiceProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ListChoiceProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ListChoiceProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('List field column labels.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'text' => [
-                    'type'        => 'String',
-                    'description' => __('The text to be displayed in the column header. Required.', 'wp-graphql-gravity-forms'),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __('The text to be displayed in the column header.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'List field column labels.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'text'  => [
+						'type'        => 'String',
+						'description' => __( 'The text to be displayed in the column header. Required.', 'wp-graphql-gravity-forms' ),
+					],
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The text to be displayed in the column header.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/MaxLengthProperty.php
+++ b/src/Types/Field/FieldProperty/MaxLengthProperty.php
@@ -6,18 +6,18 @@ use GF_Field;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class MaxLengthProperty implements FieldProperty {
-    /**
-     * Get 'maxLength' property.
-     */
-    public static function get() : array {
-        return [
-            'maxLength' => [
-                'type'        => 'Integer',
-                'description' => __('Specifies the maximum number of characters allowed in a text or textarea (paragraph) field.', 'wp-graphql-gravity-forms'),
-                'resolve' => function( GF_Field $field ) : int {
-                    return (int) $field['maxLength'];
-                },
-            ],
-        ];
-    }
+	/**
+	 * Get 'maxLength' property.
+	 */
+	public static function get() : array {
+		return [
+			'maxLength' => [
+				'type'        => 'Integer',
+				'description' => __( 'Specifies the maximum number of characters allowed in a text or textarea (paragraph) field.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => function( GF_Field $field ) : int {
+					return (int) $field['maxLength'];
+				},
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/MaxLengthProperty.php
+++ b/src/Types/Field/FieldProperty/MaxLengthProperty.php
@@ -1,13 +1,24 @@
 <?php
+/**
+ * Max length field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use GF_Field;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - MaxLengthProperty
+ */
 abstract class MaxLengthProperty implements FieldProperty {
 	/**
 	 * Get 'maxLength' property.
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/MultiSelectChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/MultiSelectChoiceProperty.php
@@ -11,32 +11,35 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/gf_field_multiselect/
  */
 class MultiSelectChoiceProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'MultiSelectChoiceProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'MultiSelectChoiceProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms input property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'text' => [
-                    'type'        => 'String',
-                    'description' => __('The text that is displayed.', 'wp-graphql-gravity-forms'),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __('The value that is used for the multi select when the form is submitted.', 'wp-graphql-gravity-forms'),
-                ],
-                'isSelected' => [
-                    'type'        => 'Boolean',
-                    'description' => __('Indicates whether the item is selected.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'text'       => [
+						'type'        => 'String',
+						'description' => __( 'The text that is displayed.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'      => [
+						'type'        => 'String',
+						'description' => __( 'The value that is used for the multi select when the form is submitted.', 'wp-graphql-gravity-forms' ),
+					],
+					'isSelected' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Indicates whether the item is selected.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/MultiSelectChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/MultiSelectChoiceProperty.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * GraphQL Object Type - MultiSelectChoiceProperty
+ * An individual property for the 'choices' MultiSelect field property.
+ *
+ * @see https://docs.gravityforms.com/gf_field_multiselect/
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,9 +15,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual property for the 'choices' MultiSelect field property.
- *
- * @see https://docs.gravityforms.com/gf_field_multiselect/
+ * Class - MultiSelectChoiceProperty
  */
 class MultiSelectChoiceProperty implements Hookable, Type {
 	/**
@@ -16,10 +23,16 @@ class MultiSelectChoiceProperty implements Hookable, Type {
 	 */
 	const TYPE = 'MultiSelectChoiceProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
+++ b/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
@@ -5,18 +5,18 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class NoDuplicatesProperty implements FieldProperty {
-    /**
-     * Get 'noDuplicates' property.
-     *
-     * Applies to: hidden, text, website, phone, number, date, time, textarea,
-     * select, radio, email, post_custom_field
-     */
-    public static function get() : array {
-        return [
-            'noDuplicates' => [
-                'type'        => 'Boolean',
-                'description' => __('Determines if the field allows duplicate submissions. 1 to prevent users from submitting the same value more than once, 0 to allow duplicate values.', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'noDuplicates' property.
+	 *
+	 * Applies to: hidden, text, website, phone, number, date, time, textarea,
+	 * select, radio, email, post_custom_field
+	 */
+	public static function get() : array {
+		return [
+			'noDuplicates' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if the field allows duplicate submissions. 1 to prevent users from submitting the same value more than once, 0 to allow duplicate values.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
+++ b/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
@@ -1,15 +1,26 @@
 <?php
+/**
+ * No duplicates field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - NoDuplicatesProperty
+ */
 abstract class NoDuplicatesProperty implements FieldProperty {
 	/**
 	 * Get 'noDuplicates' property.
 	 *
 	 * Applies to: hidden, text, website, phone, number, date, time, textarea,
 	 * select, radio, email, post_custom_field
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/PasswordInputProperty.php
+++ b/src/Types/Field/FieldProperty/PasswordInputProperty.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * GraphQL Object Type - PasswordInputProperty
+ * An individual input in the Password field 'inputs' property.
+ *
+ * @see https://docs.gravityforms.com/gf_field_password/
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
@@ -6,9 +15,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * An individual input in the Password field 'inputs' property.
- *
- * @see https://docs.gravityforms.com/gf_field_password/
+ * Class - PasswordInputProperty
  */
 class PasswordInputProperty implements Hookable, Type {
 	/**
@@ -16,10 +23,16 @@ class PasswordInputProperty implements Hookable, Type {
 	 */
 	const TYPE = 'PasswordInputProperty';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldProperty/PasswordInputProperty.php
+++ b/src/Types/Field/FieldProperty/PasswordInputProperty.php
@@ -11,36 +11,39 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/gf_field_password/
  */
 class PasswordInputProperty implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PasswordInputProperty';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PasswordInputProperty';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __('Gravity Forms input property.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'id' => [
-                    'type'        => 'Float',
-                    'description' => __('The id of the input field.', 'wp-graphql-gravity-forms'),
-                ],
-                'label' => [
-                    'type'        => 'String',
-                    'description' => __('The label for the input.', 'wp-graphql-gravity-forms'),
-                ],
-                'customLabel' => [
-                    'type'        => 'String',
-                    'description' => __('The custom label for the input. When set, this is used in place of the label.', 'wp-graphql-gravity-forms'),
-                ],
-                'placeholder' => [
-                    'type'        => 'String',
-                    'description' => __('Placeholder text to give the user a hint on how to fill out the field. This is not submitted with the form.', 'wp-graphql-gravity-forms'),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'          => [
+						'type'        => 'Float',
+						'description' => __( 'The id of the input field.', 'wp-graphql-gravity-forms' ),
+					],
+					'label'       => [
+						'type'        => 'String',
+						'description' => __( 'The label for the input.', 'wp-graphql-gravity-forms' ),
+					],
+					'customLabel' => [
+						'type'        => 'String',
+						'description' => __( 'The custom label for the input. When set, this is used in place of the label.', 'wp-graphql-gravity-forms' ),
+					],
+					'placeholder' => [
+						'type'        => 'String',
+						'description' => __( 'Placeholder text to give the user a hint on how to fill out the field. This is not submitted with the form.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldProperty/PlaceholderProperty.php
+++ b/src/Types/Field/FieldProperty/PlaceholderProperty.php
@@ -5,15 +5,15 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class PlaceholderProperty implements FieldProperty {
-    /**
-     * Get 'placeholder' property.
-     */
-    public static function get() : array {
-        return [
-            'placeholder' => [
-                'type'        => 'String',
-                'description' => __( 'Field placeholder.', 'wp-graphql-gravity-forms' ),
-            ],
-        ];
-    }
+	/**
+	 * Get 'placeholder' property.
+	 */
+	public static function get() : array {
+		return [
+			'placeholder' => [
+				'type'        => 'String',
+				'description' => __( 'Field placeholder.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/PlaceholderProperty.php
+++ b/src/Types/Field/FieldProperty/PlaceholderProperty.php
@@ -1,12 +1,23 @@
 <?php
+/**
+ * Placeholder field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - PlaceholderProperty
+ */
 abstract class PlaceholderProperty implements FieldProperty {
 	/**
 	 * Get 'placeholder' property.
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldProperty/SizeProperty.php
+++ b/src/Types/Field/FieldProperty/SizeProperty.php
@@ -5,19 +5,19 @@ namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
 abstract class SizeProperty implements FieldProperty {
-    /**
-     * Get 'size' property.
-     *
-     * Applies to: All fields except html, section and captcha
-     * Possible values: small, medium, large
-     */
-    public static function get() : array {
-        return [
-            // @TODO: Convert to enum. Possible values: small, medium, large
-            'size' => [
-                'type'        => 'String',
-                'description' => __('Determines the size of the field when displayed on the page. Possible values are: "small", "medium", "large".', 'wp-graphql-gravity-forms'),
-            ],
-        ];
-    }
+	/**
+	 * Get 'size' property.
+	 *
+	 * Applies to: All fields except html, section and captcha
+	 * Possible values: small, medium, large
+	 */
+	public static function get() : array {
+		return [
+			// @TODO: Convert to enum. Possible values: small, medium, large
+			'size' => [
+				'type'        => 'String',
+				'description' => __( 'Determines the size of the field when displayed on the page. Possible values are: "small", "medium", "large".', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
 }

--- a/src/Types/Field/FieldProperty/SizeProperty.php
+++ b/src/Types/Field/FieldProperty/SizeProperty.php
@@ -1,15 +1,26 @@
 <?php
+/**
+ * Size field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 use WPGraphQLGravityForms\Interfaces\FieldProperty;
 
+/**
+ * Class - SizeProperty
+ */
 abstract class SizeProperty implements FieldProperty {
 	/**
 	 * Get 'size' property.
 	 *
 	 * Applies to: All fields except html, section and captcha
 	 * Possible values: small, medium, large
+	 *
+	 * @return array
 	 */
 	public static function get() : array {
 		return [

--- a/src/Types/Field/FieldValue/AddressFieldValue.php
+++ b/src/Types/Field/FieldValue/AddressFieldValue.php
@@ -12,63 +12,66 @@ use WPGraphQLGravityForms\Types\Field\AddressField;
  * Values for an individual Address field.
  */
 class AddressFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = AddressField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = AddressField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms address field values.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'street' => [
-                    'type'        => 'String',
-                    'description' => __( 'Street address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'lineTwo' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address line two.', 'wp-graphql-gravity-forms' ),
-                ],
-                'city' => [
-                    'type'        => 'String',
-                    'description' => __( 'City.', 'wp-graphql-gravity-forms' ),
-                ],
-                'state' => [
-                    'type'        => 'String',
-                    'description' => __( 'State / province.', 'wp-graphql-gravity-forms' ),
-                ],
-                'zip' => [
-                    'type'        => 'String',
-                    'description' => __( 'ZIP / postal code.', 'wp-graphql-gravity-forms' ),
-                ],
-                'country' => [
-                    'type'        => 'String',
-                    'description' => __( 'Country.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms address field values.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'street'  => [
+						'type'        => 'String',
+						'description' => __( 'Street address.', 'wp-graphql-gravity-forms' ),
+					],
+					'lineTwo' => [
+						'type'        => 'String',
+						'description' => __( 'Address line two.', 'wp-graphql-gravity-forms' ),
+					],
+					'city'    => [
+						'type'        => 'String',
+						'description' => __( 'City.', 'wp-graphql-gravity-forms' ),
+					],
+					'state'   => [
+						'type'        => 'String',
+						'description' => __( 'State / province.', 'wp-graphql-gravity-forms' ),
+					],
+					'zip'     => [
+						'type'        => 'String',
+						'description' => __( 'ZIP / postal code.', 'wp-graphql-gravity-forms' ),
+					],
+					'country' => [
+						'type'        => 'String',
+						'description' => __( 'Country.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'street'  => $entry[ $field['inputs'][0]['id'] ] ?? null,
-            'lineTwo' => $entry[ $field['inputs'][1]['id'] ] ?? null,
-            'city'    => $entry[ $field['inputs'][2]['id'] ] ?? null,
-            'state'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
-            'zip'     => $entry[ $field['inputs'][4]['id'] ] ?? null,
-            'country' => $entry[ $field['inputs'][5]['id'] ] ?? null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'street'  => $entry[ $field['inputs'][0]['id'] ] ?? null,
+			'lineTwo' => $entry[ $field['inputs'][1]['id'] ] ?? null,
+			'city'    => $entry[ $field['inputs'][2]['id'] ] ?? null,
+			'state'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
+			'zip'     => $entry[ $field['inputs'][4]['id'] ] ?? null,
+			'country' => $entry[ $field['inputs'][5]['id'] ] ?? null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/AddressFieldValue.php
+++ b/src/Types/Field/FieldValue/AddressFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - AddressFieldValue
+ * Values for an individual Address field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\AddressField;
 
 /**
- * Values for an individual Address field.
+ * Class - AddressFieldValue
  */
 class AddressFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class AddressFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = AddressField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/ChainedSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/ChainedSelectFieldValue.php
@@ -12,40 +12,46 @@ use WPGraphQLGravityForms\Types\Field\ChainedSelectField;
  * Values for an individual Chained Select field.
  */
 class ChainedSelectFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = ChainedSelectField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = ChainedSelectField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Chained Select field values.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'values' => [
-                    'type'        => [ 'list_of' => 'String' ],
-                    'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Chained Select field values.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'values' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field values.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field values.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        $values = array_map( function( $input ) use ( $entry ) {
-            return $entry[ $input['id'] ] ?? '';
-        }, $field->inputs );
+	/**
+	 * Get the field values.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field values.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		$values = array_map(
+			function( $input ) use ( $entry ) {
+				return $entry[ $input['id'] ] ?? '';
+			},
+			$field->inputs
+		);
 
-        return compact( 'values' );
-    }
+		return compact( 'values' );
+	}
 }

--- a/src/Types/Field/FieldValue/ChainedSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/ChainedSelectFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - ChainedSelectFieldValue
+ * Values for an individual Chained Select field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\ChainedSelectField;
 
 /**
- * Values for an individual Chained Select field.
+ * Class - ChainedSelectFieldValue
  */
 class ChainedSelectFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class ChainedSelectFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = ChainedSelectField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/CheckboxFieldValue.php
+++ b/src/Types/Field/FieldValue/CheckboxFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - CheckboxFieldValue
+ * Value for a checkbox field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -17,10 +24,16 @@ class CheckboxFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = CheckboxField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/CheckboxFieldValue.php
+++ b/src/Types/Field/FieldValue/CheckboxFieldValue.php
@@ -12,50 +12,53 @@ use WPGraphQLGravityForms\Types\Field\CheckboxField;
  * Value for a checkbox field.
  */
 class CheckboxFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = CheckboxField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = CheckboxField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Checkbox field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'checkboxValues' => [
-                    'type'        => [ 'list_of' => CheckboxInputValue::TYPE ],
-                    'description' => __( 'Values.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Checkbox field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'checkboxValues' => [
+						'type'        => [ 'list_of' => CheckboxInputValue::TYPE ],
+						'description' => __( 'Values.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        $field_input_ids = wp_list_pluck( $field->inputs, 'id' );
-        $checkboxValues  = [];
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		$field_input_ids = wp_list_pluck( $field->inputs, 'id' );
+		$checkboxValues  = [];
 
-        foreach( $entry as $input_id => $value ) {
-            $is_field_input_value = in_array( $input_id, $field_input_ids, true ) && '' !== $value;
+		foreach ( $entry as $input_id => $value ) {
+			$is_field_input_value = in_array( $input_id, $field_input_ids, true ) && '' !== $value;
 
-            if ( $is_field_input_value ) {
-                $checkboxValues[] = [
-                    'inputId' => $input_id,
-                    'value'   => $value,
-                ];
-            }
-        }
+			if ( $is_field_input_value ) {
+				$checkboxValues[] = [
+					'inputId' => $input_id,
+					'value'   => $value,
+				];
+			}
+		}
 
-        return compact( 'checkboxValues' );
-    }
+		return compact( 'checkboxValues' );
+	}
 }

--- a/src/Types/Field/FieldValue/CheckboxInputValue.php
+++ b/src/Types/Field/FieldValue/CheckboxInputValue.php
@@ -9,28 +9,31 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * Value for a single input within a checkbox field.
  */
 class CheckboxInputValue implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'CheckboxInputValue';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'CheckboxInputValue';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Value for a single input within a checkbox field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'inputId' => [
-                    'type'        => 'Float',
-                    'description' => __( 'Input ID.', 'wp-graphql-gravity-forms' ),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Value for a single input within a checkbox field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'inputId' => [
+						'type'        => 'Float',
+						'description' => __( 'Input ID.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'   => [
+						'type'        => 'String',
+						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Field/FieldValue/CheckboxInputValue.php
+++ b/src/Types/Field/FieldValue/CheckboxInputValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - CheckboxInputValue
+ * Value for a single input within a checkbox field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * Value for a single input within a checkbox field.
+ * Class - CheckboxInputValue
  */
 class CheckboxInputValue implements Hookable, Type {
 	/**
@@ -14,10 +21,16 @@ class CheckboxInputValue implements Hookable, Type {
 	 */
 	const TYPE = 'CheckboxInputValue';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/DateFieldValue.php
+++ b/src/Types/Field/FieldValue/DateFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\DateField;
  * Value for a date field.
  */
 class DateFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = DateField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = DateField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Date field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Date field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/DateFieldValue.php
+++ b/src/Types/Field/FieldValue/DateFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - DateFieldValue
+ * Values for an individual Date field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\DateField;
 
 /**
- * Value for a date field.
+ * Class - DateFieldValue
  */
 class DateFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class DateFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = DateField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/EmailFieldValue.php
+++ b/src/Types/Field/FieldValue/EmailFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\EmailField;
  * Value for an email field.
  */
 class EmailFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = EmailField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = EmailField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Email field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Email field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/EmailFieldValue.php
+++ b/src/Types/Field/FieldValue/EmailFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - EmailFieldValue
+ * Values for an individual Email field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\EmailField;
 
 /**
- * Value for an email field.
+ * Class - EmailFieldValue
  */
 class EmailFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class EmailFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = EmailField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/FileUploadFieldValue.php
+++ b/src/Types/Field/FieldValue/FileUploadFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - FileUploadFieldValue
+ * Values for an individual FileUpload field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\FileUploadField;
 
 /**
- * Value for an individual File Upload field.
+ * Class - FileUploadFieldValue
  */
 class FileUploadFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class FileUploadFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = FileUploadField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/FileUploadFieldValue.php
+++ b/src/Types/Field/FieldValue/FileUploadFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\FileUploadField;
  * Value for an individual File Upload field.
  */
 class FileUploadFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = FileUploadField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = FileUploadField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'File upload field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'url' => [
-                    'type'        => 'String',
-                    'description' => __( 'URL to the uploaded file.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'File upload field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'url' => [
+						'type'        => 'String',
+						'description' => __( 'URL to the uploaded file.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'url' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'url' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/ListFieldValue.php
+++ b/src/Types/Field/FieldValue/ListFieldValue.php
@@ -23,15 +23,18 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 	}
 
 	public function register_type() {
-			register_graphql_object_type( self::TYPE, [
+			register_graphql_object_type(
+				self::TYPE,
+				[
 					'description' => __( 'List field values.', 'wp-graphql-gravity-forms' ),
 					'fields'      => [
-							'listValues' => [
-									'type'        => [ 'list_of' => ListInputValue::TYPE ],
-									'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
-							],
+						'listValues' => [
+							'type'        => [ 'list_of' => ListInputValue::TYPE ],
+							'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
+						],
 					],
-			] );
+				]
+			);
 	}
 
 	/**
@@ -57,23 +60,29 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 			$field_keys = wp_list_pluck( $field->choices, 'text' );
 
 			// Save each row-value pair.
-			$listValues = array_map( function( $row ) use ( $field_keys ) {
-				$row_values = [];
+			$listValues = array_map(
+				function( $row ) use ( $field_keys ) {
+					$row_values = [];
 
-				foreach( $row as $key=>$single_value){
-					$row_values[] = $single_value[ $field_keys[ $key ] ];
-				}
+					foreach ( $row as $key => $single_value ) {
+						  $row_values[] = $single_value[ $field_keys[ $key ] ];
+					}
 
-				return ['value' => $row_values];
-			}, $entry_values );
+					return [ 'value' => $row_values ];
+				},
+				$entry_values
+			);
 
 			return compact( 'listValues' );
 		}
 
 		// If no columns, entry values can be mapped directly to 'value'.
-		$listValues = array_map( function( $single_value ) {
-			return [ 'value' => [ $single_value ] ]; // $single_value must be Iteratable.
-		}, $entry_values );
+		$listValues = array_map(
+			function( $single_value ) {
+				return [ 'value' => [ $single_value ] ]; // $single_value must be Iteratable.
+			},
+			$entry_values
+		);
 
 		return compact( 'listValues' );
 	}

--- a/src/Types/Field/FieldValue/ListFieldValue.php
+++ b/src/Types/Field/FieldValue/ListFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - ListFieldValue
+ * Values for an individual List field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -10,7 +17,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\ListField;
 
 /**
- * Values for an individual List field.
+ * Class - ListFieldValue
  */
 class ListFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -18,10 +25,16 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = ListField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 			add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 			register_graphql_object_type(
 				self::TYPE,
@@ -44,6 +57,8 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 	 * @param GF_Field $field Gravity Forms field.
 	 *
 	 * @return array Entry field values.
+	 *
+	 * @throws UserError .
 	 */
 	public static function get( array $entry, GF_Field $field ) : array {
 		$entry_values = isset( $entry[ $field['id'] ] ) ? unserialize( $entry[ $field['id'] ] ) : [];
@@ -65,7 +80,7 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 					$row_values = [];
 
 					foreach ( $row as $key => $single_value ) {
-						  $row_values[] = $single_value[ $field_keys[ $key ] ];
+						$row_values[] = $single_value[ $field_keys[ $key ] ];
 					}
 
 					return [ 'value' => $row_values ];

--- a/src/Types/Field/FieldValue/ListFieldValue.php
+++ b/src/Types/Field/FieldValue/ListFieldValue.php
@@ -65,6 +65,7 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 
 		// Check if there are too many rows.
 		if ( $field['maxRows'] < count( $entry_values ) ) {
+			// translators: maximum number of rows.
 			throw new UserError( sprintf( __( 'You may only submit %d rows.', 'wp-graphql-gravity-forms' ), $field['maxRows'] ) );
 		}
 

--- a/src/Types/Field/FieldValue/ListInputValue.php
+++ b/src/Types/Field/FieldValue/ListInputValue.php
@@ -19,14 +19,17 @@ class ListInputValue implements Hookable, Type {
 	}
 
 	public function register_type() {
-		register_graphql_object_type( self::TYPE, [
-			'description' => __( 'Value for a single input within a list field.', 'wp-graphql-gravity-forms' ),
-			'fields'      => [
-				'value' => [
-					'type'        => ['list_of' => 'String'],
-					'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Value for a single input within a list field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+					],
 				],
-			],
-		] );
+			]
+		);
 	}
 }

--- a/src/Types/Field/FieldValue/ListInputValue.php
+++ b/src/Types/Field/FieldValue/ListInputValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - ListInputValue
+ * Value for a single input within a List field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * Value for a single input within a List field.
+ * Class - ListInputValue
  */
 class ListInputValue implements Hookable, Type {
 	/**
@@ -14,10 +21,16 @@ class ListInputValue implements Hookable, Type {
 	 */
 	const TYPE = 'ListInputValue';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 			add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/MultiSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/MultiSelectFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - MultiSelectFieldValue
+ * Values for an individual MultiSelect field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\MultiSelectField;
 
 /**
- * Values for an individual MultiSelect field.
+ * Class - MultiSelectFieldValue
  */
 class MultiSelectFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class MultiSelectFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = MultiSelectField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,
@@ -45,7 +58,6 @@ class MultiSelectFieldValue implements Hookable, Type, FieldValue {
 	 * @return array Entry field values.
 	 */
 	public static function get( array $entry, GF_Field $field ) : array {
-			error_log( print_r( $entry, true ) );
 		return [
 			'values' => isset( $entry[ $field['id'] ] ) ? json_decode( $entry[ $field['id'] ], true ) : null,
 		];

--- a/src/Types/Field/FieldValue/MultiSelectFieldValue.php
+++ b/src/Types/Field/FieldValue/MultiSelectFieldValue.php
@@ -12,39 +12,42 @@ use WPGraphQLGravityForms\Types\Field\MultiSelectField;
  * Values for an individual MultiSelect field.
  */
 class MultiSelectFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = MultiSelectField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = MultiSelectField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Multiselect field values.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'values' => [
-                    'type'        => [ 'list_of' => 'String' ],
-                    'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Multiselect field values.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'values' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Field values.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field values.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field values.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-			error_log(print_r($entry, true));
-        return [
-            'values' => isset( $entry[ $field['id'] ] ) ? json_decode( $entry[ $field['id'] ], true ) : null,
-        ];
-    }
+	/**
+	 * Get the field values.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field values.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+			error_log( print_r( $entry, true ) );
+		return [
+			'values' => isset( $entry[ $field['id'] ] ) ? json_decode( $entry[ $field['id'] ], true ) : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - NameFieldValue
+ * Values for an individual Name field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\NameField;
 
 /**
- * Values for an individual Name field.
+ * Class - NameFieldValue
  */
 class NameFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class NameFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = NameField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/NameFieldValue.php
+++ b/src/Types/Field/FieldValue/NameFieldValue.php
@@ -12,58 +12,61 @@ use WPGraphQLGravityForms\Types\Field\NameField;
  * Values for an individual Name field.
  */
 class NameFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = NameField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = NameField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Name field values.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'prefix' => [
-                    'type'        => 'String',
-                    'description' => __( 'Prefix, such as Mr., Mrs. etc.', 'wp-graphql-gravity-forms' ),
-                ],
-                'first' => [
-                    'type'        => 'String',
-                    'description' => __( 'First name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'middle' => [
-                    'type'        => 'String',
-                    'description' => __( 'Middle name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'last' => [
-                    'type'        => 'String',
-                    'description' => __( 'Last name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'suffix' => [
-                    'type'        => 'String',
-                    'description' => __( 'Suffix, such as Sr., Jr. etc.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Name field values.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'prefix' => [
+						'type'        => 'String',
+						'description' => __( 'Prefix, such as Mr., Mrs. etc.', 'wp-graphql-gravity-forms' ),
+					],
+					'first'  => [
+						'type'        => 'String',
+						'description' => __( 'First name.', 'wp-graphql-gravity-forms' ),
+					],
+					'middle' => [
+						'type'        => 'String',
+						'description' => __( 'Middle name.', 'wp-graphql-gravity-forms' ),
+					],
+					'last'   => [
+						'type'        => 'String',
+						'description' => __( 'Last name.', 'wp-graphql-gravity-forms' ),
+					],
+					'suffix' => [
+						'type'        => 'String',
+						'description' => __( 'Suffix, such as Sr., Jr. etc.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
 			return [
-					'prefix' => $entry[ $field['inputs'][0]['id'] ] ?? null,
-					'first'  => $entry[ $field['inputs'][1]['id'] ] ?? null,
-					'middle' => $entry[ $field['inputs'][2]['id'] ] ?? null,
-					'last'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
-					'suffix' => $entry[ $field['inputs'][4]['id'] ] ?? null,
+				'prefix' => $entry[ $field['inputs'][0]['id'] ] ?? null,
+				'first'  => $entry[ $field['inputs'][1]['id'] ] ?? null,
+				'middle' => $entry[ $field['inputs'][2]['id'] ] ?? null,
+				'last'   => $entry[ $field['inputs'][3]['id'] ] ?? null,
+				'suffix' => $entry[ $field['inputs'][4]['id'] ] ?? null,
 			];
-    }
+	}
 }

--- a/src/Types/Field/FieldValue/NumberFieldValue.php
+++ b/src/Types/Field/FieldValue/NumberFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\NumberField;
  * Value for a number field.
  */
 class NumberFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = NumberField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = NumberField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Number field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Number field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/NumberFieldValue.php
+++ b/src/Types/Field/FieldValue/NumberFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - NumberFieldValue
+ * Values for an individual Number field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\NumberField;
 
 /**
- * Value for a number field.
+ * Class - NumberFieldValue
  */
 class NumberFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class NumberFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = NumberField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/PhoneFieldValue.php
+++ b/src/Types/Field/FieldValue/PhoneFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\PhoneField;
  * Value for a phone field.
  */
 class PhoneFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = PhoneField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = PhoneField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Phone field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Phone field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/PhoneFieldValue.php
+++ b/src/Types/Field/FieldValue/PhoneFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - PhoneFieldValue
+ * Values for an individual Phone field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\PhoneField;
 
 /**
- * Value for a phone field.
+ * Class - PhoneFieldValue
  */
 class PhoneFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class PhoneFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = PhoneField::TYPE . 'Value';
 
+	/**
+	 * Type registered in WPGraphQL.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/RadioFieldValue.php
+++ b/src/Types/Field/FieldValue/RadioFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - RadioFieldValue
+ * Values for an individual Radio field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\RadioField;
 
 /**
- * Value for a radio field.
+ * Class - RadioFieldValue
  */
 class RadioFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class RadioFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = RadioField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/RadioFieldValue.php
+++ b/src/Types/Field/FieldValue/RadioFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\RadioField;
  * Value for a radio field.
  */
 class RadioFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = RadioField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = RadioField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Radio field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Radio field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        $value = isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null;
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		$value = isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null;
 
-        return [ 'value' => $value ];
-    }
+		return [ 'value' => $value ];
+	}
 }

--- a/src/Types/Field/FieldValue/SelectFieldValue.php
+++ b/src/Types/Field/FieldValue/SelectFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - SelectFieldValue
+ * Values for an individual Select field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\SelectField;
 
 /**
- * Value for a select field.
+ * Class - SelectFieldValue
  */
 class SelectFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class SelectFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = SelectField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/SelectFieldValue.php
+++ b/src/Types/Field/FieldValue/SelectFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\SelectField;
  * Value for a select field.
  */
 class SelectFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = SelectField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = SelectField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Select field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Select field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/SignatureFieldValue.php
+++ b/src/Types/Field/FieldValue/SignatureFieldValue.php
@@ -12,42 +12,45 @@ use WPGraphQLGravityForms\Types\Field\SignatureField;
  * Value for an individual Signature field.
  */
 class SignatureFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = SignatureField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = SignatureField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Signature field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'url' => [
-                    'type'        => 'String',
-                    'description' => __( 'The URL to the signature image.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Signature field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'url' => [
+						'type'        => 'String',
+						'description' => __( 'The URL to the signature image.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        if ( ! function_exists( 'gf_signature' ) || ! array_key_exists( $field['id'], $entry ) ) {
-            return [ 'url' => null ];
-        }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		if ( ! function_exists( 'gf_signature' ) || ! array_key_exists( $field['id'], $entry ) ) {
+			return [ 'url' => null ];
+		}
 
-        return [
-            'url' => gf_signature()->get_signature_url( $entry[ $field['id'] ] ),
-        ];
-    }
+		return [
+			'url' => gf_signature()->get_signature_url( $entry[ $field['id'] ] ),
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/SignatureFieldValue.php
+++ b/src/Types/Field/FieldValue/SignatureFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - SignatureFieldValue
+ * Values for an individual Signature field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\SignatureField;
 
 /**
- * Value for an individual Signature field.
+ * Class - SignatureFieldValue
  */
 class SignatureFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class SignatureFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = SignatureField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/TextAreaFieldValue.php
+++ b/src/Types/Field/FieldValue/TextAreaFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\TextAreaField;
  * Value for a text area field.
  */
 class TextAreaFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = TextAreaField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = TextAreaField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Textarea field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Textarea field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        $value = isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null;
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		$value = isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null;
 
-        return [ 'value' => $value ];
-    }
+		return [ 'value' => $value ];
+	}
 }

--- a/src/Types/Field/FieldValue/TextAreaFieldValue.php
+++ b/src/Types/Field/FieldValue/TextAreaFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - TextAreaFieldValue
+ * Values for an individual Textarea field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\TextAreaField;
 
 /**
- * Value for a text area field.
+ * Class - TextAreaFieldValue
  */
 class TextAreaFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class TextAreaFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = TextAreaField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/TextFieldValue.php
+++ b/src/Types/Field/FieldValue/TextFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - TextFieldValue
+ * Values for an individual Text field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\TextField;
 
 /**
- * Value for a text field.
+ * Class - TextFieldValue
  */
 class TextFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class TextFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = TextField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/TextFieldValue.php
+++ b/src/Types/Field/FieldValue/TextFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\TextField;
  * Value for a text field.
  */
 class TextFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = TextField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = TextField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Text field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Text field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-        return [
-            'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
-        ];
-    }
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		return [
+			'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
+		];
+	}
 }

--- a/src/Types/Field/FieldValue/TimeFieldValue.php
+++ b/src/Types/Field/FieldValue/TimeFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - TimeFieldValue
+ * Values for an individual Time field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\TimeField;
 
 /**
- * Values for an individual Time field.
+ * Class - TimeFieldValue
  */
 class TimeFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class TimeFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = TimeField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/TimeFieldValue.php
+++ b/src/Types/Field/FieldValue/TimeFieldValue.php
@@ -12,56 +12,59 @@ use WPGraphQLGravityForms\Types\Field\TimeField;
  * Values for an individual Time field.
  */
 class TimeFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = TimeField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = TimeField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Time field values.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'displayValue' => [
-                    'type'        => 'String',
-                    'description' => __( 'The full display value. Example: "08:25 am".', 'wp-graphql-gravity-forms' ),
-                ],
-                'hours' => [
-                    'type'        => 'String',
-                    'description' => __( 'The hours, in this format: hh.', 'wp-graphql-gravity-forms' ),
-                ],
-                'minutes' => [
-                    'type'        => 'String',
-                    'description' => __( 'The minutes, in this format: mm.', 'wp-graphql-gravity-forms' ),
-                ],
-                'amPm' => [
-                    'type'        => 'String',
-                    'description' => __( 'AM or PM.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Time field values.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'displayValue' => [
+						'type'        => 'String',
+						'description' => __( 'The full display value. Example: "08:25 am".', 'wp-graphql-gravity-forms' ),
+					],
+					'hours'        => [
+						'type'        => 'String',
+						'description' => __( 'The hours, in this format: hh.', 'wp-graphql-gravity-forms' ),
+					],
+					'minutes'      => [
+						'type'        => 'String',
+						'description' => __( 'The minutes, in this format: mm.', 'wp-graphql-gravity-forms' ),
+					],
+					'amPm'         => [
+						'type'        => 'String',
+						'description' => __( 'AM or PM.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
-			if ( ! isset( $entry [ $field['id'] ] ) ) {
-				return [ 
-					'displayValue' => null,
-					'hours' => null,
-					'minutes' => null,
-					'amPm'=> null,
-				];
-			}
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
+		if ( ! isset( $entry [ $field['id'] ] ) ) {
+			return [
+				'displayValue' => null,
+				'hours'        => null,
+				'minutes'      => null,
+				'amPm'         => null,
+			];
+		}
 
 			$display_value  = $entry[ $field['id'] ];
 			$parts_by_colon = explode( ':', $display_value );
@@ -71,10 +74,10 @@ class TimeFieldValue implements Hookable, Type, FieldValue {
 			$minutes        = rtrim( ltrim( $display_value, "{$hours}:" ), " {$am_pm}" );
 
 			return [
-					'displayValue' => $display_value,
-					'hours'        => $hours,
-					'minutes'      => $minutes,
-					'amPm'         => $am_pm,
+				'displayValue' => $display_value,
+				'hours'        => $hours,
+				'minutes'      => $minutes,
+				'amPm'         => $am_pm,
 			];
-    }
+	}
 }

--- a/src/Types/Field/FieldValue/WebsiteFieldValue.php
+++ b/src/Types/Field/FieldValue/WebsiteFieldValue.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Object Type - WebsiteFieldValue
+ * Values for an individual Website field.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldValue
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\WebsiteField;
 
 /**
- * Value for a website field.
+ * Class - WebsiteFieldValue
  */
 class WebsiteFieldValue implements Hookable, Type, FieldValue {
 	/**
@@ -17,10 +24,16 @@ class WebsiteFieldValue implements Hookable, Type, FieldValue {
 	 */
 	const TYPE = WebsiteField::TYPE . 'Value';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FieldValue/WebsiteFieldValue.php
+++ b/src/Types/Field/FieldValue/WebsiteFieldValue.php
@@ -12,38 +12,41 @@ use WPGraphQLGravityForms\Types\Field\WebsiteField;
  * Value for a website field.
  */
 class WebsiteFieldValue implements Hookable, Type, FieldValue {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = WebsiteField::TYPE . 'Value';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = WebsiteField::TYPE . 'Value';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Website field value.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Website field value.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value' => [
+						'type'        => 'String',
+						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    /**
-     * Get the field value.
-     *
-     * @param array    $entry Gravity Forms entry.
-     * @param GF_Field $field Gravity Forms field.
-     *
-     * @return array Entry field value.
-     */
-    public static function get( array $entry, GF_Field $field ) : array {
+	/**
+	 * Get the field value.
+	 *
+	 * @param array    $entry Gravity Forms entry.
+	 * @param GF_Field $field Gravity Forms field.
+	 *
+	 * @return array Entry field value.
+	 */
+	public static function get( array $entry, GF_Field $field ) : array {
 			return [
 				'value' => isset( $entry[ $field['id'] ] ) ? (string) $entry[ $field['id'] ] : null,
 			];
-    }
+	}
 }

--- a/src/Types/Field/FileUploadField.php
+++ b/src/Types/Field/FileUploadField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - FileUploadField
+ *
+ * @see https://docs.gravityforms.com/gf_field_fileupload/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * File upload field.
- *
- * @see https://docs.gravityforms.com/gf_field_fileupload/
+ * Class - FileUploadField
  */
 class FileUploadField extends Field {
 	/**
@@ -20,10 +26,16 @@ class FileUploadField extends Field {
 	 */
 	const GF_TYPE = 'fileupload';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/FileUploadField.php
+++ b/src/Types/Field/FileUploadField.php
@@ -10,50 +10,53 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_fileupload/
  */
 class FileUploadField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'FileUploadField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'FileUploadField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'fileupload';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'fileupload';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms File Upload field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-								[
-									'allowedExtensions' => [
-										'type' => 'String',
-										'description' => __( 'A comma-delimited list of the file extensions which may be uploaded.', 'wp-graphql-gravity-forms' )
-									],
-									'maxFiles' => [
-										'type' => 'String',
-										'description' => __('When the field is set to allow multiple files to be uploaded, this property is available to set a limit on how many may be uploaded.', 'wp-graphql-gravity-forms'),
-									],
-									'maxFileSize' => [
-										'type' => 'Integer',
-										'description' => __('The maximum size (in MB) an uploaded file may be .', 'wp-graphql-gravity-forms' ),
-									],
-									'multipleFiles' => [
-										'type' => 'Boolean',
-										'description' => __('Indicates whether multiple files may be uploaded.', 'wp-graphql-gravity-forms')
-									],
-								],
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms File Upload field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'allowedExtensions' => [
+							'type'        => 'String',
+							'description' => __( 'A comma-delimited list of the file extensions which may be uploaded.', 'wp-graphql-gravity-forms' ),
+						],
+						'maxFiles'          => [
+							'type'        => 'String',
+							'description' => __( 'When the field is set to allow multiple files to be uploaded, this property is available to set a limit on how many may be uploaded.', 'wp-graphql-gravity-forms' ),
+						],
+						'maxFileSize'       => [
+							'type'        => 'Integer',
+							'description' => __( 'The maximum size (in MB) an uploaded file may be .', 'wp-graphql-gravity-forms' ),
+						],
+						'multipleFiles'     => [
+							'type'        => 'Boolean',
+							'description' => __( 'Indicates whether multiple files may be uploaded.', 'wp-graphql-gravity-forms' ),
+						],
+					],
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/HiddenField.php
+++ b/src/Types/Field/HiddenField.php
@@ -10,32 +10,35 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_hidden/
  */
 class HiddenField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'HiddenField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'HiddenField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'hidden';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'hidden';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Hidden field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Hidden field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/HiddenField.php
+++ b/src/Types/Field/HiddenField.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - HiddenField
+ *
+ * @see https://docs.gravityforms.com/gf_field_hidden/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
@@ -20,10 +28,16 @@ class HiddenField extends Field {
 	 */
 	const GF_TYPE = 'hidden';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/HtmlField.php
+++ b/src/Types/Field/HtmlField.php
@@ -10,34 +10,37 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_html/
  */
 class HtmlField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'HtmlField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'HtmlField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'html';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'html';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms HTML field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\InputNameProperty::get(),
-                [
-                    'content' => [
-                        'type'        => 'String',
-                        'description' => __( 'Content of an HTML block field to be displayed on the form.', 'wp-graphql-gravity-forms' ),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms HTML field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\InputNameProperty::get(),
+					[
+						'content' => [
+							'type'        => 'String',
+							'description' => __( 'Content of an HTML block field to be displayed on the form.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/HtmlField.php
+++ b/src/Types/Field/HtmlField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - HtmlField
+ *
+ * @see https://docs.gravityforms.com/gf_field_html/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * HTML field.
- *
- * @see https://docs.gravityforms.com/gf_field_html/
+ * Class - HtmlField
  */
 class HtmlField extends Field {
 	/**
@@ -20,10 +26,16 @@ class HtmlField extends Field {
 	 */
 	const GF_TYPE = 'html';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -10,59 +10,62 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_list/
  */
 class ListField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ListField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ListField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'list';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'list';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms List field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionPlacementProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\LabelPlacementProperty::get(),
-                [
-                    'addIconUrl' => [
-                        'type'        => 'String',
-                        'description' => __('The URL of the image to be used for the add row button.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'choices' => [
-                        'type'        => [ 'list_of' => FieldProperty\ListChoiceProperty::TYPE ],
-                        'description' => __('The column labels. Only used when enableColumns is true.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'deleteIconUrl' => [
-                        'type'        => 'String',
-                        'description' => __('The URL of the image to be used for the delete row button.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'enableColumns' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Determines if the field should use multiple columns. Default is false.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'maxRows' => [
-                        'type'        => 'Integer',
-                        'description' => __( 'The maximum number of rows the user can add to the field.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'pageNumber' => [
-                        'type'        => 'Integer',
-                        'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms List field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionPlacementProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelPlacementProperty::get(),
+					[
+						'addIconUrl'    => [
+							'type'        => 'String',
+							'description' => __( 'The URL of the image to be used for the add row button.', 'wp-graphql-gravity-forms' ),
+						],
+						'choices'       => [
+							'type'        => [ 'list_of' => FieldProperty\ListChoiceProperty::TYPE ],
+							'description' => __( 'The column labels. Only used when enableColumns is true.', 'wp-graphql-gravity-forms' ),
+						],
+						'deleteIconUrl' => [
+							'type'        => 'String',
+							'description' => __( 'The URL of the image to be used for the delete row button.', 'wp-graphql-gravity-forms' ),
+						],
+						'enableColumns' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Determines if the field should use multiple columns. Default is false.', 'wp-graphql-gravity-forms' ),
+						],
+						'maxRows'       => [
+							'type'        => 'Integer',
+							'description' => __( 'The maximum number of rows the user can add to the field.', 'wp-graphql-gravity-forms' ),
+						],
+						'pageNumber'    => [
+							'type'        => 'Integer',
+							'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - ListField
+ *
+ * @see https://docs.gravityforms.com/gf_field_list/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * List field.
- *
- * @see https://docs.gravityforms.com/gf_field_list/
+ * Class - ListField
  */
 class ListField extends Field {
 	/**
@@ -20,10 +26,16 @@ class ListField extends Field {
 	 */
 	const GF_TYPE = 'list';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/MultiSelectField.php
+++ b/src/Types/Field/MultiSelectField.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - MultiSelectField
+ *
+ * @see https://docs.gravityforms.com/gf_field_multiselect/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
@@ -20,10 +28,17 @@ class MultiSelectField extends Field {
 	 */
 	const GF_TYPE = 'multiselect';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/MultiSelectField.php
+++ b/src/Types/Field/MultiSelectField.php
@@ -10,41 +10,44 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_multiselect/
  */
 class MultiSelectField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'MultiSelectField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'MultiSelectField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'multiselect';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'multiselect';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Multi-Select field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionPlacementProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\EnableChoiceValueProperty::get(),
-                FieldProperty\EnableEnhancedUiProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'choices' => [
-                        'type'        => [ 'list_of' => FieldProperty\MultiSelectChoiceProperty::TYPE ],
-                        'description' => __('The individual properties for each item in the multi-select.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Multi-Select field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionPlacementProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\EnableChoiceValueProperty::get(),
+					FieldProperty\EnableEnhancedUiProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'choices' => [
+							'type'        => [ 'list_of' => FieldProperty\MultiSelectChoiceProperty::TYPE ],
+							'description' => __( 'The individual properties for each item in the multi-select.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/NameField.php
+++ b/src/Types/Field/NameField.php
@@ -10,43 +10,46 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_name/
  */
 class NameField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'NameField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'NameField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'name';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'name';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Name field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\InputsProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    /**
-                     * Possible values: normal, extended, simple
-                     */
-                    'nameFormat' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the format of the name field.', 'wp-graphql-gravity-forms'),
-                    ],
-                    // @TODO: Add placeholders.
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Name field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\InputsProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						/**
+						 * Possible values: normal, extended, simple
+						 */
+						'nameFormat' => [
+							'type'        => 'String',
+							'description' => __( 'Determines the format of the name field.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO: Add placeholders.
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/NameField.php
+++ b/src/Types/Field/NameField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - NameField
+ *
+ * @see https://docs.gravityforms.com/gf_field_name/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Name field.
- *
- * @see https://docs.gravityforms.com/gf_field_name/
+ * Class - NameField
  */
 class NameField extends Field {
 	/**
@@ -20,10 +26,16 @@ class NameField extends Field {
 	 */
 	const GF_TYPE = 'name';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/NumberField.php
+++ b/src/Types/Field/NumberField.php
@@ -11,66 +11,69 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_number/
  */
 class NumberField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'NumberField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'NumberField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'number';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'number';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Number field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    /**
-                     * Possible values: decimal_dot (9,999.99), decimal_comma (9.999,99), currency.
-                     */
-                    'numberFormat' => [
-                        'type'        => 'String',
-                        'description' => __( 'Specifies the format allowed for the number field.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'rangeMin' => [
-                        'type'        => 'Float',
-                        'description' => __( 'Minimum allowed value for a number field. Values lower than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-                        'resolve' => function( GF_Field_Number $root ) {
-                            if ( '' === $root['rangeMin'] ) {
-                                return null;
-                            }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Number field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						/**
+						 * Possible values: decimal_dot (9,999.99), decimal_comma (9.999,99), currency.
+						 */
+						'numberFormat' => [
+							'type'        => 'String',
+							'description' => __( 'Specifies the format allowed for the number field.', 'wp-graphql-gravity-forms' ),
+						],
+						'rangeMin'     => [
+							'type'        => 'Float',
+							'description' => __( 'Minimum allowed value for a number field. Values lower than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
+							'resolve'     => function( GF_Field_Number $root ) {
+								if ( '' === $root['rangeMin'] ) {
+									return null;
+								}
 
-                            return (float) $root['rangeMin'];
-                        }
-                    ],
-                    'rangeMax' => [
-                        'type'        => 'Float',
-                        'description' => __( 'Maximum allowed value for a number field. Values higher than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-                        'resolve' => function( GF_Field_Number $root ) {
-                            if ( '' === $root['rangeMax'] ) {
-                                return null;
-                            }
+								return (float) $root['rangeMin'];
+							},
+						],
+						'rangeMax'     => [
+							'type'        => 'Float',
+							'description' => __( 'Maximum allowed value for a number field. Values higher than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
+							'resolve'     => function( GF_Field_Number $root ) {
+								if ( '' === $root['rangeMax'] ) {
+									return null;
+								}
 
-                            return (float) $root['rangeMax'];
-                        }
-                    ],
-                ]
-            ),
-        ] );
-    }
+								return (float) $root['rangeMax'];
+							},
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/NumberField.php
+++ b/src/Types/Field/NumberField.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - NumberField
+ *
+ * @see https://docs.gravityforms.com/gf_field_number/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
@@ -6,9 +14,7 @@ use GF_Field_Number;
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Number field.
- *
- * @see https://docs.gravityforms.com/gf_field_number/
+ * Class - NumberField
  */
 class NumberField extends Field {
 	/**
@@ -21,10 +27,16 @@ class NumberField extends Field {
 	 */
 	const GF_TYPE = 'number';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PageField.php
+++ b/src/Types/Field/PageField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PageField
+ *
+ * @see https://docs.gravityforms.com/gf_field_page/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Button\Button;
 
 /**
- * Page field.
- *
- * @see https://docs.gravityforms.com/gf_field_page/
+ * Class - PageField
  */
 class PageField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PageField extends Field {
 	 */
 	const GF_TYPE = 'page';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PageField.php
+++ b/src/Types/Field/PageField.php
@@ -10,45 +10,48 @@ use WPGraphQLGravityForms\Types\Button\Button;
  * @see https://docs.gravityforms.com/gf_field_page/
  */
 class PageField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PageField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PageField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'page';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'page';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Page field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                [
-                    'displayOnly' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Indicates the field is only displayed and its contents are not submitted with the form/saved with the entry. This is set to true.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'nextButton' => [
-                        'type'        => Button::TYPE,
-                        'description' => __('An array containing the the individual properties for the "Next" button.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'pageNumber' => [
-                        'type'        => 'Integer',
-                        'description' => __('The page number of the current page.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'previousButton' => [
-                        'type'        => Button::TYPE,
-                        'description' => __('An array containing the the individual properties for the "Previous" button.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            )
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Page field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					[
+						'displayOnly'    => [
+							'type'        => 'Boolean',
+							'description' => __( 'Indicates the field is only displayed and its contents are not submitted with the form/saved with the entry. This is set to true.', 'wp-graphql-gravity-forms' ),
+						],
+						'nextButton'     => [
+							'type'        => Button::TYPE,
+							'description' => __( 'An array containing the the individual properties for the "Next" button.', 'wp-graphql-gravity-forms' ),
+						],
+						'pageNumber'     => [
+							'type'        => 'Integer',
+							'description' => __( 'The page number of the current page.', 'wp-graphql-gravity-forms' ),
+						],
+						'previousButton' => [
+							'type'        => Button::TYPE,
+							'description' => __( 'An array containing the the individual properties for the "Previous" button.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PasswordField.php
+++ b/src/Types/Field/PasswordField.php
@@ -10,47 +10,50 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_password/
  */
 class PasswordField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PasswordField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PasswordField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'password';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'password';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Password field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionPlacementProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                [
-                    'inputs' => [
-                        'type'        => [ 'list_of' => FieldProperty\PasswordInputProperty::TYPE ],
-                        'description' => __('Individual properties for each element of the password field.', 'wp-graphql-gravity-forms'),
-                    ],
-                    // @TODO: Convert to an enum.
-                    'minPasswordStrength' => [
-                        'type'        => 'String',
-                        'description' => __('Indicates how strong the password should be. The possible values are: short, bad, good, strong.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'passwordStrengthEnabled' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Indicates whether the field displays the password strength indicator.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Password field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionPlacementProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					[
+						'inputs'                  => [
+							'type'        => [ 'list_of' => FieldProperty\PasswordInputProperty::TYPE ],
+							'description' => __( 'Individual properties for each element of the password field.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO: Convert to an enum.
+						'minPasswordStrength'     => [
+							'type'        => 'String',
+							'description' => __( 'Indicates how strong the password should be. The possible values are: short, bad, good, strong.', 'wp-graphql-gravity-forms' ),
+						],
+						'passwordStrengthEnabled' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Indicates whether the field displays the password strength indicator.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PasswordField.php
+++ b/src/Types/Field/PasswordField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PasswordField
+ *
+ * @see https://docs.gravityforms.com/gf_field_password/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Password field.
- *
- * @see https://docs.gravityforms.com/gf_field_password/
+ * Class - PasswordField
  */
 class PasswordField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PasswordField extends Field {
 	 */
 	const GF_TYPE = 'password';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PhoneField.php
+++ b/src/Types/Field/PhoneField.php
@@ -10,44 +10,47 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_phone/
  */
 class PhoneField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PhoneField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PhoneField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'phone';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'phone';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Phone field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    /**
-                     * Possible values: standard, international
-                     */
-                    'phoneFormat' => [
-                        'type'        => 'String',
-                        'description' => __('Determines the allowed format for phones. If the phone value does not conform with the specified format, the field will fail validation.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Phone field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						/**
+						 * Possible values: standard, international
+						 */
+						'phoneFormat' => [
+							'type'        => 'String',
+							'description' => __( 'Determines the allowed format for phones. If the phone value does not conform with the specified format, the field will fail validation.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PhoneField.php
+++ b/src/Types/Field/PhoneField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PhoneField
+ *
+ * @see https://docs.gravityforms.com/gf_field_phone/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Phone field.
- *
- * @see https://docs.gravityforms.com/gf_field_phone/
+ * Class - PhoneField
  */
 class PhoneField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PhoneField extends Field {
 	 */
 	const GF_TYPE = 'phone';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostCategoryField.php
+++ b/src/Types/Field/PostCategoryField.php
@@ -10,39 +10,42 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-category/
  */
 class PostCategoryField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostCategoryField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostCategoryField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_category';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_category';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Category field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\ChoicesProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'displayAllCategories' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Determines if all categories should be displayed on the Post Category drop down. 1 to display all categories, 0 otherwise. If this property is set to 1 (display all categories), the Post Category drop down will display the categories hierarchically.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Category field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\ChoicesProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'displayAllCategories' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Determines if all categories should be displayed on the Post Category drop down. 1 to display all categories, 0 otherwise. If this property is set to 1 (display all categories), the Post Category drop down will display the categories hierarchically.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostCategoryField.php
+++ b/src/Types/Field/PostCategoryField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostCategoryField
+ *
+ * @see https://docs.gravityforms.com/post-category/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Category field.
- *
- * @see https://docs.gravityforms.com/post-category/
+ * Class - PostCategoryField
  */
 class PostCategoryField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostCategoryField extends Field {
 	 */
 	const GF_TYPE = 'post_category';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostContentField.php
+++ b/src/Types/Field/PostContentField.php
@@ -10,34 +10,37 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-body/
  */
 class PostContentField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostContentField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostContentField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_content';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_content';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Content field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Content field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostContentField.php
+++ b/src/Types/Field/PostContentField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostContentField
+ *
+ * @see https://docs.gravityforms.com/post-body/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Content (Post Body) field.
- *
- * @see https://docs.gravityforms.com/post-body/
+ * Class - PostContentField
  */
 class PostContentField extends Field {
 	/**
@@ -20,10 +26,17 @@ class PostContentField extends Field {
 	 */
 	const GF_TYPE = 'post_content';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostCustomField.php
+++ b/src/Types/Field/PostCustomField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostCustomField
+ *
+ * @see https://docs.gravityforms.com/post-custom/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Custom Field.
- *
- * @see https://docs.gravityforms.com/post-custom/
+ * Class - PostCustomField
  */
 class PostCustomField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostCustomField extends Field {
 	 */
 	const GF_TYPE = 'post_custom_field';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostCustomField.php
+++ b/src/Types/Field/PostCustomField.php
@@ -10,45 +10,48 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-custom/
  */
 class PostCustomField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostCustomField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostCustomField';
 
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const GF_TYPE = 'post_custom_field';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const GF_TYPE = 'post_custom_field';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Custom Field field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'postCustomFieldName' => [
-                        'type'        => 'String',
-                        'description' => __('The name of the Post Custom Field that the submitted value should be assigned to.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'inputType' => [
-                        'type'        => 'String',
-                        'description' => __('Contains a field type and allows a field type to be displayed as another field type. A good example is the Post Custom Field, that can be displayed as various different types of fields.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Custom Field field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'postCustomFieldName' => [
+							'type'        => 'String',
+							'description' => __( 'The name of the Post Custom Field that the submitted value should be assigned to.', 'wp-graphql-gravity-forms' ),
+						],
+						'inputType'           => [
+							'type'        => 'String',
+							'description' => __( 'Contains a field type and allows a field type to be displayed as another field type. A good example is the Post Custom Field, that can be displayed as various different types of fields.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostExcerptField.php
+++ b/src/Types/Field/PostExcerptField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostExcerptField
+ *
+ * @see https://docs.gravityforms.com/post-excerpt/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Excerpt field.
- *
- * @see https://docs.gravityforms.com/post-excerpt/
+ * Class - PostExcerptField
  */
 class PostExcerptField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostExcerptField extends Field {
 	 */
 	const GF_TYPE = 'post_excerpt';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostExcerptField.php
+++ b/src/Types/Field/PostExcerptField.php
@@ -10,34 +10,37 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-excerpt/
  */
 class PostExcerptField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostExcerptField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostExcerptField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_excerpt';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_excerpt';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Excerpt field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Excerpt field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostImageField.php
+++ b/src/Types/Field/PostImageField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostImageField
+ *
+ * @see https://docs.gravityforms.com/post-image/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Image field.
- *
- * @see https://docs.gravityforms.com/post-image/
+ * Class - PostImageField
  */
 class PostImageField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostImageField extends Field {
 	 */
 	const GF_TYPE = 'post_image';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostImageField.php
+++ b/src/Types/Field/PostImageField.php
@@ -10,46 +10,49 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-image/
  */
 class PostImageField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostImageField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostImageField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_image';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_image';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Image field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'displayCaption' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Controls the visibility of the caption metadata for Post Image fields. 1 will display the caption field, 0 will hide it.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'displayDescription' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Controls the visibility of the description metadata for Post Image fields. 1 will display the description field, 0 will hide it.', 'wp-graphql-gravity-forms'),
-                    ],
-                    'displayTitle' => [
-                        'type'        => 'Boolean',
-                        'description' => __('Controls the visibility of the title metadata for Post Image fields. 1 will display the title field, 0 will hide it.', 'wp-graphql-gravity-forms'),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Image field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'displayCaption'     => [
+							'type'        => 'Boolean',
+							'description' => __( 'Controls the visibility of the caption metadata for Post Image fields. 1 will display the caption field, 0 will hide it.', 'wp-graphql-gravity-forms' ),
+						],
+						'displayDescription' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Controls the visibility of the description metadata for Post Image fields. 1 will display the description field, 0 will hide it.', 'wp-graphql-gravity-forms' ),
+						],
+						'displayTitle'       => [
+							'type'        => 'Boolean',
+							'description' => __( 'Controls the visibility of the title metadata for Post Image fields. 1 will display the title field, 0 will hide it.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostTagsField.php
+++ b/src/Types/Field/PostTagsField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostTagsField
+ *
+ * @see https://docs.gravityforms.com/post-tags/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Tags field.
- *
- * @see https://docs.gravityforms.com/post-tags/
+ * Class - PostTagsField
  */
 class PostTagsField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostTagsField extends Field {
 	 */
 	const GF_TYPE = 'post_tags';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostTagsField.php
+++ b/src/Types/Field/PostTagsField.php
@@ -10,34 +10,37 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-tags/
  */
 class PostTagsField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostTagsField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostTagsField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_tags';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_tags';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Tags field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Tags field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/PostTitleField.php
+++ b/src/Types/Field/PostTitleField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - PostTitleField
+ *
+ * @see https://docs.gravityforms.com/post-title/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Post Title field.
- *
- * @see https://docs.gravityforms.com/post-title/
+ * Class - PostTitleField
  */
 class PostTitleField extends Field {
 	/**
@@ -20,10 +26,16 @@ class PostTitleField extends Field {
 	 */
 	const GF_TYPE = 'post_title';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/PostTitleField.php
+++ b/src/Types/Field/PostTitleField.php
@@ -10,34 +10,37 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/post-title/
  */
 class PostTitleField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'PostTitleField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'PostTitleField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'post_title';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'post_title';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Post Title field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Post Title field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/RadioField.php
+++ b/src/Types/Field/RadioField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - RadioField
+ *
+ * @see https://docs.gravityforms.com/gf_field_radio/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Radio button field.
- *
- * @see https://docs.gravityforms.com/gf_field_radio/
+ * Class - RadioField
  */
 class RadioField extends Field {
 	/**
@@ -20,10 +26,17 @@ class RadioField extends Field {
 	 */
 	const GF_TYPE = 'radio';
 
+
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/RadioField.php
+++ b/src/Types/Field/RadioField.php
@@ -10,41 +10,44 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_radio/
  */
 class RadioField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'RadioField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'RadioField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'radio';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'radio';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Radio field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\ChoicesProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\EnableChoiceValueProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'enableOtherChoice' => [
-                        'type'        => 'Boolean',
-                        'description' => __( 'Indicates whether the \'Enable "other" choice\' option is checked in the editor.', 'wp-graphql-gravity-forms' ),
-                    ],
-                ],
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Radio field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\ChoicesProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\EnableChoiceValueProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'enableOtherChoice' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Indicates whether the \'Enable "other" choice\' option is checked in the editor.', 'wp-graphql-gravity-forms' ),
+						],
+					],
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/SectionField.php
+++ b/src/Types/Field/SectionField.php
@@ -1,11 +1,17 @@
 <?php
+/**
+ * GraphQL Object Type - SectionField
+ *
+ * @see https://docs.gravityforms.com/gf_field_section/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 /**
- * Section field.
- *
- * @see https://docs.gravityforms.com/gf_field_section/
+ * Class - SectionField
  */
 class SectionField extends Field {
 	/**
@@ -18,10 +24,16 @@ class SectionField extends Field {
 	 */
 	const GF_TYPE = 'section';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/SectionField.php
+++ b/src/Types/Field/SectionField.php
@@ -8,28 +8,31 @@ namespace WPGraphQLGravityForms\Types\Field;
  * @see https://docs.gravityforms.com/gf_field_section/
  */
 class SectionField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'SectionField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'SectionField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'section';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'section';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Section field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Section field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/SelectField.php
+++ b/src/Types/Field/SelectField.php
@@ -10,37 +10,40 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_select/
  */
 class SelectField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'SelectField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'SelectField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'select';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'select';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Select field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\ChoicesProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\EnableChoiceValueProperty::get(),
-                FieldProperty\EnableEnhancedUiProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Select field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\ChoicesProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\EnableChoiceValueProperty::get(),
+					FieldProperty\EnableEnhancedUiProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/SelectField.php
+++ b/src/Types/Field/SelectField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - SelectField
+ *
+ * @see https://docs.gravityforms.com/gf_field_select/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Select field.
- *
- * @see https://docs.gravityforms.com/gf_field_select/
+ * Class - SelectField
  */
 class SelectField extends Field {
 	/**
@@ -20,10 +26,16 @@ class SelectField extends Field {
 	 */
 	const GF_TYPE = 'select';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/SignatureField.php
+++ b/src/Types/Field/SignatureField.php
@@ -11,62 +11,65 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/signature-add-on/
  */
 class SignatureField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'SignatureField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'SignatureField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'signature';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'signature';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Signature field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                [
-                    'penSize' => [
-                        'type'        => 'Integer',
-                        'description' => __( 'Size of the pen cursor.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'boxWidth' => [
-                        'type'        => 'Integer',
-                        'description' => __( 'Width of the signature field in pixels.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    // @TODO: Convert to an enum.
-                    'borderWidth' => [
-                        'type'        => 'String',
-                        'description' => __( 'Width of the border around the signature area. Possible values are: 0 (none), 1 (small), 2 (medium) or 3 (large).', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'backgroundColor' => [
-                        'type'        => 'String',
-                        'description' => __( 'Color to be used for the background of the signature area. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'borderColor' => [
-                        'type'        => 'String',
-                        'description' => __( 'Color to be used for the border around the signature area. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    // @TODO: Convert to an enum.
-                    'borderStyle' => [
-                        'type'        => 'String',
-                        'description' => __( 'Border style to be used around the signature area. Possible values: dotted, dashed, groove, ridge, inset, outset, double, solid.', 'wp-graphql-gravity-forms' ),
-                    ],
-                    'penColor' => [
-                        'type'        => 'String',
-                        'description' => __( 'Color of the pen to be used for the signature. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Signature field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					[
+						'penSize'         => [
+							'type'        => 'Integer',
+							'description' => __( 'Size of the pen cursor.', 'wp-graphql-gravity-forms' ),
+						],
+						'boxWidth'        => [
+							'type'        => 'Integer',
+							'description' => __( 'Width of the signature field in pixels.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO: Convert to an enum.
+						'borderWidth'     => [
+							'type'        => 'String',
+							'description' => __( 'Width of the border around the signature area. Possible values are: 0 (none), 1 (small), 2 (medium) or 3 (large).', 'wp-graphql-gravity-forms' ),
+						],
+						'backgroundColor' => [
+							'type'        => 'String',
+							'description' => __( 'Color to be used for the background of the signature area. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
+						],
+						'borderColor'     => [
+							'type'        => 'String',
+							'description' => __( 'Color to be used for the border around the signature area. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
+						],
+						// @TODO: Convert to an enum.
+						'borderStyle'     => [
+							'type'        => 'String',
+							'description' => __( 'Border style to be used around the signature area. Possible values: dotted, dashed, groove, ridge, inset, outset, double, solid.', 'wp-graphql-gravity-forms' ),
+						],
+						'penColor'        => [
+							'type'        => 'String',
+							'description' => __( 'Color of the pen to be used for the signature. Can be any valid CSS color value.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/SignatureField.php
+++ b/src/Types/Field/SignatureField.php
@@ -1,14 +1,20 @@
 <?php
+/**
+ * GraphQL Object Type - SignatureField
+ *
+ * @see https://www.gravityforms.com/add-ons/signature/
+ * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/signature-add-on/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Signature field.
- *
- * @see https://www.gravityforms.com/add-ons/signature/
- * @see https://docs.gravityforms.com/category/add-ons-gravity-forms/signature-add-on/
+ * Class - SignatureField
  */
 class SignatureField extends Field {
 	/**
@@ -21,10 +27,17 @@ class SignatureField extends Field {
 	 */
 	const GF_TYPE = 'signature';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/TextAreaField.php
+++ b/src/Types/Field/TextAreaField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - TextAreaField
+ *
+ * @see https://docs.gravityforms.com/gf_field_textarea/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Text Area (Paragraph Text) field.
- *
- * @see https://docs.gravityforms.com/gf_field_textarea/
+ * Class - TextAreaField
  */
 class TextAreaField extends Field {
 	/**
@@ -20,10 +26,16 @@ class TextAreaField extends Field {
 	 */
 	const GF_TYPE = 'textarea';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/TextAreaField.php
+++ b/src/Types/Field/TextAreaField.php
@@ -10,36 +10,39 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_textarea/
  */
 class TextAreaField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'TextAreaField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'TextAreaField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'textarea';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'textarea';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Textarea (Paragraph Text) field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\MaxLengthProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Textarea (Paragraph Text) field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\MaxLengthProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/TextField.php
+++ b/src/Types/Field/TextField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - TextField
+ *
+ * @see https://docs.gravityforms.com/gf_field_text/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Single-line text field.
- *
- * @see https://docs.gravityforms.com/gf_field_text/
+ * Class - TextField
  */
 class TextField extends Field {
 	/**
@@ -20,10 +26,16 @@ class TextField extends Field {
 	 */
 	const GF_TYPE = 'text';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/TextField.php
+++ b/src/Types/Field/TextField.php
@@ -10,42 +10,45 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_text/
  */
 class TextField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'TextField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'TextField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'text';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'text';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Single Line Text field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\MaxLengthProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get(),
-                [
-                    'enablePasswordInput' => [
-                        'type'        => 'Boolean',
-                        'description' => __( 'Determines if a text field input tag should be created with a "password" type.', 'wp-graphql-gravity-forms' ),
-                    ],
-                ]
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Single Line Text field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\MaxLengthProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						'enablePasswordInput' => [
+							'type'        => 'Boolean',
+							'description' => __( 'Determines if a text field input tag should be created with a "password" type.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/TimeField.php
+++ b/src/Types/Field/TimeField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - TimeField
+ *
+ * @see https://docs.gravityforms.com/gf_field_time/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Time field.
- *
- * @see https://docs.gravityforms.com/gf_field_time/
+ * Class - TimeField
  */
 class TimeField extends Field {
 	/**
@@ -20,10 +26,16 @@ class TimeField extends Field {
 	 */
 	const GF_TYPE = 'time';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/TimeField.php
+++ b/src/Types/Field/TimeField.php
@@ -10,43 +10,46 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_time/
  */
 class TimeField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'TimeField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'TimeField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'time';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'time';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Time field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\SizeProperty::get(),
-								[
-									/**
-									 * Possible values: 12, 24
-									 */
-									'timeFormat' => [
-										'type'        => 'String',
-										'description' => __('Determines how the time is displayed.', 'wp-graphql-gravity-forms'),
-                    ],
-								]
-                // @TODO: Add placeholders.
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Time field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\SizeProperty::get(),
+					[
+						/**
+						 * Possible values: 12, 24
+						 */
+						'timeFormat' => [
+							'type'        => 'String',
+							'description' => __( 'Determines how the time is displayed.', 'wp-graphql-gravity-forms' ),
+						],
+					]
+					// @TODO: Add placeholders.
+				),
+			]
+		);
+	}
 }

--- a/src/Types/Field/WebsiteField.php
+++ b/src/Types/Field/WebsiteField.php
@@ -1,13 +1,19 @@
 <?php
+/**
+ * GraphQL Object Type - WebsiteField
+ *
+ * @see https://docs.gravityforms.com/gf_field_website/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
- * Website field.
- *
- * @see https://docs.gravityforms.com/gf_field_website/
+ * Class - WebsiteField
  */
 class WebsiteField extends Field {
 	/**
@@ -20,10 +26,16 @@ class WebsiteField extends Field {
 	 */
 	const GF_TYPE = 'website';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Field/WebsiteField.php
+++ b/src/Types/Field/WebsiteField.php
@@ -10,35 +10,38 @@ use WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @see https://docs.gravityforms.com/gf_field_website/
  */
 class WebsiteField extends Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'WebsiteField';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'WebsiteField';
 
-    /**
-     * Type registered in Gravity Forms.
-     */
-    const GF_TYPE = 'website';
+	/**
+	 * Type registered in Gravity Forms.
+	 */
+	const GF_TYPE = 'website';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms Website field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => array_merge(
-                $this->get_global_properties(),
-                $this->get_custom_properties(),
-                FieldProperty\DefaultValueProperty::get(),
-                FieldProperty\DescriptionProperty::get(),
-                FieldProperty\ErrorMessageProperty::get(),
-                FieldProperty\InputNameProperty::get(),
-                FieldProperty\IsRequiredProperty::get(),
-                FieldProperty\NoDuplicatesProperty::get(),
-                FieldProperty\PlaceholderProperty::get(),
-                FieldProperty\SizeProperty::get()
-            ),
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms Website field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => array_merge(
+					$this->get_global_properties(),
+					$this->get_custom_properties(),
+					FieldProperty\DefaultValueProperty::get(),
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\InputNameProperty::get(),
+					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\NoDuplicatesProperty::get(),
+					FieldProperty\PlaceholderProperty::get(),
+					FieldProperty\SizeProperty::get()
+				),
+			]
+		);
+	}
 }

--- a/src/Types/FieldError/FieldError.php
+++ b/src/Types/FieldError/FieldError.php
@@ -9,21 +9,24 @@ use WPGraphQLGravityForms\Interfaces\Type;
  *  Field error.
  */
 class FieldError implements Hookable, Type {
-    const TYPE = 'FieldError';
+	const TYPE = 'FieldError';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Field error.', 'wp-graphql-gravity-forms' ),
-            'fields' => [
-                'message' => [
-                    'type'        => 'String',
-                    'description' => __( 'Error message.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Field error.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'message' => [
+						'type'        => 'String',
+						'description' => __( 'Error message.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/FieldError/FieldError.php
+++ b/src/Types/FieldError/FieldError.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * GraphQL Object Type - Field error.
+ *
+ * @package WPGraphQLGravityForms\Types\FieldError
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\FieldError;
 
@@ -6,15 +12,21 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- *  Field error.
+ * Class - FieldError
  */
 class FieldError implements Hookable, Type {
 	const TYPE = 'FieldError';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Form/Form.php
+++ b/src/Types/Form/Form.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms Form
+ *
+ * @see https://docs.gravityforms.com/form-object/
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -13,9 +21,7 @@ use WPGraphQLGravityForms\Types\Union\ObjectFieldUnion;
 use WPGraphQLGravityForms\Types\Button\Button;
 
 /**
- * Gravity Forms form.
- *
- * @see https://docs.gravityforms.com/form-object/
+ * Class - Form
  */
 class Form implements Hookable, Type, Field {
 	/**
@@ -30,18 +36,31 @@ class Form implements Hookable, Type, Field {
 
 	/**
 	 * FormDataManipulator instance.
+	 *
+	 * @var FormDataManipulator
 	 */
 	private $form_data_manipulator;
 
+	/**
+	 * Constructor
+	 *
+	 * @param FormDataManipulator $form_data_manipulator .
+	 */
 	public function __construct( FormDataManipulator $form_data_manipulator ) {
 		$this->form_data_manipulator = $form_data_manipulator;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,
@@ -249,6 +268,9 @@ class Form implements Hookable, Type, Field {
 		);
 	}
 
+	/**
+	 * Register form query.
+	 */
 	public function register_field() {
 		register_graphql_field(
 			'RootQuery',

--- a/src/Types/Form/Form.php
+++ b/src/Types/Form/Form.php
@@ -18,270 +18,277 @@ use WPGraphQLGravityForms\Types\Button\Button;
  * @see https://docs.gravityforms.com/form-object/
  */
 class Form implements Hookable, Type, Field {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'GravityFormsForm';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'GravityFormsForm';
 
-    /**
-     * Field registered in WPGraphQL.
-     */
-    const FIELD = 'gravityFormsForm';
+	/**
+	 * Field registered in WPGraphQL.
+	 */
+	const FIELD = 'gravityFormsForm';
 
-    /**
-     * FormDataManipulator instance.
-     */
-    private $form_data_manipulator;
+	/**
+	 * FormDataManipulator instance.
+	 */
+	private $form_data_manipulator;
 
-    public function __construct( FormDataManipulator $form_data_manipulator ) {
-        $this->form_data_manipulator = $form_data_manipulator;
-    }
+	public function __construct( FormDataManipulator $form_data_manipulator ) {
+		$this->form_data_manipulator = $form_data_manipulator;
+	}
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-        add_action( 'graphql_register_types', [ $this, 'register_field' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms form.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'id' => [
-                    'type'        => [ 'non_null' => 'ID' ],
-                    'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),
-                ],
-                'formId' => [
-                    'type'        => 'Int',
-                    'description' => __( 'Form ID.', 'wp-graphql-gravity-forms' ),
-                ],
-                'title' => [
-                    'type'        => 'String',
-                    'description' => __( 'Form title.', 'wp-graphql-gravity-forms' ),
-                ],
-                'description' => [
-                    'type'        => 'String',
-                    'description' => __( 'Form description.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO - Convert to enum. Possible values: top_label, left_label, right_label
-                'labelPlacement' => [
-                    'type'        => 'String',
-                    'description' => __( 'Determines if the field labels are displayed on top of the fields (top_label), beside the fields and aligned to the left (left_label) or beside the fields and aligned to the right (right_label).', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO - Convert to enum. Possible values: above, below
-                'descriptionPlacement' => [
-                    'type'        => 'String',
-                    'description' => __( 'Determines if the field description is displayed above the field input (i.e. immediately after the field label) or below the field input.', 'wp-graphql-gravity-forms' ),
-                ],
-                'button' => [
-                    'type'        => Button::TYPE,
-                    'description' => __( 'Contains the form button settings such as the button text or image button source.', 'wp-graphql-gravity-forms' ),
-                ],
-                'useCurrentUserAsAuthor'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'For forms with Post fields, this determines if the post should be created using the current logged in user as the author. 1 to use the current user, 0 otherwise.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postContentTemplateEnabled'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines if the post template functionality is enabled. When enabled, the post content will be created based on the template specified by postContentTemplate.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postTitleTemplateEnabled'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines if the post title template functionality is enabled. When enabled, the post title will be created based on the template specified by postTitleTemplate.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postTitleTemplate'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Template to be used when creating the post title. Field variables (i.e. {Name:3} ) can be added to the template to insert user submitted values into the post title. Only applicable when postTitleTemplateEnabled is true', 'wp-graphql-gravity-forms' ),
-                ],
-                'postContentTemplate'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Template to be used when creating the post content. Field variables (i.e. {Name:3} ) can be added to the template to insert user submitted values into the post content. Only applicable when postContentTemplateEnabled is true.', 'wp-graphql-gravity-forms' ),
-                ],
-                'lastPageButton'   => [
-                    'type'        => Button::TYPE,
-                    'description' => __( 'Last page button data.', 'wp-graphql-gravity-forms' ),
-                ],
-                'pagination'   => [
-                    'type'        => FormPagination::TYPE,
-                    'description' => __( 'Pagination data.', 'wp-graphql-gravity-forms' ),
-                ],
-                'firstPageCssClass'   => [
-                    'type'        => 'String',
-                    'description' => __( 'CSS class for the first page.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postAuthor'   => [
-                    'type'        => 'Int',
-                    'description' => __( 'When useCurrentUserAsAuthor is set to 0, this property contains the user Id that will be used as the Post author.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postCategory'   => [
-                    'type'        => 'Int',
-                    'description' => __( 'Form forms with Post fields, but without a Post Category field, this property determines the default category that the post will be associated with when created.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postFormat'   => [
-                    'type'        => 'String',
-                    'description' => __( 'For forms with Post fields, determines the format that the Post should be created with.', 'wp-graphql-gravity-forms' ),
-                ],
-                'postStatus'   => [
-                    'type'        => 'String',
-                    'description' => __( 'For forms with Post fields, determines the status that the Post should be created with.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to an enum. https://docs.gravityforms.com/gf_field_name/
-                'subLabelPlacement'   => [
-                    'type'        => 'String',
-                    'description' => __( 'How sub-labels are aligned.', 'wp-graphql-gravity-forms' ),
-                ],
-                'cssClass'   => [
-                    'type'        => 'String',
-                    'description' => __( 'String containing the custom CSS classes to be added to the <form> tag.', 'wp-graphql-gravity-forms' ),
-                ],
-                'cssClassList'   => [
-                    'type'        => [ 'list_of' => 'String' ],
-                    'description' => __( 'Array of the custom CSS classes to be added to the <form> tag.', 'wp-graphql-gravity-forms' ),
-                ],
-                'enableHoneypot'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Specifies if the form has the Honeypot spam-protection feature.', 'wp-graphql-gravity-forms' ),
-                ],
-                'enableAnimation'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'When enabled, conditional logic hide/show operation will be performed with a jQuery slide animation. Only applicable to forms with conditional logic.', 'wp-graphql-gravity-forms' ),
-                ],
-                'save'   => [
-                    'type'        => SaveAndContinue::TYPE,
-                    'description' => __( '"Save and Continue" data.', 'wp-graphql-gravity-forms' ),
-                ],
-                'limitEntries'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Specifies if this form has a limit on the number of submissions. 1 if the form limits submissions, 0 otherwise.', 'wp-graphql-gravity-forms' ),
-                ],
-                'limitEntriesCount'   => [
-                    'type'        => 'Int',
-                    'description' => __( 'When limitEntries is set to 1, this property specifies the number of submissions allowed.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to an enum.
-                'limitEntriesPeriod' => [
-                    'type'        => 'String',
-                    'description' => __( 'When limitEntries is set to 1, this property specifies the time period during which submissions are allowed. Options are "day", "week", "month" and "year".', 'wp-graphql-gravity-forms' ),
-                ],
-                'limitEntriesMessage' => [
-                    'type'        => 'String',
-                    'description' => __( 'Message that will be displayed when the maximum number of submissions have been reached.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleForm' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Specifies if this form is scheduled to be displayed only during a certain configured date/time.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleStart' => [
-                    'type'        => 'String',
-                    'description' => __( 'Date in the format (mm/dd/yyyy) that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleStartHour' => [
-                    'type'        => 'Int',
-                    'description' => __( 'Hour (1 to 12) that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleStartMinute' => [
-                    'type'        => 'Int',
-                    'description' => __( 'Minute that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleStartAmpm' => [
-                    'type'        => 'String',
-                    'description' => __( '"am" or "pm". Applies to scheduleStartHour', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleEnd' => [
-                    'type'        => 'String',
-                    'description' => __( 'Date in the format (mm/dd/yyyy) that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleEndHour' => [
-                    'type'        => 'Int',
-                    'description' => __( 'Hour (1 to 12) that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleEndMinute' => [
-                    'type'        => 'Int',
-                    'description' => __( 'Minute that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleEndAmpm' => [
-                    'type'        => 'String',
-                    'description' => __( '"am? or "pm?. Applies to scheduleEndHour', 'wp-graphql-gravity-forms' ),
-                ],
-                'schedulePendingMessage' => [
-                    'type'        => 'String',
-                    'description' => __( 'Message to be displayed when form is not yet available.', 'wp-graphql-gravity-forms' ),
-                ],
-                'scheduleMessage' => [
-                    'type'        => 'String',
-                    'description' => __( 'Message to be displayed when form is no longer available', 'wp-graphql-gravity-forms' ),
-                ],
-                'requireLogin' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether the form is configured to be displayed only to logged in users.', 'wp-graphql-gravity-forms' ),
-                ],
-                'requireLoginMessage' => [
-                    'type'        => 'String',
-                    'description' => __( 'When requireLogin is set to true, this controls the message displayed when non-logged in user tries to access the form.', 'wp-graphql-gravity-forms' ),
-                ],
-                'notifications' => [
-                    'type'        => [ 'list_of' => FormNotification::TYPE ],
-                    'description' => __( 'The properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
-                ],
-                'confirmations' => [
-                    'type'        => [ 'list_of' => FormConfirmation::TYPE ],
-                    'description' => __( 'Contains the form confirmation settings such as confirmation text or redirect URL', 'wp-graphql-gravity-forms' ),
-                ],
-                'nextFieldId' => [
-                    'type'        => 'Int',
-                    'description' => __( 'The ID to assign to the next field that is added to the form.', 'wp-graphql-gravity-forms' ),
-                ],
-                'isActive' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines whether the form is active.', 'wp-graphql-gravity-forms' ),
-                ],
-                'dateCreated' => [
-                    'type'        => 'String',
-                    'description' => __( 'The date the form was created in this format: YYYY-MM-DD HH:mm:ss.', 'wp-graphql-gravity-forms' ),
-                ],
-                'isTrash' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines whether the form is in the trash.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms form.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'                         => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),
+					],
+					'formId'                     => [
+						'type'        => 'Int',
+						'description' => __( 'Form ID.', 'wp-graphql-gravity-forms' ),
+					],
+					'title'                      => [
+						'type'        => 'String',
+						'description' => __( 'Form title.', 'wp-graphql-gravity-forms' ),
+					],
+					'description'                => [
+						'type'        => 'String',
+						'description' => __( 'Form description.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO - Convert to enum. Possible values: top_label, left_label, right_label
+					'labelPlacement'             => [
+						'type'        => 'String',
+						'description' => __( 'Determines if the field labels are displayed on top of the fields (top_label), beside the fields and aligned to the left (left_label) or beside the fields and aligned to the right (right_label).', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO - Convert to enum. Possible values: above, below
+					'descriptionPlacement'       => [
+						'type'        => 'String',
+						'description' => __( 'Determines if the field description is displayed above the field input (i.e. immediately after the field label) or below the field input.', 'wp-graphql-gravity-forms' ),
+					],
+					'button'                     => [
+						'type'        => Button::TYPE,
+						'description' => __( 'Contains the form button settings such as the button text or image button source.', 'wp-graphql-gravity-forms' ),
+					],
+					'useCurrentUserAsAuthor'     => [
+						'type'        => 'Boolean',
+						'description' => __( 'For forms with Post fields, this determines if the post should be created using the current logged in user as the author. 1 to use the current user, 0 otherwise.', 'wp-graphql-gravity-forms' ),
+					],
+					'postContentTemplateEnabled' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if the post template functionality is enabled. When enabled, the post content will be created based on the template specified by postContentTemplate.', 'wp-graphql-gravity-forms' ),
+					],
+					'postTitleTemplateEnabled'   => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if the post title template functionality is enabled. When enabled, the post title will be created based on the template specified by postTitleTemplate.', 'wp-graphql-gravity-forms' ),
+					],
+					'postTitleTemplate'          => [
+						'type'        => 'String',
+						'description' => __( 'Template to be used when creating the post title. Field variables (i.e. {Name:3} ) can be added to the template to insert user submitted values into the post title. Only applicable when postTitleTemplateEnabled is true', 'wp-graphql-gravity-forms' ),
+					],
+					'postContentTemplate'        => [
+						'type'        => 'String',
+						'description' => __( 'Template to be used when creating the post content. Field variables (i.e. {Name:3} ) can be added to the template to insert user submitted values into the post content. Only applicable when postContentTemplateEnabled is true.', 'wp-graphql-gravity-forms' ),
+					],
+					'lastPageButton'             => [
+						'type'        => Button::TYPE,
+						'description' => __( 'Last page button data.', 'wp-graphql-gravity-forms' ),
+					],
+					'pagination'                 => [
+						'type'        => FormPagination::TYPE,
+						'description' => __( 'Pagination data.', 'wp-graphql-gravity-forms' ),
+					],
+					'firstPageCssClass'          => [
+						'type'        => 'String',
+						'description' => __( 'CSS class for the first page.', 'wp-graphql-gravity-forms' ),
+					],
+					'postAuthor'                 => [
+						'type'        => 'Int',
+						'description' => __( 'When useCurrentUserAsAuthor is set to 0, this property contains the user Id that will be used as the Post author.', 'wp-graphql-gravity-forms' ),
+					],
+					'postCategory'               => [
+						'type'        => 'Int',
+						'description' => __( 'Form forms with Post fields, but without a Post Category field, this property determines the default category that the post will be associated with when created.', 'wp-graphql-gravity-forms' ),
+					],
+					'postFormat'                 => [
+						'type'        => 'String',
+						'description' => __( 'For forms with Post fields, determines the format that the Post should be created with.', 'wp-graphql-gravity-forms' ),
+					],
+					'postStatus'                 => [
+						'type'        => 'String',
+						'description' => __( 'For forms with Post fields, determines the status that the Post should be created with.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to an enum. https://docs.gravityforms.com/gf_field_name/
+					'subLabelPlacement'          => [
+						'type'        => 'String',
+						'description' => __( 'How sub-labels are aligned.', 'wp-graphql-gravity-forms' ),
+					],
+					'cssClass'                   => [
+						'type'        => 'String',
+						'description' => __( 'String containing the custom CSS classes to be added to the <form> tag.', 'wp-graphql-gravity-forms' ),
+					],
+					'cssClassList'               => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Array of the custom CSS classes to be added to the <form> tag.', 'wp-graphql-gravity-forms' ),
+					],
+					'enableHoneypot'             => [
+						'type'        => 'Boolean',
+						'description' => __( 'Specifies if the form has the Honeypot spam-protection feature.', 'wp-graphql-gravity-forms' ),
+					],
+					'enableAnimation'            => [
+						'type'        => 'Boolean',
+						'description' => __( 'When enabled, conditional logic hide/show operation will be performed with a jQuery slide animation. Only applicable to forms with conditional logic.', 'wp-graphql-gravity-forms' ),
+					],
+					'save'                       => [
+						'type'        => SaveAndContinue::TYPE,
+						'description' => __( '"Save and Continue" data.', 'wp-graphql-gravity-forms' ),
+					],
+					'limitEntries'               => [
+						'type'        => 'Boolean',
+						'description' => __( 'Specifies if this form has a limit on the number of submissions. 1 if the form limits submissions, 0 otherwise.', 'wp-graphql-gravity-forms' ),
+					],
+					'limitEntriesCount'          => [
+						'type'        => 'Int',
+						'description' => __( 'When limitEntries is set to 1, this property specifies the number of submissions allowed.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to an enum.
+					'limitEntriesPeriod'         => [
+						'type'        => 'String',
+						'description' => __( 'When limitEntries is set to 1, this property specifies the time period during which submissions are allowed. Options are "day", "week", "month" and "year".', 'wp-graphql-gravity-forms' ),
+					],
+					'limitEntriesMessage'        => [
+						'type'        => 'String',
+						'description' => __( 'Message that will be displayed when the maximum number of submissions have been reached.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleForm'               => [
+						'type'        => 'Boolean',
+						'description' => __( 'Specifies if this form is scheduled to be displayed only during a certain configured date/time.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleStart'              => [
+						'type'        => 'String',
+						'description' => __( 'Date in the format (mm/dd/yyyy) that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleStartHour'          => [
+						'type'        => 'Int',
+						'description' => __( 'Hour (1 to 12) that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleStartMinute'        => [
+						'type'        => 'Int',
+						'description' => __( 'Minute that the form will become active/visible.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleStartAmpm'          => [
+						'type'        => 'String',
+						'description' => __( '"am" or "pm". Applies to scheduleStartHour', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleEnd'                => [
+						'type'        => 'String',
+						'description' => __( 'Date in the format (mm/dd/yyyy) that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleEndHour'            => [
+						'type'        => 'Int',
+						'description' => __( 'Hour (1 to 12) that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleEndMinute'          => [
+						'type'        => 'Int',
+						'description' => __( 'Minute that the form will become inactive/hidden.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleEndAmpm'            => [
+						'type'        => 'String',
+						'description' => __( '"am? or "pm?. Applies to scheduleEndHour', 'wp-graphql-gravity-forms' ),
+					],
+					'schedulePendingMessage'     => [
+						'type'        => 'String',
+						'description' => __( 'Message to be displayed when form is not yet available.', 'wp-graphql-gravity-forms' ),
+					],
+					'scheduleMessage'            => [
+						'type'        => 'String',
+						'description' => __( 'Message to be displayed when form is no longer available', 'wp-graphql-gravity-forms' ),
+					],
+					'requireLogin'               => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the form is configured to be displayed only to logged in users.', 'wp-graphql-gravity-forms' ),
+					],
+					'requireLoginMessage'        => [
+						'type'        => 'String',
+						'description' => __( 'When requireLogin is set to true, this controls the message displayed when non-logged in user tries to access the form.', 'wp-graphql-gravity-forms' ),
+					],
+					'notifications'              => [
+						'type'        => [ 'list_of' => FormNotification::TYPE ],
+						'description' => __( 'The properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
+					],
+					'confirmations'              => [
+						'type'        => [ 'list_of' => FormConfirmation::TYPE ],
+						'description' => __( 'Contains the form confirmation settings such as confirmation text or redirect URL', 'wp-graphql-gravity-forms' ),
+					],
+					'nextFieldId'                => [
+						'type'        => 'Int',
+						'description' => __( 'The ID to assign to the next field that is added to the form.', 'wp-graphql-gravity-forms' ),
+					],
+					'isActive'                   => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines whether the form is active.', 'wp-graphql-gravity-forms' ),
+					],
+					'dateCreated'                => [
+						'type'        => 'String',
+						'description' => __( 'The date the form was created in this format: YYYY-MM-DD HH:mm:ss.', 'wp-graphql-gravity-forms' ),
+					],
+					'isTrash'                    => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines whether the form is in the trash.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 
-    public function register_field() {
-        register_graphql_field( 'RootQuery', self::FIELD, [
-            'description' => __( 'Get a Gravity Forms form.', 'wp-graphql-gravity-forms' ),
-            'type' => self::TYPE,
-            'args' => [
-                'id' => [
-                    'type'        => [ 'non_null' => 'ID' ],
-                    'description' => __( "Unique global ID for the object. Base-64 encode a string like this, where '123' is the form ID: '{self::TYPE}:123'.", 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-            'resolve' => function( $root, array $args ) : array {
-                $id_parts = Relay::fromGlobalId( $args['id'] );
+	public function register_field() {
+		register_graphql_field(
+			'RootQuery',
+			self::FIELD,
+			[
+				'description' => __( 'Get a Gravity Forms form.', 'wp-graphql-gravity-forms' ),
+				'type'        => self::TYPE,
+				'args'        => [
+					'id' => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => __( "Unique global ID for the object. Base-64 encode a string like this, where '123' is the form ID: '{self::TYPE}:123'.", 'wp-graphql-gravity-forms' ),
+					],
+				],
+				'resolve'     => function( $root, array $args ) : array {
+					$id_parts = Relay::fromGlobalId( $args['id'] );
 
-                if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
-                    throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
+						throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $form_raw = GFAPI::get_form( $id_parts['id'] );
+					$form_raw = GFAPI::get_form( $id_parts['id'] );
 
-                if ( ! $form_raw ) {
-                    throw new UserError( __( 'A valid form ID must be provided.', 'wp-graphql-gravity-forms' ) );
-                }
+					if ( ! $form_raw ) {
+						throw new UserError( __( 'A valid form ID must be provided.', 'wp-graphql-gravity-forms' ) );
+					}
 
-                $form = $this->form_data_manipulator->manipulate( $form_raw, $args );
+					$form = $this->form_data_manipulator->manipulate( $form_raw, $args );
 
-                /**
-                 * "wp_graphql_gf_form_object" filter
-                 *
-                 * Provides the ability to manipulate the form data before it is sent to the
-                 * client. This hook is somewhat similar to Gravity Forms' gform_pre_render hook
-                 * and can be used for dynamic field input population, among other things.
-                 *
-                 * @param array $form Form meta array.
-                 */
-                return apply_filters( 'wp_graphql_gf_form_object', $form );
-            }
-        ] );
-    }
+					/**
+					 * "wp_graphql_gf_form_object" filter
+					 *
+					 * Provides the ability to manipulate the form data before it is sent to the
+					 * client. This hook is somewhat similar to Gravity Forms' gform_pre_render hook
+					 * and can be used for dynamic field input population, among other things.
+					 *
+					 * @param array $form Form meta array.
+					 */
+					return apply_filters( 'wp_graphql_gf_form_object', $form );
+				},
+			]
+		);
+	}
 }

--- a/src/Types/Form/FormConfirmation.php
+++ b/src/Types/Form/FormConfirmation.php
@@ -11,49 +11,52 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/confirmation/
  */
 class FormConfirmation implements Hookable, Type {
-    const TYPE = 'FormConfirmation';
+	const TYPE = 'FormConfirmation';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'id' => [
-                    'type'        => 'String',
-                    'description' => __( 'ID.', 'wp-graphql-gravity-forms' ),
-                ],
-                'name' => [
-                    'type'        => 'String',
-                    'description' => __( 'Name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'isDefault' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether this is the default confirmation.', 'wp-graphql-gravity-forms' ),
-                ],
-                'type' => [
-                    'type'        => 'String',
-                    'description' => __( 'Determines the type of confirmation to be used. Possible values: message, page, redirect.', 'wp-graphql-gravity-forms' ),
-                ],
-                'message' => [
-                    'type'        => 'String',
-                    'description' => __( 'Contains the confirmation message that will be displayed. Only applicable when type is set to message.', 'wp-graphql-gravity-forms' ),
-                ],
-                'url' => [
-                    'type'        => 'String',
-                    'description' => __( 'Contains the URL that the browser will be redirected to. Only applicable when type is set to redirect.', 'wp-graphql-gravity-forms' ),
-                ],
-                'pageId' => [
-                    'type'        => 'Integer',
-                    'description' => __( 'Contains the Id of the WordPress page that the browser will be redirected to. Only applicable when type is set to page.', 'wp-graphql-gravity-forms' ),
-                ],
-                'queryString' => [
-                    'type'        => 'String',
-                    'description' => __( 'Contains the query string to be appended to the redirection url. Only applicable when type is set to redirect.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'id'          => [
+						'type'        => 'String',
+						'description' => __( 'ID.', 'wp-graphql-gravity-forms' ),
+					],
+					'name'        => [
+						'type'        => 'String',
+						'description' => __( 'Name.', 'wp-graphql-gravity-forms' ),
+					],
+					'isDefault'   => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether this is the default confirmation.', 'wp-graphql-gravity-forms' ),
+					],
+					'type'        => [
+						'type'        => 'String',
+						'description' => __( 'Determines the type of confirmation to be used. Possible values: message, page, redirect.', 'wp-graphql-gravity-forms' ),
+					],
+					'message'     => [
+						'type'        => 'String',
+						'description' => __( 'Contains the confirmation message that will be displayed. Only applicable when type is set to message.', 'wp-graphql-gravity-forms' ),
+					],
+					'url'         => [
+						'type'        => 'String',
+						'description' => __( 'Contains the URL that the browser will be redirected to. Only applicable when type is set to redirect.', 'wp-graphql-gravity-forms' ),
+					],
+					'pageId'      => [
+						'type'        => 'Integer',
+						'description' => __( 'Contains the Id of the WordPress page that the browser will be redirected to. Only applicable when type is set to page.', 'wp-graphql-gravity-forms' ),
+					],
+					'queryString' => [
+						'type'        => 'String',
+						'description' => __( 'Contains the query string to be appended to the redirection url. Only applicable when type is set to redirect.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Form/FormConfirmation.php
+++ b/src/Types/Form/FormConfirmation.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms Form confirmation
+ *
+ * @see https://docs.gravityforms.com/confirmation/
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -6,17 +14,21 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * Form confirmation.
- *
- * @see https://docs.gravityforms.com/confirmation/
+ * Class - FormConfirmation
  */
 class FormConfirmation implements Hookable, Type {
 	const TYPE = 'FormConfirmation';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Form/FormNotification.php
+++ b/src/Types/Form/FormNotification.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms form notification
+ *
+ * @see https://docs.gravityforms.com/notifications-object/
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -7,17 +15,21 @@ use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
 
 /**
- * Form notification.
- *
- * @see https://docs.gravityforms.com/notifications-object/
+ * Class - FormNotification
  */
 class FormNotification implements Hookable, Type {
 	const TYPE = 'FormNotification';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Form/FormNotification.php
+++ b/src/Types/Form/FormNotification.php
@@ -12,85 +12,88 @@ use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
  * @see https://docs.gravityforms.com/notifications-object/
  */
 class FormNotification implements Hookable, Type {
-    const TYPE = 'FormNotification';
+	const TYPE = 'FormNotification';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'isActive'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Is the notification active or inactive. The default is true (active).', 'wp-graphql-gravity-forms' ),
-                ],
-                'id'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The notification ID. A 13 character unique ID.', 'wp-graphql-gravity-forms' ),
-                ],
-                'name'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The notification name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'service'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The name of the service to be used when sending this notification. Default is wordpress.', 'wp-graphql-gravity-forms' ),
-                ],
-                'event'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The notification event. Default is form_submission.', 'wp-graphql-gravity-forms' ),
-                ],
-                'to'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The ID of an email field, an email address or merge tag to be used as the email to address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'toType'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Identifies what to use for the notification to. Possible values: email, field, routing or hidden.', 'wp-graphql-gravity-forms' ),
-                ],
-                'bcc'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email or merge tags to be used as the email bcc address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'subject'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email subject line. Merge tags supported.', 'wp-graphql-gravity-forms' ),
-                ],
-                'message'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email body/content. Merge tags supported.', 'wp-graphql-gravity-forms' ),
-                ],
-                'from'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email or merge tag to be used as the email from address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'fromName'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The text or merge tag to be used as the email from name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'replyTo'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email or merge tags to be used as the email reply to address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'routing'   => [
-                    'type'        => [ 'list_of' => FormNotificationRouting::TYPE ],
-                    'description' => __( 'Routing rules.', 'wp-graphql-gravity-forms' ),
-                ],
-                'conditionalLogic'   => [
-                    'type'        => ConditionalLogic::TYPE,
-                    'description' => __( 'An associative array containing the conditional logic rules. See the Conditional Logic Object for more details.', 'wp-graphql-gravity-forms' ),
-                ],
-                'disableAutoformat'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines if the email message should be formatted so that paragraphs are automatically added for new lines. Default is false (auto-formatting enabled).', 'wp-graphql-gravity-forms' ),
-                ],
-                'enableAttachments'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Determines if files uploaded on the form should be included when the notification is sent.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'isActive'          => [
+						'type'        => 'Boolean',
+						'description' => __( 'Is the notification active or inactive. The default is true (active).', 'wp-graphql-gravity-forms' ),
+					],
+					'id'                => [
+						'type'        => 'String',
+						'description' => __( 'The notification ID. A 13 character unique ID.', 'wp-graphql-gravity-forms' ),
+					],
+					'name'              => [
+						'type'        => 'String',
+						'description' => __( 'The notification name.', 'wp-graphql-gravity-forms' ),
+					],
+					'service'           => [
+						'type'        => 'String',
+						'description' => __( 'The name of the service to be used when sending this notification. Default is wordpress.', 'wp-graphql-gravity-forms' ),
+					],
+					'event'             => [
+						'type'        => 'String',
+						'description' => __( 'The notification event. Default is form_submission.', 'wp-graphql-gravity-forms' ),
+					],
+					'to'                => [
+						'type'        => 'String',
+						'description' => __( 'The ID of an email field, an email address or merge tag to be used as the email to address.', 'wp-graphql-gravity-forms' ),
+					],
+					'toType'            => [
+						'type'        => 'String',
+						'description' => __( 'Identifies what to use for the notification to. Possible values: email, field, routing or hidden.', 'wp-graphql-gravity-forms' ),
+					],
+					'bcc'               => [
+						'type'        => 'String',
+						'description' => __( 'The email or merge tags to be used as the email bcc address.', 'wp-graphql-gravity-forms' ),
+					],
+					'subject'           => [
+						'type'        => 'String',
+						'description' => __( 'The email subject line. Merge tags supported.', 'wp-graphql-gravity-forms' ),
+					],
+					'message'           => [
+						'type'        => 'String',
+						'description' => __( 'The email body/content. Merge tags supported.', 'wp-graphql-gravity-forms' ),
+					],
+					'from'              => [
+						'type'        => 'String',
+						'description' => __( 'The email or merge tag to be used as the email from address.', 'wp-graphql-gravity-forms' ),
+					],
+					'fromName'          => [
+						'type'        => 'String',
+						'description' => __( 'The text or merge tag to be used as the email from name.', 'wp-graphql-gravity-forms' ),
+					],
+					'replyTo'           => [
+						'type'        => 'String',
+						'description' => __( 'The email or merge tags to be used as the email reply to address.', 'wp-graphql-gravity-forms' ),
+					],
+					'routing'           => [
+						'type'        => [ 'list_of' => FormNotificationRouting::TYPE ],
+						'description' => __( 'Routing rules.', 'wp-graphql-gravity-forms' ),
+					],
+					'conditionalLogic'  => [
+						'type'        => ConditionalLogic::TYPE,
+						'description' => __( 'An associative array containing the conditional logic rules. See the Conditional Logic Object for more details.', 'wp-graphql-gravity-forms' ),
+					],
+					'disableAutoformat' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if the email message should be formatted so that paragraphs are automatically added for new lines. Default is false (auto-formatting enabled).', 'wp-graphql-gravity-forms' ),
+					],
+					'enableAttachments' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Determines if files uploaded on the form should be included when the notification is sent.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Form/FormNotificationRouting.php
+++ b/src/Types/Form/FormNotificationRouting.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms form notification routing
+ *
+ * @see https://docs.gravityforms.com/notifications-object/#routing-rule-properties
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -6,17 +14,21 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * Form notification routing.
- *
- * @see https://docs.gravityforms.com/notifications-object/#routing-rule-properties
+ * Class - FormNotificationRouting
  */
 class FormNotificationRouting implements Hookable, Type {
 	const TYPE = 'FormNotificationRouting';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Form/FormNotificationRouting.php
+++ b/src/Types/Form/FormNotificationRouting.php
@@ -11,34 +11,37 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/notifications-object/#routing-rule-properties
  */
 class FormNotificationRouting implements Hookable, Type {
-    const TYPE = 'FormNotificationRouting';
+	const TYPE = 'FormNotificationRouting';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'fieldId'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Target field ID. The field that will have it’s value compared with the value property to determine if this rule is a match.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: convert to an enum.
-                'operator'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Operator to be used when evaluating this rule. Possible values: is, isnot, >, <, contains, starts_with, or ends_with.', 'wp-graphql-gravity-forms' ),
-                ],
-                'value'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The value to compare with the field specified by fieldId.', 'wp-graphql-gravity-forms' ),
-                ],
-                'email'   => [
-                    'type'        => 'String',
-                    'description' => __( 'The email or merge tag to be used as the email To address if this rule is a match.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'fieldId'  => [
+						'type'        => 'String',
+						'description' => __( 'Target field ID. The field that will have it’s value compared with the value property to determine if this rule is a match.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: convert to an enum.
+					'operator' => [
+						'type'        => 'String',
+						'description' => __( 'Operator to be used when evaluating this rule. Possible values: is, isnot, >, <, contains, starts_with, or ends_with.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'    => [
+						'type'        => 'String',
+						'description' => __( 'The value to compare with the field specified by fieldId.', 'wp-graphql-gravity-forms' ),
+					],
+					'email'    => [
+						'type'        => 'String',
+						'description' => __( 'The email or merge tag to be used as the email To address if this rule is a match.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Form/FormPagination.php
+++ b/src/Types/Form/FormPagination.php
@@ -11,47 +11,50 @@ use WPGraphQLGravityForms\Interfaces\Type;
  * @see https://docs.gravityforms.com/page-break/
  */
 class FormPagination implements Hookable, Type {
-    const TYPE = 'FormPagination';
+	const TYPE = 'FormPagination';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms form pagination data.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                // @TODO - convert to enum
-                'type'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Type of progress indicator. Possible values are: percentage, steps or none.', 'wp-graphql-gravity-forms' ),
-                ],
-                'pages'   => [
-                    'type'        => [ 'list_of' => 'String' ],
-                    'description' => __( 'Names of the form\'s pages.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO - convert to enum
-                'style'   => [
-                    'type'        => 'String',
-                    'description' => __( 'Style of progress bar. Possible values are: blue, gray, green, orange, red or custom.', 'wp-graphql-gravity-forms' ),
-                ],
-                'backgroundColor' => [
-                    'type'        => 'String',
-                    'description' => __( 'Progress bar background color. Can be any CSS color value. Only applies when "style" is set to "custom".', 'wp-graphql-gravity-forms' ),
-                ],
-                'color' => [
-                    'type'        => 'String',
-                    'description' => __( 'Progress bar text color. Can be any CSS color value. Only applies when "style" is set to "custom".', 'wp-graphql-gravity-forms' ),
-                ],
-                'displayProgressbarOnConfirmation' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether the confirmation bar should be displayed with the confirmation text.', 'wp-graphql-gravity-forms' ),
-                ],
-                'progressbarCompletionText' => [
-                    'type'        => 'String',
-                    'description' => __( 'The confirmation text to display once the end of the progress bar has been reached. Only applies when displayProgressbarOnConfirmation is set to true.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms form pagination data.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					// @TODO - convert to enum
+					'type'                             => [
+						'type'        => 'String',
+						'description' => __( 'Type of progress indicator. Possible values are: percentage, steps or none.', 'wp-graphql-gravity-forms' ),
+					],
+					'pages'                            => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Names of the form\'s pages.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO - convert to enum
+					'style'                            => [
+						'type'        => 'String',
+						'description' => __( 'Style of progress bar. Possible values are: blue, gray, green, orange, red or custom.', 'wp-graphql-gravity-forms' ),
+					],
+					'backgroundColor'                  => [
+						'type'        => 'String',
+						'description' => __( 'Progress bar background color. Can be any CSS color value. Only applies when "style" is set to "custom".', 'wp-graphql-gravity-forms' ),
+					],
+					'color'                            => [
+						'type'        => 'String',
+						'description' => __( 'Progress bar text color. Can be any CSS color value. Only applies when "style" is set to "custom".', 'wp-graphql-gravity-forms' ),
+					],
+					'displayProgressbarOnConfirmation' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the confirmation bar should be displayed with the confirmation text.', 'wp-graphql-gravity-forms' ),
+					],
+					'progressbarCompletionText'        => [
+						'type'        => 'String',
+						'description' => __( 'The confirmation text to display once the end of the progress bar has been reached. Only applies when displayProgressbarOnConfirmation is set to true.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Form/FormPagination.php
+++ b/src/Types/Form/FormPagination.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms form pagination
+ *
+ * @see https://docs.gravityforms.com/page-break/
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -6,17 +14,21 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 
 /**
- * Form pagination.
- *
- * @see https://docs.gravityforms.com/page-break/
+ * Class - FormPagination
  */
 class FormPagination implements Hookable, Type {
 	const TYPE = 'FormPagination';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Form/SaveAndContinue.php
+++ b/src/Types/Form/SaveAndContinue.php
@@ -10,25 +10,28 @@ use WPGraphQLGravityForms\Types\Button\Button;
  * Form "Save and Continue" data.
  */
 class SaveAndContinue implements Hookable, Type {
-    const TYPE = 'SaveAndContinue';
+	const TYPE = 'SaveAndContinue';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
 
-    public function register_type() {
-        register_graphql_object_type( self::TYPE, [
-            'description' => __( 'Gravity Forms form Save and Continue data.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'enabled'   => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether the Save And Continue feature is enabled.', 'wp-graphql-gravity-forms' ),
-                ],
-                'button'   => [
-                    'type'        => Button::TYPE,
-                    'description' => __( 'Contains the button text. Only applicable when type is set to text.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_type() {
+		register_graphql_object_type(
+			self::TYPE,
+			[
+				'description' => __( 'Gravity Forms form Save and Continue data.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'enabled' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the Save And Continue feature is enabled.', 'wp-graphql-gravity-forms' ),
+					],
+					'button'  => [
+						'type'        => Button::TYPE,
+						'description' => __( 'Contains the button text. Only applicable when type is set to text.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Form/SaveAndContinue.php
+++ b/src/Types/Form/SaveAndContinue.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * GraphQL Object Type - Gravity Forms 'Save and Continue' data.
+ *
+ * @package WPGraphQLGravityForms\Types\Form
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Form;
 
@@ -7,15 +13,21 @@ use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Button\Button;
 
 /**
- * Form "Save and Continue" data.
+ * Class - SaveAndContinue
  */
 class SaveAndContinue implements Hookable, Type {
 	const TYPE = 'SaveAndContinue';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
 	}
 
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
 	public function register_type() {
 		register_graphql_object_type(
 			self::TYPE,

--- a/src/Types/Input/AddressInput.php
+++ b/src/Types/Input/AddressInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - AddressInput
+ * Input fields for address field.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Input fields for address field.
+ * Class - AddressInput
  */
 class AddressInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class AddressInput implements Hookable, InputType {
 	 */
 	const TYPE = 'AddressInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/AddressInput.php
+++ b/src/Types/Input/AddressInput.php
@@ -9,44 +9,47 @@ use WPGraphQLGravityForms\Interfaces\InputType;
  * Input fields for address field.
  */
 class AddressInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'AddressInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'AddressInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __( 'Input fields for address field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'street' => [
-                    'type'        => 'String',
-                    'description' => __( 'Street address.', 'wp-graphql-gravity-forms' ),
-                ],
-                'lineTwo' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address line two.', 'wp-graphql-gravity-forms' ),
-                ],
-                'city' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address city.', 'wp-graphql-gravity-forms' ),
-                ],
-                'state' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address state/region/province name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'zip' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address zip code', 'wp-graphql-gravity-forms' ),
-                ],
-                'country' => [
-                    'type'        => 'String',
-                    'description' => __( 'Address country name.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Input fields for address field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'street'  => [
+						'type'        => 'String',
+						'description' => __( 'Street address.', 'wp-graphql-gravity-forms' ),
+					],
+					'lineTwo' => [
+						'type'        => 'String',
+						'description' => __( 'Address line two.', 'wp-graphql-gravity-forms' ),
+					],
+					'city'    => [
+						'type'        => 'String',
+						'description' => __( 'Address city.', 'wp-graphql-gravity-forms' ),
+					],
+					'state'   => [
+						'type'        => 'String',
+						'description' => __( 'Address state/region/province name.', 'wp-graphql-gravity-forms' ),
+					],
+					'zip'     => [
+						'type'        => 'String',
+						'description' => __( 'Address zip code', 'wp-graphql-gravity-forms' ),
+					],
+					'country' => [
+						'type'        => 'String',
+						'description' => __( 'Address country name.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/CheckboxInput.php
+++ b/src/Types/Input/CheckboxInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - CheckboxInput
+ * Input fields for a single checkbox.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Input fields for a single checkbox.
+ * Class - CheckboxInput
  */
 class CheckboxInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class CheckboxInput implements Hookable, InputType {
 	 */
 	const TYPE = 'CheckboxInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/CheckboxInput.php
+++ b/src/Types/Input/CheckboxInput.php
@@ -9,28 +9,31 @@ use WPGraphQLGravityForms\Interfaces\InputType;
  * Input fields for a single checkbox.
  */
 class CheckboxInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'CheckboxInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'CheckboxInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __( 'Input fields for a single checkbox.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'inputId' => [
-                    'type'        => 'Float',
-                    'description' => __( 'Input ID.', 'wp-graphql-gravity-forms' ),
-                ],
-                'value' => [
-                    'type'        => 'String',
-                    'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Input fields for a single checkbox.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'inputId' => [
+						'type'        => 'Float',
+						'description' => __( 'Input ID.', 'wp-graphql-gravity-forms' ),
+					],
+					'value'   => [
+						'type'        => 'String',
+						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/EntriesDateFiltersInput.php
+++ b/src/Types/Input/EntriesDateFiltersInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - EntriesDateFiltersInput
+ * Date Filters input type for Entries queries.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Date Filters input type for Entries queries.
+ * Class - EntriesDateFiltersInput
  */
 class EntriesDateFiltersInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class EntriesDateFiltersInput implements Hookable, InputType {
 	 */
 	const TYPE = 'EntriesDateFiltersInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/EntriesDateFiltersInput.php
+++ b/src/Types/Input/EntriesDateFiltersInput.php
@@ -9,28 +9,31 @@ use WPGraphQLGravityForms\Interfaces\InputType;
  * Date Filters input type for Entries queries.
  */
 class EntriesDateFiltersInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'EntriesDateFiltersInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EntriesDateFiltersInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __('Date Filters input fields for Entries queries.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'startDate' => [
-                    'type'        => 'String',
-                    'description' => __( 'Start date in Y-m-d H:i:s format.', 'wp-graphql-gravity-forms' ),
-                ],
-                'endDate' => [
-                    'type'        => 'String',
-                    'description' => __( 'End date in Y-m-d H:i:s format.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Date Filters input fields for Entries queries.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'startDate' => [
+						'type'        => 'String',
+						'description' => __( 'Start date in Y-m-d H:i:s format.', 'wp-graphql-gravity-forms' ),
+					],
+					'endDate'   => [
+						'type'        => 'String',
+						'description' => __( 'End date in Y-m-d H:i:s format.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/EntriesFieldFiltersInput.php
+++ b/src/Types/Input/EntriesFieldFiltersInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - EntriesFieldFiltersInput
+ * Field Filters input type for Entries queries.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -7,7 +14,7 @@ use WPGraphQLGravityForms\Interfaces\InputType;
 use WPGraphQLGravityForms\Types\Enum\FieldFiltersOperatorInputEnum;
 
 /**
- * Field Filters input type for Entries queries.
+ * Class - EntriesFieldFiltersInput
  */
 class EntriesFieldFiltersInput implements Hookable, InputType {
 	/**
@@ -15,10 +22,16 @@ class EntriesFieldFiltersInput implements Hookable, InputType {
 	 */
 	const TYPE = 'EntriesFieldFiltersInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/EntriesFieldFiltersInput.php
+++ b/src/Types/Input/EntriesFieldFiltersInput.php
@@ -10,45 +10,48 @@ use WPGraphQLGravityForms\Types\Enum\FieldFiltersOperatorInputEnum;
  * Field Filters input type for Entries queries.
  */
 class EntriesFieldFiltersInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'EntriesFieldFiltersInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EntriesFieldFiltersInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __( 'Field Filters input fields for Entries queries.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'key' => [
-                    'type'        => 'String',
-                    'description' => __( 'The ID of the field to filter by. Use "0" to search all keys. You can also use the names of the columns in Gravity Forms\' database table for entries, such as "date_created", "is_read, "created_by", etc.', 'wp-graphql-gravity-forms' ),
-                ],
-                'operator' => [
-                    'type'        => FieldFiltersOperatorInputEnum::TYPE,
-                    'description' => __( 'The operator to use for filtering.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO - Is there a cleaner way to do this? Values can be any of these types.
-                'stringValues' => [
-                    'type'        => [ 'list_of' => 'String' ],
-                    'description' => __( 'The field value(s) to filter by. Must be string values. If using this field, do not also use intValues, floatValues or boolValues.', 'wp-graphql-gravity-forms' ),
-                ],
-                'intValues' => [
-                    'type'        => [ 'list_of' => 'Int' ],
-                    'description' => __( 'The field value(s) to filter by. Must be integer values. If using this field, do not also use stringValues, floatValues or boolValues.', 'wp-graphql-gravity-forms' ),
-                ],
-                'floatValues' => [
-                    'type'        => [ 'list_of' => 'Float' ],
-                    'description' => __( 'The field value(s) to filter by. Must be float values. If using this field, do not also use stringValues, intValues or boolValues.', 'wp-graphql-gravity-forms' ),
-                ],
-                'boolValues' => [
-                    'type'        => [ 'list_of' => 'Boolean' ],
-                    'description' => __( 'The field value(s) to filter by. Must be boolean values. If using this field, do not also use stringValues, intValues or floatValues.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Field Filters input fields for Entries queries.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'key'          => [
+						'type'        => 'String',
+						'description' => __( 'The ID of the field to filter by. Use "0" to search all keys. You can also use the names of the columns in Gravity Forms\' database table for entries, such as "date_created", "is_read, "created_by", etc.', 'wp-graphql-gravity-forms' ),
+					],
+					'operator'     => [
+						'type'        => FieldFiltersOperatorInputEnum::TYPE,
+						'description' => __( 'The operator to use for filtering.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO - Is there a cleaner way to do this? Values can be any of these types.
+					'stringValues' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'The field value(s) to filter by. Must be string values. If using this field, do not also use intValues, floatValues or boolValues.', 'wp-graphql-gravity-forms' ),
+					],
+					'intValues'    => [
+						'type'        => [ 'list_of' => 'Int' ],
+						'description' => __( 'The field value(s) to filter by. Must be integer values. If using this field, do not also use stringValues, floatValues or boolValues.', 'wp-graphql-gravity-forms' ),
+					],
+					'floatValues'  => [
+						'type'        => [ 'list_of' => 'Float' ],
+						'description' => __( 'The field value(s) to filter by. Must be float values. If using this field, do not also use stringValues, intValues or boolValues.', 'wp-graphql-gravity-forms' ),
+					],
+					'boolValues'   => [
+						'type'        => [ 'list_of' => 'Boolean' ],
+						'description' => __( 'The field value(s) to filter by. Must be boolean values. If using this field, do not also use stringValues, intValues or floatValues.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/EntriesSortingInput.php
+++ b/src/Types/Input/EntriesSortingInput.php
@@ -9,33 +9,36 @@ use WPGraphQLGravityForms\Interfaces\InputType;
  * Sorting input type for Entries queries.
  */
 class EntriesSortingInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'EntriesSortingInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EntriesSortingInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __('Sorting input fields for Entries queries.', 'wp-graphql-gravity-forms'),
-            'fields'      => [
-                'key' => [
-                    'type'        => 'String',
-                    'description' => __( 'The key of the field to sort by.', 'wp-graphql-gravity-forms' ),
-                ],
-                // @TODO: Convert to enum.
-                'direction' => [
-                    'type'        => 'String',
-                    'description' => __( 'The sorting direction. Possible values: DESC for descending (default), or ASC for ascending.', 'wp-graphql-gravity-forms' ),
-                ],
-                'isNumeric' => [
-                    'type'        => 'Boolean',
-                    'description' => __( 'Whether the sorting field\'s values are numeric.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Sorting input fields for Entries queries.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'key'       => [
+						'type'        => 'String',
+						'description' => __( 'The key of the field to sort by.', 'wp-graphql-gravity-forms' ),
+					],
+					// @TODO: Convert to enum.
+					'direction' => [
+						'type'        => 'String',
+						'description' => __( 'The sorting direction. Possible values: DESC for descending (default), or ASC for ascending.', 'wp-graphql-gravity-forms' ),
+					],
+					'isNumeric' => [
+						'type'        => 'Boolean',
+						'description' => __( 'Whether the sorting field\'s values are numeric.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/EntriesSortingInput.php
+++ b/src/Types/Input/EntriesSortingInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - EntriesSortingInput
+ * Sorting input type for Entries queries.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Sorting input type for Entries queries.
+ * Class - EntriesSortingInput
  */
 class EntriesSortingInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class EntriesSortingInput implements Hookable, InputType {
 	 */
 	const TYPE = 'EntriesSortingInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/ListInput.php
+++ b/src/Types/Input/ListInput.php
@@ -19,14 +19,17 @@ class ListInput implements Hookable, InputType {
 	}
 
 	public function register_input_type() {
-		register_graphql_input_type( self::TYPE, [
-			'description' => __( 'Input fields for a single List field item.', 'wp-graphql-gravity-forms' ),
-			'fields'      => [
-				'values' => [
-					'type'        => [ 'list_of' => 'String' ],
-					'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Input fields for a single List field item.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'values' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+					],
 				],
-			],
-		] );
+			]
+		);
 	}
 }

--- a/src/Types/Input/ListInput.php
+++ b/src/Types/Input/ListInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - ListInput
+ * Input fields for a single List field item.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Input fields for a single List field item.
+ * Class - ListInput
  */
 class ListInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class ListInput implements Hookable, InputType {
 	 */
 	const TYPE = 'ListInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Input/NameInput.php
+++ b/src/Types/Input/NameInput.php
@@ -9,40 +9,43 @@ use WPGraphQLGravityForms\Interfaces\InputType;
  * Input fields for name field.
  */
 class NameInput implements Hookable, InputType {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'NameInput';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'NameInput';
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
 
-    public function register_input_type() {
-        register_graphql_input_type( self::TYPE, [
-            'description' => __( 'Input fields for name field.', 'wp-graphql-gravity-forms' ),
-            'fields'      => [
-                'prefix' => [
-                    'type'        => 'String',
-                    'description' => __( 'Prefix, such as Mr., Mrs. etc.', 'wp-graphql-gravity-forms' ),
-                ],
-                'first' => [
-                    'type'        => 'String',
-                    'description' => __( 'First name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'middle' => [
-                    'type'        => 'String',
-                    'description' => __( 'Middle name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'last' => [
-                    'type'        => 'String',
-                    'description' => __( 'Last name.', 'wp-graphql-gravity-forms' ),
-                ],
-                'suffix' => [
-                    'type'        => 'String',
-                    'description' => __( 'Suffix, such as Sr., Jr. etc.', 'wp-graphql-gravity-forms' ),
-                ],
-            ],
-        ] );
-    }
+	public function register_input_type() {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Input fields for name field.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'prefix' => [
+						'type'        => 'String',
+						'description' => __( 'Prefix, such as Mr., Mrs. etc.', 'wp-graphql-gravity-forms' ),
+					],
+					'first'  => [
+						'type'        => 'String',
+						'description' => __( 'First name.', 'wp-graphql-gravity-forms' ),
+					],
+					'middle' => [
+						'type'        => 'String',
+						'description' => __( 'Middle name.', 'wp-graphql-gravity-forms' ),
+					],
+					'last'   => [
+						'type'        => 'String',
+						'description' => __( 'Last name.', 'wp-graphql-gravity-forms' ),
+					],
+					'suffix' => [
+						'type'        => 'String',
+						'description' => __( 'Suffix, such as Sr., Jr. etc.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
 }

--- a/src/Types/Input/NameInput.php
+++ b/src/Types/Input/NameInput.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Input Type - NameInput
+ * Input fields for name field.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Input;
 
@@ -6,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\InputType;
 
 /**
- * Input fields for name field.
+ * Class - NameInput
  */
 class NameInput implements Hookable, InputType {
 	/**
@@ -14,10 +21,16 @@ class NameInput implements Hookable, InputType {
 	 */
 	const TYPE = 'NameInput';
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
 	}
 
+	/**
+	 * Register input type to GraphQL schema.
+	 */
 	public function register_input_type() {
 		register_graphql_input_type(
 			self::TYPE,

--- a/src/Types/Union/ObjectFieldUnion.php
+++ b/src/Types/Union/ObjectFieldUnion.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Union Type - ObjectFieldUnion
+ * Union between an object and a Gravity Forms field.
+ *
+ * @package WPGraphQLGravityForms\Types\Union
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Union;
 
@@ -9,7 +16,7 @@ use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\Field;
 
 /**
- * Union between an object and a Gravity Forms field.
+ * Class - ObjectFieldUnion
  */
 class ObjectFieldUnion implements Hookable, Type {
 	/**
@@ -25,16 +32,26 @@ class ObjectFieldUnion implements Hookable, Type {
 	private $instances;
 
 	/**
-	 * @param array WPGraphQL for Gravity Forms plugin's class instances.
+	 * Constructor
+	 *
+	 * @param array $instances WPGraphQL for Gravity Forms plugin's class instances.
 	 */
 	public function __construct( array $instances ) {
 		$this->instances = $instances;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ], 11 );
 	}
 
+	/**
+	 * Registers union type to GraphQL schema.
+	 *
+	 * @param TypeRegistry $type_registry .
+	 */
 	public function register_type( TypeRegistry $type_registry ) {
 		$field_mappings = $this->get_field_type_mappings();
 

--- a/src/Types/Union/ObjectFieldValueUnion.php
+++ b/src/Types/Union/ObjectFieldValueUnion.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * GraphQL Union Type - ObjectFieldValueUnion
+ * Union between an object and a Gravity Forms field value.
+ *
+ * @package WPGraphQLGravityForms\Types\Union
+ * @since   0.0.1
+ */
 
 namespace WPGraphQLGravityForms\Types\Union;
 
@@ -11,7 +18,7 @@ use WPGraphQLGravityForms\Interfaces\FieldValue;
 use WPGraphQLGravityForms\Types\Field\Field;
 
 /**
- * Union between an object and a Gravity Forms field value.
+ * Class - ObjectFieldValueUnion
  */
 class ObjectFieldValueUnion implements Hookable, Type {
 	/**
@@ -27,16 +34,26 @@ class ObjectFieldValueUnion implements Hookable, Type {
 	private $instances;
 
 	/**
-	 * @param array WPGraphQL for Gravity Forms plugin's class instances.
+	 * Constructor
+	 *
+	 * @param array $instances WPGraphQL for Gravity Forms plugin's class instances.
 	 */
 	public function __construct( array $instances ) {
 		$this->instances = $instances;
 	}
 
+	/**
+	 * Register hooks to WordPress.
+	 */
 	public function register_hooks() {
 		add_action( 'graphql_register_types', [ $this, 'register_type' ], 11 );
 	}
 
+	/**
+	 * Registers union type to GraphQL schema.
+	 *
+	 * @param TypeRegistry $type_registry .
+	 */
 	public function register_type( TypeRegistry $type_registry ) {
 		register_graphql_union_type(
 			self::TYPE,

--- a/src/Types/Union/ObjectFieldValueUnion.php
+++ b/src/Types/Union/ObjectFieldValueUnion.php
@@ -14,56 +14,59 @@ use WPGraphQLGravityForms\Types\Field\Field;
  * Union between an object and a Gravity Forms field value.
  */
 class ObjectFieldValueUnion implements Hookable, Type {
-    /**
-     * Type registered in WPGraphQL.
-     */
-    const TYPE = 'ObjectFieldValueUnion';
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'ObjectFieldValueUnion';
 
-    /**
-     * WPGraphQL for Gravity Forms plugin's class instances.
-     *
-     * @var array
-     */
-    private $instances;
+	/**
+	 * WPGraphQL for Gravity Forms plugin's class instances.
+	 *
+	 * @var array
+	 */
+	private $instances;
 
-    /**
-     * @param array WPGraphQL for Gravity Forms plugin's class instances.
-     */
-    public function __construct( array $instances ) {
-        $this->instances = $instances;
-    }
+	/**
+	 * @param array WPGraphQL for Gravity Forms plugin's class instances.
+	 */
+	public function __construct( array $instances ) {
+		$this->instances = $instances;
+	}
 
-    public function register_hooks() {
-        add_action( 'graphql_register_types', [ $this, 'register_type' ], 11 );
-    }
+	public function register_hooks() {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ], 11 );
+	}
 
-    public function register_type( TypeRegistry $type_registry ) {
-        register_graphql_union_type( self::TYPE, [
-            'typeNames'   => $this->get_field_value_type_names(),
-            'resolveType' => function( $object ) use ( $type_registry ) {
-                return $type_registry->get_type( $object['value_class']::TYPE );
-            },
-        ] );
-    }
+	public function register_type( TypeRegistry $type_registry ) {
+		register_graphql_union_type(
+			self::TYPE,
+			[
+				'typeNames'   => $this->get_field_value_type_names(),
+				'resolveType' => function( $object ) use ( $type_registry ) {
+					return $type_registry->get_type( $object['value_class']::TYPE );
+				},
+			]
+		);
+	}
 
-    private function get_field_value_type_names() : array {
-        return array_values( array_map( fn( $class ) => $class::TYPE, $this->get_field_value_classes() ) );
-    }
+	private function get_field_value_type_names() : array {
+		return array_values( array_map( fn( $class ) => $class::TYPE, $this->get_field_value_classes() ) );
+	}
 
-    private function get_field_value_classes() : array {
-        $is_field_value_instance = fn( $instance ) => $instance instanceof FieldValue;
-        $field_values            = array_filter( $this->instances, $is_field_value_instance );
+	private function get_field_value_classes() : array {
+		$is_field_value_instance = fn( $instance ) => $instance instanceof FieldValue;
+		$field_values            = array_filter( $this->instances, $is_field_value_instance );
 
-        /**
-         * Filter for adding custom field value class instances.
-         * Classes must implement the WPGraphQLGravityForms\Interfaces\FieldValue interface
-         * and define a "TYPE" class constant string in this format: "<field_name>Value".
-         *
-         * @param array $field_values Field value class instances.
-         */
-        $field_values = apply_filters( 'wp_graphql_gf_field_value_instances', $field_values );
+		/**
+		 * Filter for adding custom field value class instances.
+		 * Classes must implement the WPGraphQLGravityForms\Interfaces\FieldValue interface
+		 * and define a "TYPE" class constant string in this format: "<field_name>Value".
+		 *
+		 * @param array $field_values Field value class instances.
+		 */
+		$field_values = apply_filters( 'wp_graphql_gf_field_value_instances', $field_values );
 
-        // Filter the array a second time to guarantee that any classes added are instances of FieldValue.
-        return array_filter( $field_values, $is_field_value_instance );
-    }
+		// Filter the array a second time to guarantee that any classes added are instances of FieldValue.
+		return array_filter( $field_values, $is_field_value_instance );
+	}
 }

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * Plugin Name: WP GraphQL
+ * Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * Description: GraphQL API for WordPress
+ * Author: Harness Software
+ * Author URI: https://www.harnessup.com
+ * Version: 0.0.1
+ * Text Domain: wp-graphql-gravity-forms
+ * Domain Path: /languages
+ * Requires at least: 5.0
+ * WPGraphQL requires at least: 1.0.0+
+ * GravityForms requires at least: 2.4.0+
+ * Tested up to: 5.6.1
+ * Requires PHP: 7.4
+ * License: GPL-3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * @package WPGraphQLGravityForms
+ * @author harnessup
+ * @license GPL-3
+ */
 
 namespace WPGraphQLGravityForms;
 
@@ -22,6 +44,8 @@ use WPGraphQLGravityForms\Types\Input;
 final class WPGraphQLGravityForms {
 	/**
 	 * Class instances.
+	 *
+	 * @var array $instances
 	 */
 	private $instances = [];
 
@@ -33,27 +57,30 @@ final class WPGraphQLGravityForms {
 		$this->register_hooks();
 	}
 
+	/**
+	 * Create instances.
+	 */
 	private function create_instances() {
-		// Settings
+		// Settings.
 		$this->instances['wpgraphql_settings'] = new Settings\WPGraphQLSettings();
 
-		// Data manipulators
+		// Data manipulators.
 		$this->instances['fields_data_manipulator']      = new DataManipulators\FieldsDataManipulator();
 		$this->instances['form_data_manipulator']        = new DataManipulators\FormDataManipulator( $this->instances['fields_data_manipulator'] );
 		$this->instances['entry_data_manipulator']       = new DataManipulators\EntryDataManipulator();
 		$this->instances['draft_entry_data_manipulator'] = new DataManipulators\DraftEntryDataManipulator( $this->instances['entry_data_manipulator'] );
 
-		// Data loaders
+		// Data loaders.
 		$this->instances['loader_registrar'] = new Data\Loader\LoadersRegistrar();
 
-		// Buttons
+		// Buttons.
 		$this->instances['button'] = new Button();
 
-		// Conditional Logic
+		// Conditional Logic.
 		$this->instances['conditional_logic']      = new ConditionalLogic\ConditionalLogic();
 		$this->instances['conditional_logic_rule'] = new ConditionalLogic\ConditionalLogicRule();
 
-		// Forms
+		// Forms.
 		$this->instances['save_and_continue']         = new Form\SaveAndContinue();
 		$this->instances['form_notification_routing'] = new Form\FormNotificationRouting();
 		$this->instances['form_notification']         = new Form\FormNotification();
@@ -61,7 +88,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['form_pagination']           = new Form\FormPagination();
 		$this->instances['form']                      = new Form\Form( $this->instances['form_data_manipulator'] );
 
-		// Fields
+		// Fields.
 		$this->instances['address_field']        = new Field\AddressField();
 		$this->instances['captcha_field']        = new Field\CaptchaField();
 		$this->instances['chained_select_field'] = new Field\ChainedSelectField();
@@ -94,7 +121,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['time_field']           = new Field\TimeField();
 		$this->instances['website_field']        = new Field\WebsiteField();
 
-		// Field Properties
+		// Field Properties.
 		$this->instances['chained_select_choice_property'] = new FieldProperty\ChainedSelectChoiceProperty();
 		$this->instances['checkbox_input_property']        = new FieldProperty\CheckboxInputProperty();
 		$this->instances['choice_property']                = new FieldProperty\ChoiceProperty();
@@ -103,7 +130,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['multi_select_choice_property']   = new FieldProperty\MultiSelectChoiceProperty();
 		$this->instances['password_input_property']        = new FieldProperty\PasswordInputProperty();
 
-		// Field Values
+		// Field Values.
 		$this->instances['address_field_value']        = new FieldValue\AddressFieldValue();
 		$this->instances['chained_select_field_value'] = new FieldValue\ChainedSelectFieldValue();
 		$this->instances['checkbox_input_value']       = new FieldValue\CheckboxInputValue();
@@ -125,12 +152,12 @@ final class WPGraphQLGravityForms {
 		$this->instances['time_field_value']           = new FieldValue\TimeFieldValue();
 		$this->instances['website_field_value']        = new FieldValue\WebsiteFieldValue();
 
-		// Entries
+		// Entries.
 		$this->instances['entry']      = new Entry\Entry( $this->instances['entry_data_manipulator'], $this->instances['draft_entry_data_manipulator'] );
 		$this->instances['entry_form'] = new Entry\EntryForm( $this->instances['form_data_manipulator'] );
 		$this->instances['entry_user'] = new Entry\EntryUser();
 
-		// Input
+		// Input.
 		$this->instances['address_input']              = new Input\AddressInput();
 		$this->instances['checkbox_input']             = new Input\CheckboxInput();
 		$this->instances['list_input']                 = new Input\ListInput();
@@ -139,24 +166,24 @@ final class WPGraphQLGravityForms {
 		$this->instances['entries_field_fiters_input'] = new Input\EntriesFieldFiltersInput();
 		$this->instances['entries_sorting_input']      = new Input\EntriesSortingInput();
 
-		// Unions
+		// Unions.
 		$this->instances['object_field_union']       = new Union\ObjectFieldUnion( $this->instances );
 		$this->instances['object_field_value_union'] = new Union\ObjectFieldValueUnion( $this->instances );
 
-		// Connections
+		// Connections.
 		$this->instances['entry_field_connection']        = new Connections\EntryFieldConnection( $this->instances );
 		$this->instances['form_field_connection']         = new Connections\FormFieldConnection();
 		$this->instances['root_query_entries_connection'] = new Connections\RootQueryEntriesConnection();
 		$this->instances['root_query_forms_connection']   = new Connections\RootQueryFormsConnection();
 
-		// Enums
+		// Enums.
 		$this->instances['form_status_enum']                  = new Enum\FormStatusEnum();
 		$this->instances['field_filters_operator_input_enum'] = new Enum\FieldFiltersOperatorInputEnum();
 
-		// Field errors
+		// Field errors.
 		$this->instances['field_error'] = new FieldError();
 
-		// Mutations
+		// Mutations.
 		$this->instances['delete_entry']                                = new Mutations\DeleteEntry();
 		$this->instances['create_draft_entry']                          = new Mutations\CreateDraftEntry();
 		$this->instances['delete_draft_entry']                          = new Mutations\DeleteDraftEntry();
@@ -179,12 +206,20 @@ final class WPGraphQLGravityForms {
 		$this->instances['update_draft_entry_website_field_value']      = new Mutations\UpdateDraftEntryWebsiteFieldValue( $this->instances['draft_entry_data_manipulator'] );
 	}
 
+	/**
+	 * Register all hooks to WordPress.
+	 */
 	private function register_hooks() {
 		foreach ( $this->get_hookable_instances() as $instance ) {
 			$instance->register_hooks();
 		}
 	}
 
+	/**
+	 * Get array of all hookable instances.
+	 *
+	 * @return array
+	 */
 	private function get_hookable_instances() {
 		return array_filter( $this->instances, fn( $instance ) => $instance instanceof Hookable );
 	}

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -23,7 +23,7 @@ final class WPGraphQLGravityForms {
 	/**
 	 * Class instances.
 	 */
-    private $instances = [];
+	private $instances = [];
 
 	/**
 	 * Main method for running the plugin.
@@ -31,17 +31,17 @@ final class WPGraphQLGravityForms {
 	public function run() {
 		$this->create_instances();
 		$this->register_hooks();
-    }
+	}
 
 	private function create_instances() {
 		// Settings
 		$this->instances['wpgraphql_settings'] = new Settings\WPGraphQLSettings();
 
 		// Data manipulators
-		$this->instances['fields_data_manipulator']       = new DataManipulators\FieldsDataManipulator();
-		$this->instances['form_data_manipulator']         = new DataManipulators\FormDataManipulator( $this->instances['fields_data_manipulator'] );
-		$this->instances['entry_data_manipulator']        = new DataManipulators\EntryDataManipulator();
-		$this->instances['draft_entry_data_manipulator']  = new DataManipulators\DraftEntryDataManipulator( $this->instances['entry_data_manipulator'] );
+		$this->instances['fields_data_manipulator']      = new DataManipulators\FieldsDataManipulator();
+		$this->instances['form_data_manipulator']        = new DataManipulators\FormDataManipulator( $this->instances['fields_data_manipulator'] );
+		$this->instances['entry_data_manipulator']       = new DataManipulators\EntryDataManipulator();
+		$this->instances['draft_entry_data_manipulator'] = new DataManipulators\DraftEntryDataManipulator( $this->instances['entry_data_manipulator'] );
 
 		// Data loaders
 		$this->instances['loader_registrar'] = new Data\Loader\LoadersRegistrar();
@@ -126,9 +126,9 @@ final class WPGraphQLGravityForms {
 		$this->instances['website_field_value']        = new FieldValue\WebsiteFieldValue();
 
 		// Entries
-		$this->instances['entry']                      = new Entry\Entry( $this->instances['entry_data_manipulator'], $this->instances['draft_entry_data_manipulator'] );
-		$this->instances['entry_form']                 = new Entry\EntryForm( $this->instances['form_data_manipulator'] );
-		$this->instances['entry_user']                 = new Entry\EntryUser();
+		$this->instances['entry']      = new Entry\Entry( $this->instances['entry_data_manipulator'], $this->instances['draft_entry_data_manipulator'] );
+		$this->instances['entry_form'] = new Entry\EntryForm( $this->instances['form_data_manipulator'] );
+		$this->instances['entry_user'] = new Entry\EntryUser();
 
 		// Input
 		$this->instances['address_input']              = new Input\AddressInput();

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -1,25 +1,9 @@
 <?php
 /**
- * Plugin Name: WP GraphQL
- * Plugin URI: https://github.com/wp-graphql/wp-graphql
- * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
- * Description: GraphQL API for WordPress
- * Author: Harness Software
- * Author URI: https://www.harnessup.com
- * Version: 0.0.1
- * Text Domain: wp-graphql-gravity-forms
- * Domain Path: /languages
- * Requires at least: 5.0
- * WPGraphQL requires at least: 1.0.0+
- * GravityForms requires at least: 2.4.0+
- * Tested up to: 5.6.1
- * Requires PHP: 7.4
- * License: GPL-3
- * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Initializes a singleton instance of WPGraphQLGravityForms.
  *
  * @package WPGraphQLGravityForms
- * @author harnessup
- * @license GPL-3
+ * @since 0.0.1
  */
 
 namespace WPGraphQLGravityForms;

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WPGraphQL for Gravity Forms
  * Description: Provides a GraphQL API for interacting with Gravity Forms.
- * Version:     0.1.0
+ * Version:     0.0.1
  * Author:      Harness Software, Kellen Mace
  * Author URI:  https://harnessup.com/
  * License:     GPLv2 or later

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -38,7 +38,7 @@ add_action(
 		$display_admin_notice = function() use ( $missing_dependencies ) {
 			?>
 		<div class="notice notice-error">
-			<p><?php esc_html_e( 'The WPGraphQL for Gravity Forms plugin can\'t be loaded because these dependencies are missing:', 'wp-graphql-gravityforms' ); ?></p>
+			<p><?php esc_html_e( 'The WPGraphQL for Gravity Forms plugin can\'t be loaded because these dependencies are missing:', 'wp-graphql-gravity-forms' ); ?></p>
 			<ul>
 				<?php foreach ( $missing_dependencies as $missing_dependency ) : ?>
 					<li><?php echo esc_html( $missing_dependency ); ?></li>

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -1,12 +1,25 @@
 <?php
 /**
- * Plugin Name: WPGraphQL for Gravity Forms
- * Description: Provides a GraphQL API for interacting with Gravity Forms.
- * Version:     0.0.1
- * Author:      Harness Software, Kellen Mace
- * Author URI:  https://harnessup.com/
- * License:     GPLv2 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * Plugin Name: WP GraphQL
+ * Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql
+ * Description: GraphQL API for WordPress
+ * Author: Harness Software
+ * Author URI: https://www.harnessup.com
+ * Version: 0.0.1
+ * Text Domain: wp-graphql-gravity-forms
+ * Domain Path: /languages
+ * Requires at least: 5.0
+ * WPGraphQL requires at least: 1.0.0+
+ * GravityForms requires at least: 2.4.0+
+ * Tested up to: 5.6.1
+ * Requires PHP: 7.4
+ * License: GPL-3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * @package WPGraphQLGravityForms
+ * @author harnessup
+ * @license GPL-3
  */
 
 add_action(

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -9,39 +9,42 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-add_action( 'plugins_loaded', function() {
-    $autoload = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+add_action(
+	'plugins_loaded',
+	function() {
+		$autoload = plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
-    $dependencies = [
-        'Composer autoload files' => is_readable( $autoload ),
-        'WPGraphQL plugin'        => class_exists('WPGraphQL'),
-        'Gravity Forms plugin'    => class_exists('GFAPI'),
-    ];
+		$dependencies = [
+			'Composer autoload files' => is_readable( $autoload ),
+			'WPGraphQL plugin'        => class_exists( 'WPGraphQL' ),
+			'Gravity Forms plugin'    => class_exists( 'GFAPI' ),
+		];
 
-    $missing_dependencies = array_keys( array_diff( $dependencies, array_filter( $dependencies ) ) );
+		$missing_dependencies = array_keys( array_diff( $dependencies, array_filter( $dependencies ) ) );
 
-    $display_admin_notice = function() use ( $missing_dependencies ) {
-        ?>
-        <div class="notice notice-error">
-            <p><?php esc_html_e( 'The WPGraphQL for Gravity Forms plugin can\'t be loaded because these dependencies are missing:', 'wp-graphql-gravityforms' ); ?></p>
-            <ul>
-                <?php foreach ( $missing_dependencies as $missing_dependency ) : ?>
-                    <li><?php echo esc_html( $missing_dependency ); ?></li>
-                <?php endforeach; ?>
-            </ul>
-        </div>
-        <?php
-    };
+		$display_admin_notice = function() use ( $missing_dependencies ) {
+			?>
+		<div class="notice notice-error">
+			<p><?php esc_html_e( 'The WPGraphQL for Gravity Forms plugin can\'t be loaded because these dependencies are missing:', 'wp-graphql-gravityforms' ); ?></p>
+			<ul>
+				<?php foreach ( $missing_dependencies as $missing_dependency ) : ?>
+					<li><?php echo esc_html( $missing_dependency ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+			<?php
+		};
 
-    // If dependencies are missing, display admin notice and return early.
-    if ( $missing_dependencies ) {
-        add_action( 'network_admin_notices', $display_admin_notice );
-        add_action( 'admin_notices', $display_admin_notice );
+		// If dependencies are missing, display admin notice and return early.
+		if ( $missing_dependencies ) {
+			add_action( 'network_admin_notices', $display_admin_notice );
+			add_action( 'admin_notices', $display_admin_notice );
 
-        return;
-    }
+			return;
+		}
 
-    require_once $autoload;
+		require_once $autoload;
 
-    ( new WPGraphQLGravityForms\WPGraphQLGravityForms() )->run();
-} );
+		( new WPGraphQLGravityForms\WPGraphQLGravityForms() )->run();
+	}
+);


### PR DESCRIPTION
Lints plugin based on configuration set in #40 .

- Ran PHPBCF on entire codebase.
- Added/fixed docblocks and inline comments. (Note: there are a few functions that still need a  doc-comment).
- Fixed mismatched text domains (some old files were using `harness` instead of `wp-graphql-gravity-forms`).
- Added a WP plugin header to `wp-graphql-gravity-forms.php`
- switched `json_encode()` with `wp_json_encode()`
- and a some other small fixes (see the commit history)...