### PR TITLE
feature!:add email confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,14 @@ This is an interim solution until [the GraphQL Spec adds support for Input Union
           ]
         }
         {
+          # Email field value
+          id: 6
+          emailValues: {
+            value: "myemail@email.test"
+            confirmationValue: "myemail@email.test" # Only necessary if Email confirmation is enabled.
+          }
+        }
+        {
           # Multi-column List field value
           id: 6
           listValues: {

--- a/src/Mutations/SubmitForm.php
+++ b/src/Mutations/SubmitForm.php
@@ -278,18 +278,10 @@ class SubmitForm extends AbstractMutation {
 		foreach ( $field_values as $values ) {
 			$field = GFUtils::get_field_by_id( $this->form, $values['id'] );
 
-			$this->validate_field_value_type( $field, $values );
-
-			$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'];
-
-			$value = $this->prepare_field_value_by_type( $value, $field );
+			$value = $this->prepare_single_field_value( $values, $field );
 
 			// Add values to array based on field type.
-			if ( in_array( $field->type, [ 'address', 'chainedselect', 'checkbox', 'consent', 'name' ], true ) ) {
-				$formatted_values += $value;
-			} else {
-				$formatted_values[ $values['id'] ] = $value;
-			}
+			$formatted_values = $this->add_value_to_array( $formatted_values, $field, $value );
 		}
 
 		return $formatted_values;

--- a/src/Mutations/UpdateDraftEntry.php
+++ b/src/Mutations/UpdateDraftEntry.php
@@ -186,23 +186,16 @@ class UpdateDraftEntry extends AbstractMutation {
 		foreach ( $field_values as $values ) {
 			$field = GFUtils::get_field_by_id( $this->form, $values['id'] );
 
-			$this->validate_field_value_type( $field, $values );
+			$value = $this->prepare_single_field_value( $values, $field );
 
-			$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'];
-
-			$value = $this->prepare_field_value_by_type( $value, $field );
-
+			// Validate the field value.
 			$this->validate_field_value( $this->form, $field, $value );
 
 			// Add field values to submitted values.
 			$this->submission['submitted_values'][ $field->id ] = $value;
 
 			// Add values to array based on field type.
-			if ( in_array( $field->type, [ 'address', 'chainedselect', 'checkbox', 'consent', 'name' ], true ) ) {
-				$formatted_values += $value;
-			} else {
-				$formatted_values[ $values['id'] ] = $value;
-			}
+			$formatted_values = $this->add_value_to_array( $formatted_values, $field, $value );
 		}
 
 		return $formatted_values;

--- a/src/Mutations/UpdateDraftEntryEmailFieldValue.php
+++ b/src/Mutations/UpdateDraftEntryEmailFieldValue.php
@@ -10,6 +10,8 @@
 
 namespace WPGraphQLGravityForms\Mutations;
 
+use WPGraphQLGravityForms\Types\Input\EmailInput;
+
 /**
  * Class - UpdateDraftEntryEmailFieldValue
  */
@@ -35,7 +37,7 @@ class UpdateDraftEntryEmailFieldValue extends AbstractDraftEntryUpdater {
 	 */
 	protected function get_value_input_field() : array {
 		return [
-			'type'        => 'String',
+			'type'        => EmailInput::TYPE,
 			'description' => __( 'The form field value.', 'wp-graphql-gravity-forms' ),
 		];
 	}
@@ -43,11 +45,11 @@ class UpdateDraftEntryEmailFieldValue extends AbstractDraftEntryUpdater {
 	/**
 	 * Sanitizes the field values.
 	 *
-	 * @param string $value The field value.
+	 * @param array $value The field value.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	protected function prepare_field_value( string $value ) : string {
-		return $this->prepare_string_value( $value );
+	protected function prepare_field_value( array $value ) : array {
+		return $this->prepare_email_field_value( $value, $this->field );
 	}
 }

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -203,20 +203,13 @@ class UpdateEntry extends AbstractMutation {
 		foreach ( $field_values as $values ) {
 			$field = GFUtils::get_field_by_id( $this->form, $values['id'] );
 
-			$this->validate_field_value_type( $field, $values );
+			$value = $this->prepare_single_field_value( $values, $field );
 
-			$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'];
-
-			$value = $this->prepare_field_value_by_type( $value, $field );
-
+			// Validate the field value.
 			$this->validate_field_value( $this->form, $field, $value );
 
 			// Add values to array based on field type.
-			if ( in_array( $field->type, [ 'address', 'chainedselect', 'checkbox', 'consent', 'name' ], true ) ) {
-				$formatted_values += $value;
-			} else {
-				$formatted_values[ $values['id'] ] = $value;
-			}
+			$formatted_values = $this->add_value_to_array( $formatted_values, $field, $value );
 		}
 
 		return $formatted_values;

--- a/src/Types/Input/EmailInput.php
+++ b/src/Types/Input/EmailInput.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * GraphQL Input Type - EmailInput
+ * Input fields for a single checkbox.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.5.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Input;
+
+use WPGraphQLGravityForms\Interfaces\Hookable;
+use WPGraphQLGravityForms\Interfaces\InputType;
+
+/**
+ * Class - EmailInput
+ */
+class EmailInput implements Hookable, InputType {
+	/**
+	 * Type registered in WPGraphQL.
+	 */
+	const TYPE = 'EmailInput';
+
+	/**
+	 * Register hooks to WordPress.
+	 */
+	public function register_hooks() : void {
+		add_action( 'graphql_register_types', [ $this, 'register_input_type' ] );
+	}
+
+	/**
+	 * Register input type to GraphQL schema.
+	 */
+	public function register_input_type() : void {
+		register_graphql_input_type(
+			self::TYPE,
+			[
+				'description' => __( 'Input fields for a single checkbox.', 'wp-graphql-gravity-forms' ),
+				'fields'      => [
+					'value'             => [
+						'type'        => 'String',
+						'description' => __( 'Email input value', 'wp-graphql-gravity-forms' ),
+					],
+					'confirmationValue' => [
+						'type'        => 'String',
+						'description' => __( 'Email confirmation input value. Only used when email confirmation is enabled.', 'wp-graphql-gravity-forms' ),
+					],
+				],
+			]
+		);
+	}
+}

--- a/src/Types/Input/FieldValuesInput.php
+++ b/src/Types/Input/FieldValuesInput.php
@@ -54,6 +54,10 @@ class FieldValuesInput implements Hookable, InputType {
 						'type'        => [ 'list_of' => CheckboxInput::TYPE ],
 						'description' => __( 'The form field values for Checkbox fields', 'wp-graphql-gravity-forms' ),
 					],
+					'emailValues'         => [
+						'type'        => EmailInput::TYPE,
+						'description' => __( 'The form field values for Email fields.', 'wp-graphql-gravity-forms' ),
+					],
 					'listValues'          => [
 						'type'        => [ 'list_of' => ListInput::TYPE ],
 						'description' => __( 'The form field values for List fields', 'wp-graphql-gravity-forms' ),

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -135,6 +135,7 @@ final class WPGraphQLGravityForms {
 		$this->instances['address_input']              = new Input\AddressInput();
 		$this->instances['chained_select_input']       = new Input\ChainedSelectInput();
 		$this->instances['checkbox_input']             = new Input\CheckboxInput();
+		$this->instances['email_input']                = new Input\EmailInput();
 		$this->instances['list_input']                 = new Input\ListInput();
 		$this->instances['name_input']                 = new Input\NameInput();
 		$this->instances['entries_date_fiters_input']  = new Input\EntriesDateFiltersInput();

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -228,6 +228,7 @@ return array(
     'WPGraphQLGravityForms\\Types\\Input\\AddressInput' => $baseDir . '/src/Types/Input/AddressInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\ChainedSelectInput' => $baseDir . '/src/Types/Input/ChainedSelectInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\CheckboxInput' => $baseDir . '/src/Types/Input/CheckboxInput.php',
+    'WPGraphQLGravityForms\\Types\\Input\\EmailInput' => $baseDir . '/src/Types/Input/EmailInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\EntriesDateFiltersInput' => $baseDir . '/src/Types/Input/EntriesDateFiltersInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\EntriesFieldFiltersInput' => $baseDir . '/src/Types/Input/EntriesFieldFiltersInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\EntriesSortingInput' => $baseDir . '/src/Types/Input/EntriesSortingInput.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -243,6 +243,7 @@ class ComposerStaticInitbfbf9175b8255d015875c8ce55751c20
         'WPGraphQLGravityForms\\Types\\Input\\AddressInput' => __DIR__ . '/../..' . '/src/Types/Input/AddressInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\ChainedSelectInput' => __DIR__ . '/../..' . '/src/Types/Input/ChainedSelectInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\CheckboxInput' => __DIR__ . '/../..' . '/src/Types/Input/CheckboxInput.php',
+        'WPGraphQLGravityForms\\Types\\Input\\EmailInput' => __DIR__ . '/../..' . '/src/Types/Input/EmailInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\EntriesDateFiltersInput' => __DIR__ . '/../..' . '/src/Types/Input/EntriesDateFiltersInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\EntriesFieldFiltersInput' => __DIR__ . '/../..' . '/src/Types/Input/EntriesFieldFiltersInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\EntriesSortingInput' => __DIR__ . '/../..' . '/src/Types/Input/EntriesSortingInput.php',


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Email confirmation  was moved server-side in v0.4.0, but there was no way to input a confirmation value to the mutation. This PR changes all relevant mutations to take an `emailValues` input with a `value` and `confirmationValue` property.


Fixes: #90 


## Types of changes
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Feature (breaking): Support email confirmation on mutations.
## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
