### PR TITLE
fix: sanitize email values as text to allow validation.

### DIFF
--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -292,17 +292,6 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	}
 
 	/**
-	 * Sanitizes the EmailField value.
-	 *
-	 * @param string $value .
-	 * @return string
-	 */
-	protected function prepare_email_field_value( string $value ) : string {
-		return sanitize_email( $value );
-	}
-
-
-	/**
 	 * Formats and sanitizes ListField values.
 	 *
 	 * @param array $value .
@@ -534,8 +523,6 @@ abstract class AbstractMutation implements Hookable, Mutation {
 				return $this->prepare_complex_field_value( $value, $field );
 			case 'consent':
 				return $this->prepare_consent_field_value( $value, $field );
-			case 'email':
-				return $this->prepare_email_field_value( $value );
 			case 'list':
 				return $this->prepare_list_field_value( $value );
 			case 'multiselect':
@@ -552,6 +539,7 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			case 'website':
 				return $this->prepare_website_field_value( $value );
 			case 'date':
+			case 'email':
 			case 'hidden':
 			case 'number':
 			case 'phone':

--- a/src/Mutations/UpdateDraftEntryEmailFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryEmailFieldValue.php
@@ -48,6 +48,6 @@ class UpdateDraftEntryEmailFieldValue extends AbstractDraftEntryUpdater {
 	 * @return string
 	 */
 	protected function prepare_field_value( string $value ) : string {
-		return $this->prepare_email_field_value( $value );
+		return $this->prepare_string_value( $value );
 	}
 }


### PR DESCRIPTION
## Description
Use `sanitize_text_field()` instead of `sanitize_email()` on email values, to allow failing emails to be passed to the server and validated.

Fixes: <!-- Please reference any relevant issues from the Issue tracker. --> 
#87 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Bugfix: Use `sanitize_text_field()` instead of `sanitize_email()` on email values, to allow failing emails to be passed to the server and validated.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x ] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->