### PR TITLE
Various GFSignature fixes.

### DIFF
--- a/src/Mutations/UpdateDraftEntrySignatureFieldValue.php
+++ b/src/Mutations/UpdateDraftEntrySignatureFieldValue.php
@@ -6,6 +6,7 @@
  *
  * @package WPGraphQLGravityForms\Mutation
  * @since 0.0.1
+ * @since 0.3.0 use $this->field['id'] to correctly delete signature image.
  */
 
 namespace WPGraphQLGravityForms\Mutations;
@@ -82,7 +83,7 @@ class UpdateDraftEntrySignatureFieldValue extends DraftEntryUpdater {
 	 * Deletes previous signature image.
 	 */
 	private function delete_previous_signature_image() {
-		$prev_filename = $this->submission['partial_entry'][ $this->field_id ] ?? '';
+		$prev_filename = $this->submission['partial_entry'][ $this->field['id'] ] ?? '';
 
 		if ( ! $prev_filename ) {
 			return;

--- a/src/Types/Field/FieldValue/SignatureFieldValue.php
+++ b/src/Types/Field/FieldValue/SignatureFieldValue.php
@@ -5,11 +5,13 @@
  *
  * @package WPGraphQLGravityForms\Types\Field\FieldValue
  * @since   0.0.1
+ * @since   0.3.0 use $field->get_value_url() to retrieve signature url.
  */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldValue;
 
 use GF_Field;
+use GF_Field_Signature;
 use WPGraphQLGravityForms\Interfaces\Hookable;
 use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Interfaces\FieldValue;
@@ -58,12 +60,12 @@ class SignatureFieldValue implements Hookable, Type, FieldValue {
 	 * @return array Entry field value.
 	 */
 	public static function get( array $entry, GF_Field $field ) : array {
-		if ( ! function_exists( 'gf_signature' ) || ! array_key_exists( $field['id'], $entry ) ) {
+		if ( ! class_exists( 'GF_Field_Signature' ) || ! array_key_exists( $field['id'], $entry ) ) {
 			return [ 'url' => null ];
 		}
 
 		return [
-			'url' => gf_signature()->get_signature_url( $entry[ $field['id'] ] ),
+			'url' => $field->get_value_url( $entry[ $field['id'] ] ),
 		];
 	}
 }


### PR DESCRIPTION
## Description
This PR
- Passes correct field id in `delete_previous_signature_image()`, as they werent deleting previously.
- Uses `$field->get_value_url()` to fetch the signature url, as `gf_signature()->get_signature_url()` is deprecated.
**Fixes** #64 


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- [Bugfix] Correctly deletes old signature images when a new one is added to the `draftEntry.
- [Bugfix] Fixes deprecation notice from `gf_signature()->get_signature_url()`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->