### PR TITLE
[Bugfix] Change listFieldValue array structure

### DIFF
--- a/src/DataManipulators/FieldsDataManipulator.php
+++ b/src/DataManipulators/FieldsDataManipulator.php
@@ -29,6 +29,7 @@ class FieldsDataManipulator implements DataManipulator {
 	public function manipulate( array $data ) : array {
 		$data = array_map( [ $this, 'set_css_class_list_for_field' ], $data );
 		$data = $this->set_is_hidden_values( $data );
+		$data = $this->set_list_choice_empty_values( $data );
 		$data = $this->add_keys_to_inputs( $data, 'address' );
 		$data = $this->add_keys_to_inputs( $data, 'name' );
 
@@ -84,6 +85,37 @@ class FieldsDataManipulator implements DataManipulator {
 			$fields[ $field_index ]['inputs'] = $inputs;
 		}
 
+		return $fields;
+	}
+
+	/**
+	 * List fields without columns don't have their `choices` key set.
+	 * This sets them so we can use the same mutation for both single and multi-column list fields.
+	 *
+	 * @param array $fields Form fields.
+	 *
+	 * @return array $fields Form fields with the list `choices` values defined.
+	 */
+	private function set_list_choice_empty_values( array $fields ) {
+		$empty_choices = [
+			'text'       => null,
+			'value'      => null,
+			'isSelected' => null,
+			'price'      => null,
+		];
+
+		$fields_to_modify = array_filter(
+			$fields,
+			function( $field ) {
+				return 'list' === $field['type'];
+			}
+		);
+
+		foreach ( $fields_to_modify as $field_index => $field ) {
+			if ( empty( $field['choices'] ) ) {
+				$fields[ $field_index ]['choices'] = $empty_choices;
+			}
+		}
 		return $fields;
 	}
 

--- a/src/Mutations/UpdateDraftEntryListFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryListFieldValue.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Mutation
  * @since 0.0.1
+ * @since 0.3.0 Deprecate `values` in favor of `rowValues`.
  */
 
 namespace WPGraphQLGravityForms\Mutations;
@@ -46,23 +47,31 @@ class UpdateDraftEntryListFieldValue extends DraftEntryUpdater {
 			function( $row ) {
 				$row_values = []; // Initializes array.
 
+				/**
+				 * Deprecate `values` in favor of `rowValues`.
+				 *
+				 * @since 0.3.0
+				 */
+				if ( ! empty( $row['values'] ) ) {
+					_doing_it_wrong( 'updateDraftEntryListFieldValue', 'The listField input.value.values property has been deprecated. Please use input.value.rowValues instead.', '0.3.0' );
+					$row['rowValues'] = $row['values'];
+				}
+
 				// If columns are enabled, save each choice => value pair.
 				if ( $this->field->enableColumns ) {
 					foreach ( $this->field->choices as $choice_key => $choice ) {
-						$row_values[] = [
-							$choice['value'] => isset( $row['values'][ $choice_key ] ) ? sanitize_text_field( $row['values'][ $choice_key ] ) : null,
-						];
+						$row_values[ $choice['value'] ] = isset( $row['rowValues'][ $choice_key ] ) ? sanitize_text_field( $row['rowValues'][ $choice_key ] ) : null;
 					}
 
 					return $row_values;
 				}
 
 				// If no columns, values can be saved directly to the array.
-				return isset( $row['values'][0] ) ? sanitize_text_field( $row['values'][0] ) : null;
+				return isset( $row['rowValues'][0] ) ? sanitize_text_field( $row['rowValues'][0] ) : null;
 			},
 			$value
 		);
 
-		return (string) serialize( $values_to_save );
+		return (string) serialize( $values_to_save ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 	}
 }

--- a/src/Types/Field/FieldValue/ListInputValue.php
+++ b/src/Types/Field/FieldValue/ListInputValue.php
@@ -5,6 +5,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Field\FieldValue
  * @since   0.0.1
+ * @since   0.3.0 Deprecate `value` in favor of `values`.
  */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
@@ -37,9 +38,14 @@ class ListInputValue implements Hookable, Type {
 			[
 				'description' => __( 'Value for a single input within a list field.', 'wp-graphql-gravity-forms' ),
 				'fields'      => [
-					'value' => [
+					'value'  => [
+						'type'              => [ 'list_of' => 'String' ],
+						'description'       => __( 'Input value', 'wp-graphql-gravity-forms' ),
+						'deprecationReason' => __( 'Please use `values` instead.', 'wp-graphql-gravity-forms' ),
+					],
+					'values' => [
 						'type'        => [ 'list_of' => 'String' ],
-						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+						'description' => __( 'Input values', 'wp-graphql-gravity-forms' ),
 					],
 				],
 			]

--- a/src/Types/Input/ListInput.php
+++ b/src/Types/Input/ListInput.php
@@ -5,6 +5,7 @@
  *
  * @package WPGraphQLGravityForms\Types\Input
  * @since   0.0.1
+ * @since   0.3.0 Deprecate `values` in favor of `rowValues`.
  */
 
 namespace WPGraphQLGravityForms\Types\Input;
@@ -37,9 +38,14 @@ class ListInput implements Hookable, InputType {
 			[
 				'description' => __( 'Input fields for a single List field item.', 'wp-graphql-gravity-forms' ),
 				'fields'      => [
-					'values' => [
+					'values'    => [
+						'type'              => [ 'list_of' => 'String' ],
+						'description'       => __( 'Input value. Deprecated - please use `rowValues` instead.', 'wp-graphql-gravity-forms' ),
+						'deprecationReason' => __( 'Please use `rowValues` instead.', 'wp-graphql-gravity-forms' ),
+					],
+					'rowValues' => [
 						'type'        => [ 'list_of' => 'String' ],
-						'description' => __( 'Input value', 'wp-graphql-gravity-forms' ),
+						'description' => __( 'Input values for the specific listField row.', 'wp-graphql-gravity-forms' ),
 					],
 				],
 			]


### PR DESCRIPTION
## Description
Previously, the array values saved to `listField` had an extra level that prevented GF from reading the entry value. This PR fixes that, while renaming some of the GraphQL field properties.

Also, since we're sanitizing the values, we're suppressing the PHPCS notice about using `serialize()`.

**Fixes**: #63 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- [Bug fix] Ensures single-column `listFields` have a set `choices` property, to prevent inconsistent behavior when saving values.
- [Bug fix] Fixed the `listFieldValue` array structure, so it can be properly read by GF.
<!-- New feature (non-breaking change which adds functionality) -->
- [Deprecation] The `input.value.values` property on `updateDraftEntryListFieldValue` has been deprecated. Going forward, please use `input.value.rowValues`.
- [Deprecation] The `ListFieldValue.listValues.value` property has been deprecated. Going forward, please use `ListFieldValue.listValues.values`.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
