### PR TITLE
Set page number on submission

### DIFF
--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -13,6 +13,7 @@ namespace WPGraphQLGravityForms\Mutations;
 use GFAPI;
 use GFCOMMON;
 use GF_Field;
+use GFFormDisplay;
 use GFFormsModel;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -21,7 +22,6 @@ use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Mutation;
 use WPGraphQLGravityForms\Types\Entry\Entry;
 use WPGraphQLGravityForms\DataManipulators\EntryDataManipulator;
-use WPGraphQLGravityForms\Types\FieldError\FieldError;
 
 /**
  * Class - SubmitDraftEntry
@@ -120,6 +120,9 @@ class SubmitDraftEntry implements Hookable, Mutation {
 			$draft_entry  = $this->get_draft_entry( $resume_token );
 			$form_id      = $draft_entry['form_id'];
 
+			// Sets last page.
+			$this->set_form_page_to_last( $form_id );
+
 			$this->validate_form_id( $form_id );
 
 			$entry_id = $this->create_entry( $draft_entry );
@@ -161,6 +164,7 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	 */
 	private function validate_form_id( int $form_id ) {
 		$form_info = GFFormsModel::get_form( $form_id, true );
+		error_log( print_r( $form_info, true ) );
 
 		if ( ! $form_info || ! $form_info->is_active || $form_info->is_trash ) {
 			throw new UserError( __( 'The form associated with this entry is nonexistent or inactive.', 'wp-graphql-gravity-forms' ) );
@@ -305,5 +309,18 @@ class SubmitDraftEntry implements Hookable, Mutation {
 		}
 
 		return $matching_fields[0];
+	}
+
+	/**
+	 * Sets form page to last page so post creation can work.
+	 *
+	 * @param integer $form_id .
+	 */
+	private function set_form_page_to_last( int $form_id ) {
+		require_once GFCOMMON::get_base_path() . '/form_display.php';
+
+		$form = GFAPI::get_form( $form_id );
+
+		GFFormDisplay::set_current_page( $form_id, GFFormDisplay::get_max_page_number( $form ) );
 	}
 }

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -165,7 +165,6 @@ class SubmitDraftEntry implements Hookable, Mutation {
 	 */
 	private function validate_form_id( int $form_id ) {
 		$form_info = GFFormsModel::get_form( $form_id, true );
-		error_log( print_r( $form_info, true ) );
 
 		if ( ! $form_info || ! $form_info->is_active || $form_info->is_trash ) {
 			throw new UserError( __( 'The form associated with this entry is nonexistent or inactive.', 'wp-graphql-gravity-forms' ) );

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Mutation
  * @since 0.0.1
+ * @since 0.3.0 Sets the form pageNumber to the last page, to avoid post creation validation issues.
  */
 
 namespace WPGraphQLGravityForms\Mutations;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
To allow Post Creation to work, the form needs to have a valid page number. Since, the `pageField` is used for display purposes only, we need to artificially set it in `SubmitDraftEntry`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- [New] Sets the form pageNumber to the last page on `submitGravityFormsDraftEntry`, to avoid post creation validation issues.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
