### PR TITLE
Remove abstract from classes

### DIFF
--- a/src/Types/Field/FieldProperty/AdminLabelProperty.php
+++ b/src/Types/Field/FieldProperty/AdminLabelProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - AdminLabelProperty
  */
-abstract class AdminLabelProperty implements FieldProperty {
+class AdminLabelProperty implements FieldProperty {
 	/**
 	 * Get 'adminLabel' property.
 	 *

--- a/src/Types/Field/FieldProperty/AdminOnlyProperty.php
+++ b/src/Types/Field/FieldProperty/AdminOnlyProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - AdminOnlyProperty
  */
-abstract class AdminOnlyProperty implements FieldProperty {
+class AdminOnlyProperty implements FieldProperty {
 	/**
 	 * Get 'adminOnly' property.
 	 *

--- a/src/Types/Field/FieldProperty/AllowsPrepopulateProperty.php
+++ b/src/Types/Field/FieldProperty/AllowsPrepopulateProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - AllowsPrepopulateProperty
  */
-abstract class AllowsPrepopulateProperty implements FieldProperty {
+class AllowsPrepopulateProperty implements FieldProperty {
 	/**
 	 * Get 'allowsPrepopulate' property.
 	 *

--- a/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceIsSelectedProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceIsSelectedProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ChoiceIsSelectedProperty
  */
-abstract class ChoiceIsSelectedProperty implements FieldProperty {
+class ChoiceIsSelectedProperty implements FieldProperty {
 	/**
 	 * Get 'isSelected' property for Choice.
 	 *

--- a/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceTextProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceTextProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ChoiceTextProperty
  */
-abstract class ChoiceTextProperty implements FieldProperty {
+class ChoiceTextProperty implements FieldProperty {
 	/**
 	 * Get 'text' property for Choice.
 	 *

--- a/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceValueProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty/ChoiceValueProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ChoiceValueProperty
  */
-abstract class ChoiceValueProperty implements FieldProperty {
+class ChoiceValueProperty implements FieldProperty {
 	/**
 	 * Get 'value' property for Choice.
 	 *

--- a/src/Types/Field/FieldProperty/ChoicesProperty.php
+++ b/src/Types/Field/FieldProperty/ChoicesProperty.php
@@ -15,7 +15,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ChoicesProperty
  */
-abstract class ChoicesProperty implements FieldProperty {
+class ChoicesProperty implements FieldProperty {
 	/**
 	 * Get 'choices' property.
 	 *

--- a/src/Types/Field/FieldProperty/DefaultValueProperty.php
+++ b/src/Types/Field/FieldProperty/DefaultValueProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - DefaultValueProperty
  */
-abstract class DefaultValueProperty implements FieldProperty {
+class DefaultValueProperty implements FieldProperty {
 	/**
 	 * Get 'defaultValue' property.
 	 *

--- a/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionPlacementProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - DescriptionPlacementProperty
  */
-abstract class DescriptionPlacementProperty implements FieldProperty {
+class DescriptionPlacementProperty implements FieldProperty {
 	/**
 	 * Get Description placement property.
 	 * This is different from the 'descriptionPlacement' Form field.

--- a/src/Types/Field/FieldProperty/DescriptionProperty.php
+++ b/src/Types/Field/FieldProperty/DescriptionProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - DescriptionProperty
  */
-abstract class DescriptionProperty implements FieldProperty {
+class DescriptionProperty implements FieldProperty {
 	/**
 	 * Get 'description' property.
 	 */

--- a/src/Types/Field/FieldProperty/DisplayOnlyProperty.php
+++ b/src/Types/Field/FieldProperty/DisplayOnlyProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - DisplayOnlyProperty
  */
-abstract class DisplayOnlyProperty implements FieldProperty {
+class DisplayOnlyProperty implements FieldProperty {
 	/**
 	 * Get 'displayOnly' property.
 	 *

--- a/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
+++ b/src/Types/Field/FieldProperty/EnableChoiceValueProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - DefaultValueProperty
  */
-abstract class EnableChoiceValueProperty implements FieldProperty {
+class EnableChoiceValueProperty implements FieldProperty {
 	/**
 	 * Get 'enableChoiceValue' property.
 	 *

--- a/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
+++ b/src/Types/Field/FieldProperty/EnableEnhancedUiProperty.php
@@ -15,7 +15,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - EnableEnhancedUiProperty
  */
-abstract class EnableEnhancedUiProperty implements FieldProperty {
+class EnableEnhancedUiProperty implements FieldProperty {
 	/**
 	 * Get 'enableEnhancedUI' property.
 	 *

--- a/src/Types/Field/FieldProperty/EnablePriceProperty.php
+++ b/src/Types/Field/FieldProperty/EnablePriceProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - EnablePriceProperty
  */
-abstract class EnablePriceProperty implements FieldProperty {
+class EnablePriceProperty implements FieldProperty {
 	/**
 	 * Get 'enablePrice' property.
 	 *

--- a/src/Types/Field/FieldProperty/EnableSelectAllProperty.php
+++ b/src/Types/Field/FieldProperty/EnableSelectAllProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - EnableSelectAllProperty
  */
-abstract class EnableSelectAllProperty implements FieldProperty {
+class EnableSelectAllProperty implements FieldProperty {
 	/**
 	 * Get 'enableSelectAll' property.
 	 *

--- a/src/Types/Field/FieldProperty/ErrorMessageProperty.php
+++ b/src/Types/Field/FieldProperty/ErrorMessageProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ErrorMessageProperty
  */
-abstract class ErrorMessageProperty implements FieldProperty {
+class ErrorMessageProperty implements FieldProperty {
 	/**
 	 * Get 'errorMessage' property.
 	 *

--- a/src/Types/Field/FieldProperty/InputNameProperty.php
+++ b/src/Types/Field/FieldProperty/InputNameProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputNameProperty
  */
-abstract class InputNameProperty implements FieldProperty {
+class InputNameProperty implements FieldProperty {
 	/**
 	 * Get 'inputName' property.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputCustomLabelProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputCustomLabelProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputCustomLabelProperty
  */
-abstract class InputCustomLabelProperty implements FieldProperty {
+class InputCustomLabelProperty implements FieldProperty {
 	/**
 	 * Get 'customLabel' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputDefaultValueProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputDefaultValueProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputDefaultValueProperty
  */
-abstract class InputDefaultValueProperty implements FieldProperty {
+class InputDefaultValueProperty implements FieldProperty {
 	/**
 	 * Get 'defaultValue' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputIdProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputIdProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputIdProperty
  */
-abstract class InputIdProperty implements FieldProperty {
+class InputIdProperty implements FieldProperty {
 	/**
 	 * Get 'id' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputIsHiddenProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputIsHiddenProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputIsHiddenProperty
  */
-abstract class InputIsHiddenProperty implements FieldProperty {
+class InputIsHiddenProperty implements FieldProperty {
 	/**
 	 * Get 'isHidden' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputKeyProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputKeyProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputKeyProperty
  */
-abstract class InputKeyProperty implements FieldProperty {
+class InputKeyProperty implements FieldProperty {
 	/**
 	 * Get 'key' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputLabelProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputLabelProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputLabelProperty
  */
-abstract class InputLabelProperty implements FieldProperty {
+class InputLabelProperty implements FieldProperty {
 	/**
 	 * Get 'label' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputNameProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputNameProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputNameProperty
  */
-abstract class InputNameProperty implements FieldProperty {
+class InputNameProperty implements FieldProperty {
 	/**
 	 * Get 'name' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputProperty/InputPlaceholderProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty/InputPlaceholderProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputPlaceholderProperty
  */
-abstract class InputPlaceholderProperty implements FieldProperty {
+class InputPlaceholderProperty implements FieldProperty {
 	/**
 	 * Get 'placeholder' property for Input.
 	 *

--- a/src/Types/Field/FieldProperty/InputTypeProperty.php
+++ b/src/Types/Field/FieldProperty/InputTypeProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputTypeProperty
  */
-abstract class InputTypeProperty implements FieldProperty {
+class InputTypeProperty implements FieldProperty {
 	/**
 	 * Get 'inputType' property.
 	 *

--- a/src/Types/Field/FieldProperty/InputsProperty.php
+++ b/src/Types/Field/FieldProperty/InputsProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - InputsProperty
  */
-abstract class InputsProperty implements FieldProperty {
+class InputsProperty implements FieldProperty {
 	/**
 	 * Get 'inputs' property.
 	 *

--- a/src/Types/Field/FieldProperty/IsRequiredProperty.php
+++ b/src/Types/Field/FieldProperty/IsRequiredProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - IsRequiredProperty
  */
-abstract class IsRequiredProperty implements FieldProperty {
+class IsRequiredProperty implements FieldProperty {
 	/**
 	 * Get 'isRequired' property.
 	 *

--- a/src/Types/Field/FieldProperty/LabelPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/LabelPlacementProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - LabelPlacementProperty
  */
-abstract class LabelPlacementProperty implements FieldProperty {
+class LabelPlacementProperty implements FieldProperty {
 	/**
 	 * Get 'labelPlacement' property.
 	 *

--- a/src/Types/Field/FieldProperty/LabelProperty.php
+++ b/src/Types/Field/FieldProperty/LabelProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - LabelProperty
  */
-abstract class LabelProperty implements FieldProperty {
+class LabelProperty implements FieldProperty {
 	/**
 	 * Get 'label' property.
 	 *

--- a/src/Types/Field/FieldProperty/MaxLengthProperty.php
+++ b/src/Types/Field/FieldProperty/MaxLengthProperty.php
@@ -14,7 +14,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - MaxLengthProperty
  */
-abstract class MaxLengthProperty implements FieldProperty {
+class MaxLengthProperty implements FieldProperty {
 	/**
 	 * Get 'maxLength' property.
 	 *

--- a/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
+++ b/src/Types/Field/FieldProperty/NoDuplicatesProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - NoDuplicatesProperty
  */
-abstract class NoDuplicatesProperty implements FieldProperty {
+class NoDuplicatesProperty implements FieldProperty {
 	/**
 	 * Get 'noDuplicates' property.
 	 *

--- a/src/Types/Field/FieldProperty/PageNumberProperty.php
+++ b/src/Types/Field/FieldProperty/PageNumberProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - PageNumberProperty
  */
-abstract class PageNumberProperty implements FieldProperty {
+class PageNumberProperty implements FieldProperty {
 	/**
 	 * Get 'pageNumber' property.
 	 *

--- a/src/Types/Field/FieldProperty/PlaceholderProperty.php
+++ b/src/Types/Field/FieldProperty/PlaceholderProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - PlaceholderProperty
  */
-abstract class PlaceholderProperty implements FieldProperty {
+class PlaceholderProperty implements FieldProperty {
 	/**
 	 * Get 'placeholder' property.
 	 *

--- a/src/Types/Field/FieldProperty/ProductFieldProperty.php
+++ b/src/Types/Field/FieldProperty/ProductFieldProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - ProductFieldProperty
  */
-abstract class ProductFieldProperty implements FieldProperty {
+class ProductFieldProperty implements FieldProperty {
 	/**
 	 * Get 'productField' property.
 	 *

--- a/src/Types/Field/FieldProperty/SubLabelPlacementProperty.php
+++ b/src/Types/Field/FieldProperty/SubLabelPlacementProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - SubLabelPlacementProperty
  */
-abstract class SubLabelPlacementProperty implements FieldProperty {
+class SubLabelPlacementProperty implements FieldProperty {
 	/**
 	 * Get 'subLabelPlacement' property.
 	 *

--- a/src/Types/Field/FieldProperty/VisibilityProperty.php
+++ b/src/Types/Field/FieldProperty/VisibilityProperty.php
@@ -13,7 +13,7 @@ use WPGraphQLGravityForms\Interfaces\FieldProperty;
 /**
  * Class - VisibilityProperty
  */
-abstract class VisibilityProperty implements FieldProperty {
+class VisibilityProperty implements FieldProperty {
 	/**
 	 * Get 'visibility' property.
 	 *


### PR DESCRIPTION
## Description
Field property classes were accidentally defined as `abstract` classes. This PR removes the abstract keyword.