### PR TITLE
Add/Refactor/Deprecate field properties.

### DIFF
--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -51,6 +51,7 @@ class AddressField extends Field {
 					FieldProperty\IsRequiredProperty::get(),
 					FieldProperty\LabelPlacementProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\SubLabelPlacementProperty::get(),
 					[
 						// @TODO - Convert to an enum. Possible values: international, us, canadian
 						'addressType'       => [
@@ -68,10 +69,6 @@ class AddressField extends Field {
 						'defaultState'      => [
 							'type'        => 'String',
 							'description' => __( 'Contains the state that will be selected by default. Only applicable when "addressType" is set to "us".', 'wp-graphql-gravity-forms' ),
-						],
-						'subLabelPlacement' => [
-							'type'        => 'String',
-							'description' => __( 'The placement of the labels for the fields (street, city, zip/postal code, etc.) within the address group. This setting controls all of the address pieces, they cannot be set individually. They may be aligned above or below the inputs. If this property is not set, the “Sub-Label Placement” setting on the Form Settings->Form Layout page is used. If no setting is specified, the default is above inputs.', 'wp-graphql-gravity-forms' ),
 						],
 						// @TODO - add placeholders.
 					],

--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -45,14 +45,19 @@ class AddressField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\InputsProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\LabelPlacementProperty::get(),
 					FieldProperty\SizeProperty::get(),
 					FieldProperty\SubLabelPlacementProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						// @TODO - Convert to an enum. Possible values: international, us, canadian
 						'addressType'     => [

--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field
  * @since   0.0.1
+ * @since   0.1.0 Use FieldProperty\SubLabelPlacementProperty instead of local property.
  */
 
 namespace WPGraphQLGravityForms\Types\Field;
@@ -54,19 +55,19 @@ class AddressField extends Field {
 					FieldProperty\SubLabelPlacementProperty::get(),
 					[
 						// @TODO - Convert to an enum. Possible values: international, us, canadian
-						'addressType'       => [
+						'addressType'     => [
 							'type'        => 'String',
 							'description' => __( 'Determines the type of address to be displayed.', 'wp-graphql-gravity-forms' ),
 						],
-						'defaultCountry'    => [
+						'defaultCountry'  => [
 							'type'        => 'String',
 							'description' => __( 'Contains the country that will be selected by default. Only applicable when "addressType" is set to "international".', 'wp-graphql-gravity-forms' ),
 						],
-						'defaultProvince'   => [
+						'defaultProvince' => [
 							'type'        => 'String',
 							'description' => __( 'Contains the province that will be selected by default. Only applicable when "addressType" is set to "canadian".', 'wp-graphql-gravity-forms' ),
 						],
-						'defaultState'      => [
+						'defaultState'    => [
 							'type'        => 'String',
 							'description' => __( 'Contains the state that will be selected by default. Only applicable when "addressType" is set to "us".', 'wp-graphql-gravity-forms' ),
 						],

--- a/src/Types/Field/CaptchaField.php
+++ b/src/Types/Field/CaptchaField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - CaptchaField
@@ -44,7 +45,9 @@ class CaptchaField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					[
 						/**
 						 * Possible values: recaptcha, simple_captcha, math
@@ -75,7 +78,22 @@ class CaptchaField extends Field {
 							'type'        => 'String',
 							'description' => __( 'Determines the image’s background color, in HEX format (i.e. #CCCCCC). Only applicable to simple_captcha and math captcha types.', 'wp-graphql-gravity-forms' ),
 						],
-					]
+
+					],
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminLabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\VisibilityProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/ChainedSelectField.php
+++ b/src/Types/Field/ChainedSelectField.php
@@ -45,11 +45,16 @@ class ChainedSelectField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputsProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'choices'                    => [
 							'type'        => [ 'list_of' => FieldProperty\ChainedSelectChoiceProperty::TYPE ],

--- a/src/Types/Field/CheckboxField.php
+++ b/src/Types/Field/CheckboxField.php
@@ -44,13 +44,18 @@ class CheckboxField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\ChoicesProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\EnableChoiceValueProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'inputs'          => [
 							'type'        => [ 'list_of' => FieldProperty\CheckboxInputProperty::TYPE ],

--- a/src/Types/Field/DateField.php
+++ b/src/Types/Field/DateField.php
@@ -44,14 +44,19 @@ class DateField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						/**
 						 * Possible values: Possible values: calendar, custom, none

--- a/src/Types/Field/EmailField.php
+++ b/src/Types/Field/EmailField.php
@@ -44,14 +44,19 @@ class EmailField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/Field.php
+++ b/src/Types/Field/Field.php
@@ -7,6 +7,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field
  * @since   0.0.1
+ * @since   0.1.0 Remove adminLabel, adminOnly, allowsPrepopulate, label, and visibility from global properties.
  */
 
 namespace WPGraphQLGravityForms\Types\Field;
@@ -14,7 +15,6 @@ namespace WPGraphQLGravityForms\Types\Field;
 use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
-use WPGraphQLGravityForms\Types\Enum\FieldVisibilityEnum;
 
 /**
  * Class - Field
@@ -27,52 +27,33 @@ abstract class Field implements Hookable, Type {
 	 */
 	protected function get_global_properties() : array {
 		return [
-			'adminLabel'        => [
-				'type'        => 'String',
-				'description' => __( 'When specified, the value of this property will be used on the admin pages instead of the label. It is useful for fields with long labels.', 'wp-graphql-gravity-forms' ),
-			],
-			'adminOnly'         => [
-				'type'        => 'Boolean',
-				'description' => __( 'Determines if this field should only visible on the administration pages. A value of 1 will mark the field as admin only and will hide it from the public form. Useful for fields such as “status” that help with managing entries, but don’t apply to users filling out the form.', 'wp-graphql-gravity-forms' ),
-			],
-			'allowsPrepopulate' => [
-				'type'        => 'Boolean',
-				'description' => __( 'Determines if the field’s value can be pre-populated dynamically. 1 to allow field to be pre-populated, 0 otherwise.', 'wp-graphql-gravity-forms' ),
-			],
-			'conditionalLogic'  => [
+			'conditionalLogic' => [
 				'type'        => ConditionalLogic::TYPE,
 				'description' => __( 'Controls the visibility of the field based on values selected by the user.', 'wp-graphql-gravity-forms' ),
 			],
-			'cssClass'          => [
+			'cssClass'         => [
 				'type'        => 'String',
 				'description' => __( 'String containing the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
 			],
-			'cssClassList'      => [
+			'cssClassList'     => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => __( 'Array of the custom CSS classes to be added to the <li> tag that contains the field. Useful for applying custom formatting to specific fields.', 'wp-graphql-gravity-forms' ),
 			],
-			'id'                => [
-				'type'        => 'Integer',
-				'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
-			],
-			'label'             => [
-				'type'        => 'String',
-				'description' => __( 'Field label that will be displayed on the form and on the admin pages.', 'wp-graphql-gravity-forms' ),
-			],
-			'type'              => [
-				'type'        => 'String',
-				'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),
-			],
-			'formId'            => [
+			'formId'           => [
 				'type'        => 'Integer',
 				'description' => __( 'The ID of the form this field belongs to.', 'wp-graphql-gravity-forms' ),
 			],
-			'visibility'        => [
+			'id'               => [
+				'type'        => 'Integer',
+				'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
+			],
+			'type'             => [
 				'type'        => 'String',
-				'description' => __( 'Field visibility. Possible values: visible, hidden, or administrative.', 'wp-graphql-gravity-forms' ),
+				'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),
 			],
 		];
 	}
+
 
 	/**
 	 * Get the custom properties.

--- a/src/Types/Field/FieldProperty/AdminLabelProperty.php
+++ b/src/Types/Field/FieldProperty/AdminLabelProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Admin label field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - AdminLabelProperty
+ */
+abstract class AdminLabelProperty implements FieldProperty {
+	/**
+	 * Get 'adminLabel' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'adminLabel' => [
+				'type'        => 'String',
+				'description' => __( 'When specified, the value of this property will be used on the admin pages instead of the label. It is useful for fields with long labels.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/AdminOnlyProperty.php
+++ b/src/Types/Field/FieldProperty/AdminOnlyProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Admin only field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - AdminOnlyProperty
+ */
+abstract class AdminOnlyProperty implements FieldProperty {
+	/**
+	 * Get 'adminOnly' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'adminOnly' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if this field should only visible on the administration pages. A value of 1 will mark the field as admin only and will hide it from the public form. Useful for fields such as “status” that help with managing entries, but don’t apply to users filling out the form.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/AllowsPrepopulateProperty.php
+++ b/src/Types/Field/FieldProperty/AllowsPrepopulateProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows prepopulate field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - AllowsPrepopulateProperty
+ */
+abstract class AllowsPrepopulateProperty implements FieldProperty {
+	/**
+	 * Get 'allowsPrepopulate' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'allowsPrepopulate' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Determines if the field’s value can be pre-populated dynamically. 1 to allow field to be pre-populated, 0 otherwise.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/DisplayOnlyProperty.php
+++ b/src/Types/Field/FieldProperty/DisplayOnlyProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows display only field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - DisplayOnlyProperty
+ */
+abstract class DisplayOnlyProperty implements FieldProperty {
+	/**
+	 * Get 'displayOnly' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'displayOnly' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Indicates the field is only displayed and its contents are not submitted with the form/saved with the entry. This is set to true.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/EnablePriceProperty.php
+++ b/src/Types/Field/FieldProperty/EnablePriceProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows enable price field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - EnablePriceProperty
+ */
+abstract class EnablePriceProperty implements FieldProperty {
+	/**
+	 * Get 'enablePrice' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'enablePrice' => [
+				'type'        => 'Boolean',
+				'description' => __( 'This property is used when the radio button is a product option field and will be set to true. If not associated with a product, then it is false.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/InputTypeProperty.php
+++ b/src/Types/Field/FieldProperty/InputTypeProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows input type field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - InputTypeProperty
+ */
+abstract class InputTypeProperty implements FieldProperty {
+	/**
+	 * Get 'inputType' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'inputType' => [
+				'type'        => 'String',
+				'description' => __( 'Contains a field type and allows a field type to be displayed as another field type. A good example is the Post Custom Field, that can be displayed as various different types of fields.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/LabelProperty.php
+++ b/src/Types/Field/FieldProperty/LabelProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows label field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - LabelProperty
+ */
+abstract class LabelProperty implements FieldProperty {
+	/**
+	 * Get 'label' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'label' => [
+				'type'        => 'String',
+				'description' => __( 'Field label that will be displayed on the form and on the admin pages.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/PageNumberProperty.php
+++ b/src/Types/Field/FieldProperty/PageNumberProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows page number field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - PageNumberProperty
+ */
+abstract class PageNumberProperty implements FieldProperty {
+	/**
+	 * Get 'pageNumber' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'pageNumber' => [
+				'type'        => 'Integer',
+				'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/ProductFieldProperty.php
+++ b/src/Types/Field/FieldProperty/ProductFieldProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows product field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - ProductFieldProperty
+ */
+abstract class ProductFieldProperty implements FieldProperty {
+	/**
+	 * Get 'productField' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'productField' => [
+				'type'        => 'Integer',
+				'description' => __( 'The id of the product field to which the field is associated.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/SubLabelPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/SubLabelPlacementProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows sublabel placement field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - SubLabelPlacementProperty
+ */
+abstract class SubLabelPlacementProperty implements FieldProperty {
+	/**
+	 * Get 'subLabelPlacement' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'subLabelPlacement' => [
+				'type'        => 'String',
+				'description' => __( 'The placement of the labels for the subfields within the group. This setting controls all of the subfields, they cannot be set individually. They may be aligned above or below the inputs. If this property is not set, the “Sub-Label Placement” setting on the Form Settings->Form Layout page is used. If no setting is specified, the default is above inputs.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FieldProperty/VisibilityProperty.php
+++ b/src/Types/Field/FieldProperty/VisibilityProperty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Allows visiibility field property.
+ *
+ * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
+ * @since   0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\FieldProperty;
+
+/**
+ * Class - VisibilityProperty
+ */
+abstract class VisibilityProperty implements FieldProperty {
+	/**
+	 * Get 'visibility' property.
+	 *
+	 * Applies to: @TODO
+	 *
+	 * @return array
+	 */
+	public static function get() : array {
+		return [
+			'visibility' => [
+				'type'        => 'String',
+				'description' => __( 'Field visibility. Possible values: visible, hidden, or administrative.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Field/FileUploadField.php
+++ b/src/Types/Field/FileUploadField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - FileUploadField
@@ -44,11 +45,15 @@ class FileUploadField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'allowedExtensions' => [
 							'type'        => 'String',
@@ -67,6 +72,14 @@ class FileUploadField extends Field {
 							'description' => __( 'Indicates whether multiple files may be uploaded.', 'wp-graphql-gravity-forms' ),
 						],
 					],
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/HiddenField.php
+++ b/src/Types/Field/HiddenField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Hidden field.
@@ -46,11 +47,25 @@ class HiddenField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminLabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\VisibilityProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/HtmlField.php
+++ b/src/Types/Field/HtmlField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - HtmlField
@@ -45,12 +46,27 @@ class HtmlField extends Field {
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
 					FieldProperty\InputNameProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					[
 						'content' => [
 							'type'        => 'String',
 							'description' => __( 'Content of an HTML block field to be displayed on the form.', 'wp-graphql-gravity-forms' ),
 						],
-					]
+					],
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminLabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\VisibilityProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field
  * @since   0.0.1
+ * @since   0.1.0 Use FieldProperty\PageNumberProperty instead of local property.
  */
 
 namespace WPGraphQLGravityForms\Types\Field;

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -50,6 +50,7 @@ class ListField extends Field {
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
 					FieldProperty\LabelPlacementProperty::get(),
+					FieldProperty\PageNumberProperty::get(),
 					[
 						'addIconUrl'    => [
 							'type'        => 'String',
@@ -70,10 +71,6 @@ class ListField extends Field {
 						'maxRows'       => [
 							'type'        => 'Integer',
 							'description' => __( 'The maximum number of rows the user can add to the field.', 'wp-graphql-gravity-forms' ),
-						],
-						'pageNumber'    => [
-							'type'        => 'Integer',
-							'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
 						],
 					]
 				),

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -45,13 +45,18 @@ class ListField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionPlacementProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\LabelPlacementProperty::get(),
 					FieldProperty\PageNumberProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'addIconUrl'    => [
 							'type'        => 'String',

--- a/src/Types/Field/MultiSelectField.php
+++ b/src/Types/Field/MultiSelectField.php
@@ -47,6 +47,9 @@ class MultiSelectField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionPlacementProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\EnableChoiceValueProperty::get(),
@@ -54,7 +57,9 @@ class MultiSelectField extends Field {
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'choices' => [
 							'type'        => [ 'list_of' => FieldProperty\MultiSelectChoiceProperty::TYPE ],

--- a/src/Types/Field/NameField.php
+++ b/src/Types/Field/NameField.php
@@ -44,12 +44,17 @@ class NameField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\InputsProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						/**
 						 * Possible values: normal, extended, simple

--- a/src/Types/Field/NumberField.php
+++ b/src/Types/Field/NumberField.php
@@ -45,14 +45,19 @@ class NumberField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						/**
 						 * Possible values: decimal_dot (9,999.99), decimal_comma (9.999,99), currency.

--- a/src/Types/Field/PageField.php
+++ b/src/Types/Field/PageField.php
@@ -13,6 +13,7 @@ namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Button\Button;
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - PageField
@@ -61,7 +62,23 @@ class PageField extends Field {
 							'type'        => Button::TYPE,
 							'description' => __( 'An array containing the the individual properties for the "Previous" button.', 'wp-graphql-gravity-forms' ),
 						],
-					]
+					],
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminLabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\LabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\VisibilityProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/PageField.php
+++ b/src/Types/Field/PageField.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field
  * @since   0.0.1
+ * @since   0.1.0 Use FieldProperty\DisplayOnlyProperty instead of local property.
  */
 
 namespace WPGraphQLGravityForms\Types\Field;

--- a/src/Types/Field/PageField.php
+++ b/src/Types/Field/PageField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Button\Button;
+use WPGraphQLGravityForms\Types\Field\FieldProperty;
 
 /**
  * Class - PageField
@@ -44,15 +45,13 @@ class PageField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\DisplayOnlyProperty::get(),
 					[
-						'displayOnly'    => [
-							'type'        => 'Boolean',
-							'description' => __( 'Indicates the field is only displayed and its contents are not submitted with the form/saved with the entry. This is set to true.', 'wp-graphql-gravity-forms' ),
-						],
 						'nextButton'     => [
 							'type'        => Button::TYPE,
 							'description' => __( 'An array containing the the individual properties for the "Next" button.', 'wp-graphql-gravity-forms' ),
 						],
+						// Although the property name is the same, this field is different than FieldProperty\PageNumberProperty.
 						'pageNumber'     => [
 							'type'        => 'Integer',
 							'description' => __( 'The page number of the current page.', 'wp-graphql-gravity-forms' ),

--- a/src/Types/Field/PasswordField.php
+++ b/src/Types/Field/PasswordField.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - PasswordField
@@ -44,10 +45,13 @@ class PasswordField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
 					FieldProperty\DescriptionPlacementProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					[
 						'inputs'                  => [
@@ -63,7 +67,17 @@ class PasswordField extends Field {
 							'type'        => 'Boolean',
 							'description' => __( 'Indicates whether the field displays the password strength indicator.', 'wp-graphql-gravity-forms' ),
 						],
-					]
+					],
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\VisibilityProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/PhoneField.php
+++ b/src/Types/Field/PhoneField.php
@@ -44,14 +44,19 @@ class PhoneField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						/**
 						 * Possible values: standard, international

--- a/src/Types/Field/PostCategoryField.php
+++ b/src/Types/Field/PostCategoryField.php
@@ -44,12 +44,17 @@ class PostCategoryField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\ChoicesProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'displayAllCategories' => [
 							'type'        => 'Boolean',

--- a/src/Types/Field/PostContentField.php
+++ b/src/Types/Field/PostContentField.php
@@ -45,13 +45,17 @@ class PostContentField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/PostCustomField.php
+++ b/src/Types/Field/PostCustomField.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field
  * @since   0.0.1
+ * @since   0.1.0 Use FieldProperty\InputTypeProperty instead of local property.
  */
 
 namespace WPGraphQLGravityForms\Types\Field;
@@ -48,6 +49,7 @@ class PostCustomField extends Field {
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
+					FieldProperty\InputTypeProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
@@ -56,10 +58,6 @@ class PostCustomField extends Field {
 						'postCustomFieldName' => [
 							'type'        => 'String',
 							'description' => __( 'The name of the Post Custom Field that the submitted value should be assigned to.', 'wp-graphql-gravity-forms' ),
-						],
-						'inputType'           => [
-							'type'        => 'String',
-							'description' => __( 'Contains a field type and allows a field type to be displayed as another field type. A good example is the Post Custom Field, that can be displayed as various different types of fields.', 'wp-graphql-gravity-forms' ),
 						],
 					]
 				),

--- a/src/Types/Field/PostCustomField.php
+++ b/src/Types/Field/PostCustomField.php
@@ -45,15 +45,20 @@ class PostCustomField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\InputTypeProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'postCustomFieldName' => [
 							'type'        => 'String',

--- a/src/Types/Field/PostExcerptField.php
+++ b/src/Types/Field/PostExcerptField.php
@@ -44,13 +44,18 @@ class PostExcerptField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/PostImageField.php
+++ b/src/Types/Field/PostImageField.php
@@ -44,11 +44,16 @@ class PostImageField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'displayCaption'     => [
 							'type'        => 'Boolean',

--- a/src/Types/Field/PostTagsField.php
+++ b/src/Types/Field/PostTagsField.php
@@ -44,13 +44,18 @@ class PostTagsField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/PostTitleField.php
+++ b/src/Types/Field/PostTitleField.php
@@ -44,13 +44,18 @@ class PostTitleField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/RadioField.php
+++ b/src/Types/Field/RadioField.php
@@ -45,14 +45,19 @@ class RadioField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\ChoicesProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\EnableChoiceValueProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'enableOtherChoice' => [
 							'type'        => 'Boolean',

--- a/src/Types/Field/SectionField.php
+++ b/src/Types/Field/SectionField.php
@@ -10,6 +10,8 @@
 
 namespace WPGraphQLGravityForms\Types\Field;
 
+use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 /**
  * Class - SectionField
  */
@@ -42,7 +44,21 @@ class SectionField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
-					FieldProperty\DescriptionProperty::get()
+					FieldProperty\DescriptionProperty::get(),
+					FieldProperty\LabelProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
+					/**
+					 * Depreciated field properties.
+					 *
+					 * @since 0.1.0
+					 */
+
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminLabelProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
+					// translators: Gravity Forms Field type.
+					Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			]
 		);

--- a/src/Types/Field/SelectField.php
+++ b/src/Types/Field/SelectField.php
@@ -44,6 +44,9 @@ class SelectField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\ChoicesProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\EnableChoiceValueProperty::get(),
@@ -51,9 +54,11 @@ class SelectField extends Field {
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/SignatureField.php
+++ b/src/Types/Field/SignatureField.php
@@ -46,9 +46,13 @@ class SignatureField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'penSize'         => [
 							'type'        => 'Integer',

--- a/src/Types/Field/TextAreaField.php
+++ b/src/Types/Field/TextAreaField.php
@@ -44,15 +44,20 @@ class TextAreaField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\MaxLengthProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Types/Field/TextField.php
+++ b/src/Types/Field/TextField.php
@@ -44,15 +44,20 @@ class TextField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\MaxLengthProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						'enablePasswordInput' => [
 							'type'        => 'Boolean',

--- a/src/Types/Field/TimeField.php
+++ b/src/Types/Field/TimeField.php
@@ -44,12 +44,17 @@ class TimeField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 					[
 						/**
 						 * Possible values: 12, 24

--- a/src/Types/Field/WebsiteField.php
+++ b/src/Types/Field/WebsiteField.php
@@ -44,14 +44,19 @@ class WebsiteField extends Field {
 				'fields'      => array_merge(
 					$this->get_global_properties(),
 					$this->get_custom_properties(),
+					FieldProperty\AdminLabelProperty::get(),
+					FieldProperty\AdminOnlyProperty::get(),
+					FieldProperty\AllowsPrepopulateProperty::get(),
 					FieldProperty\DefaultValueProperty::get(),
 					FieldProperty\DescriptionProperty::get(),
 					FieldProperty\ErrorMessageProperty::get(),
 					FieldProperty\InputNameProperty::get(),
 					FieldProperty\IsRequiredProperty::get(),
+					FieldProperty\LabelProperty::get(),
 					FieldProperty\NoDuplicatesProperty::get(),
 					FieldProperty\PlaceholderProperty::get(),
-					FieldProperty\SizeProperty::get()
+					FieldProperty\SizeProperty::get(),
+					FieldProperty\VisibilityProperty::get(),
 				),
 			]
 		);

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -24,7 +24,7 @@ class Utils {
 	 * @return array
 	 * @since 0.1.0
 	 */
-	public function depricate_property( array $property, string $reason ) : array {
+	public function deprecate_property( array $property, string $reason ) : array {
 		$property_key = array_key_first( $property );
 
 		// Add deprecation reason to property.

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -24,7 +24,7 @@ class Utils {
 	 * @return array
 	 * @since 0.1.0
 	 */
-	public function deprecate_property( array $property, string $reason ) : array {
+	public static function deprecate_property( array $property, string $reason ) : array {
 		$property_key = array_key_first( $property );
 
 		// Add deprecation reason to property.

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Utils
+ *
+ * Common utility functions
+ *
+ * @package WPGraphQLGravityForms\Utils
+ * @since 0.1.0
+ */
+
+namespace WPGraphQLGravityForms\Utils;
+
+/**
+ * Class - Utils
+ */
+class Utils {
+
+	/**
+	 * Adds deprecation reason to GraphQL field property.
+	 *
+	 * @param array  $property The field property to deprecate.
+	 * @param string $reason The reason for the deprecation. Should be wrapped in __().
+	 *
+	 * @return array
+	 * @since 0.1.0
+	 */
+	public function depricate_property( array $property, string $reason ) : array {
+		$property_key = array_key_first( $property );
+
+		// Add deprecation reason to property.
+		if ( isset( $property_key ) ) {
+			$property[ $property_key ]['deprecationReason'] = $reason;
+		}
+
+		return $property;
+	}
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
- Adds missing FieldProperty classes: `ProductFieldProperty` and `EnablePriceProperty`.
- Moves some local field properties to reuseable classes: `subLabelPlacement`, `pageNumber`, `displayOnly`, `inputType`.
- Moves various global field properties _that arent actually global_ to their own FieldProperty classes, and deprecates them on fields that shouldn't use them: `adminLabel`, `adminOnly`, `allowsPrepopulate`, `label`, and `visible.

It also creates `Utils:deprecate_property()` to handle property deprecation.

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
