### PR TITLE
Add isHidden property to PasswordInputProperty

### DIFF
--- a/src/Types/Field/FieldProperty/PasswordInputProperty.php
+++ b/src/Types/Field/FieldProperty/PasswordInputProperty.php
@@ -8,6 +8,7 @@
  * @package WPGraphQLGravityForms\Types\Field\FieldProperty;
  * @since   0.0.1
  * @since   0.2.0 Use InputProperty classes.
+ * @since   0.3.0 Add isHidden property.
  */
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
@@ -43,6 +44,7 @@ class PasswordInputProperty implements Hookable, Type {
 				'fields'      => array_merge(
 					InputProperty\InputCustomLabelProperty::get(),
 					InputProperty\InputIdProperty::get(),
+					InputProperty\InputIsHiddenProperty::get(),
 					InputProperty\InputLabelProperty::get(),
 					InputProperty\InputPlaceholderProperty::get(),
 				),


### PR DESCRIPTION
## Description
Adds `isHidden` property to PasswordInputProperty.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- [Feature] Add `isHidden` property to `PasswordInputProperty`.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
