### PR TITLE
Undeprecate `key` property on AddressInput and NameInput

### DIFF
--- a/src/Types/Field/FieldProperty/AddressInputProperty.php
+++ b/src/Types/Field/FieldProperty/AddressInputProperty.php
@@ -43,17 +43,10 @@ class AddressInputProperty implements Hookable, Type {
 					InputProperty\InputDefaultValueProperty::get(),
 					InputProperty\InputIdProperty::get(),
 					InputProperty\InputIsHiddenProperty::get(),
+					InputProperty\InputKeyProperty::get(),
 					InputProperty\InputLabelProperty::get(),
 					InputProperty\InputNameProperty::get(),
 					InputProperty\InputPlaceholderProperty::get(),
-					/**
-					 * Deprecated field properties.
-					 *
-					 * @since 0.2.0
-					 */
-
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			],
 		);

--- a/src/Types/Field/FieldProperty/NameInputProperty.php
+++ b/src/Types/Field/FieldProperty/NameInputProperty.php
@@ -43,6 +43,7 @@ class NameInputProperty implements Hookable, Type {
 					InputProperty\InputDefaultValueProperty::get(),
 					InputProperty\InputIdProperty::get(),
 					InputProperty\InputIsHiddenProperty::get(),
+					InputProperty\InputKeyProperty::get(),
 					InputProperty\InputLabelProperty::get(),
 					InputProperty\InputNameProperty::get(),
 					InputProperty\InputPlaceholderProperty::get(),
@@ -58,14 +59,6 @@ class NameInputProperty implements Hookable, Type {
 							'description' => __( 'Indicates whether the choice has a value, not just the text. This is only available for the Prefix field.', 'wp-graphql-gravity-forms' ),
 						],
 					],
-					/**
-					 * Deprecated field properties.
-					 *
-					 * @since 0.2.0
-					 */
-
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
 				),
 			],
 		);

--- a/tests/wpunit/AddressFieldTest.php
+++ b/tests/wpunit/AddressFieldTest.php
@@ -106,35 +106,36 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 							id
 							type
 							... on AddressField {
-							addressType
-							adminLabel
-							adminOnly
-							copyValuesOptionDefault
-							copyValuesOptionField
-							defaultCountry
-							defaultProvince
-							defaultState
-							description
-							descriptionPlacement
-							enableCopyValuesOption
-							errorMessage
-							id
-							inputs {
-								customLabel
-								defaultValue
+								addressType
+								adminLabel
+								adminOnly
+								copyValuesOptionDefault
+								copyValuesOptionField
+								defaultCountry
+								defaultProvince
+								defaultState
+								description
+								descriptionPlacement
+								enableCopyValuesOption
+								errorMessage
 								id
-								isHidden
+								inputs {
+									customLabel
+									defaultValue
+									id
+									isHidden
+									key
+									label
+									name
+									placeholder
+								}
+								isRequired
 								label
-								name
-								placeholder
-							}
-							isRequired
-							label
-							labelPlacement
-							size
-							subLabelPlacement
-							type
-							visibility
+								labelPlacement
+								size
+								subLabelPlacement
+								type
+								visibility
 							}
 						}
 						edges {
@@ -192,6 +193,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[0]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[0]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[0]['isHidden'],
+									'key'          => 'street',
 									'label'        => $form['fields'][0]->inputs[0]['label'],
 									'name'         => $form['fields'][0]->inputs[0]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[0]['placeholder'],
@@ -201,6 +203,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[1]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[1]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[1]['isHidden'],
+									'key' => 'lineTwo',
 									'label'        => $form['fields'][0]->inputs[1]['label'],
 									'name'         => $form['fields'][0]->inputs[1]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[1]['placeholder'],
@@ -210,6 +213,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[2]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[2]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[2]['isHidden'],
+									'key' => 'city',
 									'label'        => $form['fields'][0]->inputs[2]['label'],
 									'name'         => $form['fields'][0]->inputs[2]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[2]['placeholder'],
@@ -219,6 +223,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[3]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[3]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[3]['isHidden'],
+									'key' => 'state',
 									'label'        => $form['fields'][0]->inputs[3]['label'],
 									'name'         => $form['fields'][0]->inputs[3]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[3]['placeholder'],
@@ -228,6 +233,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[4]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[4]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[4]['isHidden'],
+									'key' => 'zip',
 									'label'        => $form['fields'][0]->inputs[4]['label'],
 									'name'         => $form['fields'][0]->inputs[4]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[4]['placeholder'],
@@ -237,6 +243,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 									'defaultValue' => $form['fields'][0]->inputs[5]['defaultValue'],
 									'id'           => $form['fields'][0]->inputs[5]['id'],
 									'isHidden'     => $form['fields'][0]->inputs[5]['isHidden'],
+									'key'          => 'country',
 									'label'        => $form['fields'][0]->inputs[5]['label'],
 									'name'         => $form['fields'][0]->inputs[5]['name'],
 									'placeholder'  => $form['fields'][0]->inputs[5]['placeholder'],


### PR DESCRIPTION
## Description
Although not part of the Gravity Forms API, the `key` property on `AddressInput` and `NameInput` is essential for for indicating which fieldValue corresponds to the subfields. This PR undeprecates the property.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Bugfix: Undeprecate `key` property on `AddressInput` and `NameInput` fields.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
