### PR TITLE
Return early if listFieldValue is null or empty.

### DIFF
--- a/src/Types/Field/FieldValue/ListFieldValue.php
+++ b/src/Types/Field/FieldValue/ListFieldValue.php
@@ -5,6 +5,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field\FieldValue
  * @since   0.0.1
+ * @since   0.3.0 Return early if value is null or empty.
  */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
@@ -61,7 +62,12 @@ class ListFieldValue implements Hookable, Type, FieldValue {
 	 * @throws UserError .
 	 */
 	public static function get( array $entry, GF_Field $field ) : array {
-		$entry_values = isset( $entry[ $field['id'] ] ) ? unserialize( $entry[ $field['id'] ] ) : [];
+		$entry_values = isset( $entry[ $field['id'] ] ) ? unserialize( $entry[ $field['id'] ] ) : null;
+
+		// Return null if no value is set, or unserialize creates an empty array.
+		if ( empty( $entry_values ) ) {
+			return [];
+		}
 
 		// Check if there are too many rows.
 		if ( $field['maxRows'] < count( $entry_values ) ) {


### PR DESCRIPTION
## Description
Previously, a PHP Warning would be thrown if `listFieldValue` was null or empty. This PR checks to see if a value is set, and returns early if it isnt.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- [Bugfix] Return early if `listFieldValue` is null or empty.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
