### PR TITLE
Fix ConsentFieldValue type conflict by changing value to string

### DIFF
--- a/src/Types/Field/FieldValue/ConsentFieldValue.php
+++ b/src/Types/Field/FieldValue/ConsentFieldValue.php
@@ -41,8 +41,8 @@ class ConsentFieldValue implements Hookable, Type, FieldValue {
 				'description' => __( 'Consent field value.', 'wp-graphql-gravity-forms' ),
 				'fields'      => [
 					'value' => [
-						'type'        => 'Boolean',
-						'description' => __( 'The value.', 'wp-graphql-gravity-forms' ),
+						'type'        => 'String',
+						'description' => __( 'The value. Returns the consent message on `true`, `null` on false.', 'wp-graphql-gravity-forms' ),
 					],
 				],
 			]
@@ -59,7 +59,7 @@ class ConsentFieldValue implements Hookable, Type, FieldValue {
 	 */
 	public static function get( array $entry, GF_Field $field ) : array {
 			return [
-				'value' => $entry[ $field['inputs'][0]['id'] ] ?? null,
+				'value' => $entry[ $field['inputs'][1]['id'] ] ?? null,
 			];
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
The `value` property on `ConsentFieldValue`' was a conflicting type (boolean). This PR changes the `value` to `String` and returns the consent message (what GF does).