### PR TITLE
fix: prevent PHP notice when no `entry_id` is returned in SubmitDraftEntry

### DIFF
--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -117,7 +117,7 @@ class SubmitDraftEntry extends AbstractMutation {
 			);
 			remove_filter( 'gform_field_validation', [ $this, 'disable_validation_for_unsupported_fields' ] );
 
-			if ( $result['entry_id'] ) {
+			if ( ! empty( $result['entry_id'] ) ) {
 				GFFormsModel::delete_draft_submission( $resume_token );
 				GFFormsModel::purge_expired_draft_submissions();
 			}


### PR DESCRIPTION
## Description
Fixes a PHP Notice when no `entry_id` is returned in `submitGravityFormsDraftEntry`.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Bug fix: Fix PHP Notice when no `entry_id` is returned in `submitGravityFormsDraftEntry`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
