### PR TITLE
refactor: Refactor field properties to use AbstractProperty

### DIFF
--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -96,7 +96,7 @@ class AddressField extends AbstractField {
 					'description' => __( 'Indicates whether the copy values option can be used. This option allows users to skip filling out the field and use the same values as another. For example, if the mailing and billing address are the same.', 'wp-graphql-gravity-forms' ),
 				],
 				'inputs'                  => [
-					'type'        => [ 'list_of' => FieldProperty\AddressInputProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\AddressInputProperty::$type ],
 					'description' => __( 'An array containing the the individual properties for each element of the address field.', 'wp-graphql-gravity-forms' ),
 				],
 			],

--- a/src/Types/Field/ChainedSelectField.php
+++ b/src/Types/Field/ChainedSelectField.php
@@ -63,7 +63,7 @@ class ChainedSelectField extends AbstractField {
 			FieldProperty\VisibilityProperty::get(),
 			[
 				'choices'                    => [
-					'type'        => [ 'list_of' => FieldProperty\ChainedSelectChoiceProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\ChainedSelectChoiceProperty::$type ],
 					'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
 				],
 				'chainedSelectsAlignment'    => [
@@ -75,7 +75,7 @@ class ChainedSelectField extends AbstractField {
 					'description' => __( 'Whether inactive dropdowns should be hidden.', 'wp-graphql-gravity-forms' ),
 				],
 				'inputs'                     => [
-					'type'        => [ 'list_of' => FieldProperty\ChainedSelectInputProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\ChainedSelectInputProperty::$type ],
 					'description' => __( 'An array containing the the individual properties for each element of the Chained Select field.', 'wp-graphql-gravity-forms' ),
 				],
 			],

--- a/src/Types/Field/CheckboxField.php
+++ b/src/Types/Field/CheckboxField.php
@@ -64,7 +64,7 @@ class CheckboxField extends AbstractField {
 			FieldProperty\VisibilityProperty::get(),
 			[
 				'inputs' => [
-					'type'        => [ 'list_of' => FieldProperty\CheckboxInputProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\CheckboxInputProperty::$type ],
 					'description' => __( 'List of inputs. Checkboxes are treated as multi-input fields, since each checkbox item is stored separately.', 'wp-graphql-gravity-forms' ),
 				],
 			],

--- a/src/Types/Field/FieldProperty/AbstractProperty.php
+++ b/src/Types/Field/FieldProperty/AbstractProperty.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Abstract property type.
+ *
+ * @see https://docs.gravityforms.com/field-object/
+ * @see https://docs.gravityforms.com/gf_field/
+ *
+ * @package WPGraphQLGravityForms\Types\Field
+ * @since   0.5.0
+ */
+
+namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
+
+use WPGraphQLGravityForms\Interfaces\Hookable;
+use WPGraphQLGravityForms\Interfaces\Type;
+/**
+ * Class - AbstractProperty
+ */
+abstract class AbstractProperty implements Hookable, Type {
+	/**
+	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
+	 */
+	public static $type;
+
+	/**
+	 * Register hooks to WordPress.
+	 */
+	public function register_hooks() : void {
+		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	}
+
+	/**
+	 * Register Object type to GraphQL schema.
+	 */
+	public function register_type() : void {
+		register_graphql_object_type(
+			static::$type,
+			[
+				'description' => $this->get_type_description(),
+				'fields'      => $this->get_properties(),
+			]
+		);
+	}
+
+	/**
+	 * Sets the Field type description.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_type_description() : string;
+
+	/**
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_properties() : array;
+}

--- a/src/Types/Field/FieldProperty/AddressInputProperty.php
+++ b/src/Types/Field/FieldProperty/AddressInputProperty.php
@@ -9,46 +9,41 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\InputProperty;
-use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - AddressInputProperty
  */
-class AddressInputProperty implements Hookable, Type {
+class AddressInputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'AddressInputProperty';
+	public static $type = 'AddressInputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'An array containing the the individual properties for each element of the address field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'An array containing the the individual properties for each element of the address field.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputCustomLabelProperty::get(),
-					InputProperty\InputDefaultValueProperty::get(),
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputIsHiddenProperty::get(),
-					InputProperty\InputKeyProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					InputProperty\InputNameProperty::get(),
-					InputProperty\InputPlaceholderProperty::get(),
-				),
-			],
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputCustomLabelProperty::get(),
+			InputProperty\InputDefaultValueProperty::get(),
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputIsHiddenProperty::get(),
+			InputProperty\InputKeyProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			InputProperty\InputNameProperty::get(),
+			InputProperty\InputPlaceholderProperty::get(),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChainedSelectChoiceProperty.php
@@ -10,46 +10,42 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\ChoiceProperty;
 
 /**
  * Class - ChainedSelectChoiceProperty
  */
-class ChainedSelectChoiceProperty implements Hookable, Type {
+class ChainedSelectChoiceProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'ChainedSelectChoiceProperty';
+	public static $type = 'ChainedSelectChoiceProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
+	protected function get_properties() : array {
+		return array_merge(
+			ChoiceProperty\ChoiceIsSelectedProperty::get(),
+			ChoiceProperty\ChoiceTextProperty::get(),
+			ChoiceProperty\ChoiceValueProperty::get(),
 			[
-				'description' => __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					ChoiceProperty\ChoiceIsSelectedProperty::get(),
-					ChoiceProperty\ChoiceTextProperty::get(),
-					ChoiceProperty\ChoiceValueProperty::get(),
-					[
-						'choices' => [
-							'type'        => [ 'list_of' => self::TYPE ],
-							'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
-						],
-					],
-				),
-			]
+				'choices' => [
+					'type'        => [ 'list_of' => self::$type ],
+					'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
+				],
+			],
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/ChainedSelectInputProperty.php
+++ b/src/Types/Field/FieldProperty/ChainedSelectInputProperty.php
@@ -9,52 +9,48 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\InputProperty;
 use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - ChainedSelectInputProperty
  */
-class ChainedSelectInputProperty implements Hookable, Type {
+class ChainedSelectInputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'ChainedSelectInputProperty';
+	public static $type = 'ChainedSelectInputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'An array containing the the individual properties for each element of the address field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'An array containing the the individual properties for each element of the address field.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					/**
-					 * Deprecated field properties.
-					 *
-					 * @since 0.2.0
-					 */
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			/**
+			 * Deprecated field properties.
+			 *
+			 * @since 0.2.0
+			 */
 
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputIsHiddenProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputNameProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-				),
-			],
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputIsHiddenProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputNameProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/CheckboxInputProperty.php
+++ b/src/Types/Field/FieldProperty/CheckboxInputProperty.php
@@ -10,40 +10,36 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\InputProperty;
 
 /**
  * Class - CheckboxInputProperty
  */
-class CheckboxInputProperty implements Hookable, Type {
+class CheckboxInputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'CheckboxInputProperty';
+	public static $type = 'CheckboxInputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'An array containing the the individual properties for each element of the checkbox field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'An array containing the the individual properties for each element of the checkbox field.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					InputProperty\InputNameProperty::get(),
-				),
-			]
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			InputProperty\InputNameProperty::get(),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/ChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ChoiceProperty.php
@@ -11,39 +11,34 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
-
 /**
  * Class - ChoiceProperty
  */
-class ChoiceProperty implements Hookable, Type {
+class ChoiceProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'ChoiceProperty';
+	public static $type = 'ChoiceProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'Gravity Forms choice property.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'Gravity Forms choice property.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					ChoiceProperty\ChoiceIsSelectedProperty::get(),
-					ChoiceProperty\ChoiceTextProperty::get(),
-					ChoiceProperty\ChoiceValueProperty::get(),
-				),
-			]
+	protected function get_properties() : array {
+		return array_merge(
+			ChoiceProperty\ChoiceIsSelectedProperty::get(),
+			ChoiceProperty\ChoiceTextProperty::get(),
+			ChoiceProperty\ChoiceValueProperty::get(),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/ChoicesProperty.php
+++ b/src/Types/Field/FieldProperty/ChoicesProperty.php
@@ -26,7 +26,7 @@ class ChoicesProperty implements FieldProperty {
 	public static function get() : array {
 		return [
 			'choices' => [
-				'type'        => [ 'list_of' => ChoiceProperty::TYPE ],
+				'type'        => [ 'list_of' => ChoiceProperty::$type ],
 				'description' => __( 'Contains the available choices for the field. For instance, drop down items and checkbox items are configured with this property.', 'wp-graphql-gravity-forms' ),
 			],
 		];

--- a/src/Types/Field/FieldProperty/InputProperty.php
+++ b/src/Types/Field/FieldProperty/InputProperty.php
@@ -10,54 +10,50 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - InputProperty
  */
-class InputProperty implements Hookable, Type {
+class InputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'InputProperty';
+	public static $type = 'InputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'Gravity Forms input property.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputCustomLabelProperty::get(),
-					InputProperty\InputDefaultValueProperty::get(),
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					InputProperty\InputPlaceholderProperty::get(),
-					/**
-					 * Deprecated field properties.
-					 *
-					 * @since 0.2.0
-					 */
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputCustomLabelProperty::get(),
+			InputProperty\InputDefaultValueProperty::get(),
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			InputProperty\InputPlaceholderProperty::get(),
+			/**
+			 * Deprecated field properties.
+			 *
+			 * @since 0.2.0
+			 */
 
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputIsHiddenProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-					// translators: Gravity Forms Field input property.
-					Utils::deprecate_property( InputProperty\InputNameProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::TYPE ) ),
-				),
-			]
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputIsHiddenProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputKeyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field input property.
+			Utils::deprecate_property( InputProperty\InputNameProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/InputsProperty.php
+++ b/src/Types/Field/FieldProperty/InputsProperty.php
@@ -24,7 +24,7 @@ class InputsProperty implements FieldProperty {
 	public static function get() : array {
 		return [
 			'inputs' => [
-				'type'        => [ 'list_of' => InputProperty::TYPE ],
+				'type'        => [ 'list_of' => InputProperty::$type ],
 				'description' => __( 'An array containing the the individual properties for each element of the field.', 'wp-graphql-gravity-forms' ),
 			],
 		];

--- a/src/Types/Field/FieldProperty/ListChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/ListChoiceProperty.php
@@ -11,44 +11,39 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
-
 /**
  * Class - ListChoiceProperty
  */
-class ListChoiceProperty implements Hookable, Type {
+class ListChoiceProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'ListChoiceProperty';
+	public static $type = 'ListChoiceProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'List field column labels.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'List field column labels.', 'wp-graphql-gravity-forms' ),
-				'fields'      => [
-					'text'  => [
-						'type'        => 'String',
-						'description' => __( 'The text to be displayed in the column header. Required.', 'wp-graphql-gravity-forms' ),
-					],
-					'value' => [
-						'type'        => 'String',
-						'description' => __( 'The text to be displayed in the column header.', 'wp-graphql-gravity-forms' ),
-					],
-				],
-			]
-		);
+	protected function get_properties() : array {
+		return [
+			'text'  => [
+				'type'        => 'String',
+				'description' => __( 'The text to be displayed in the column header. Required.', 'wp-graphql-gravity-forms' ),
+			],
+			'value' => [
+				'type'        => 'String',
+				'description' => __( 'The text to be displayed in the column header.', 'wp-graphql-gravity-forms' ),
+			],
+		];
 	}
 }

--- a/src/Types/Field/FieldProperty/NameInputProperty.php
+++ b/src/Types/Field/FieldProperty/NameInputProperty.php
@@ -9,57 +9,52 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\InputProperty;
-use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - NameInputProperty
  */
-class NameInputProperty implements Hookable, Type {
+class NameInputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'NameInputProperty';
+	public static $type = 'NameInputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'An array containing the the individual properties for each element of the name field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputCustomLabelProperty::get(),
+			InputProperty\InputDefaultValueProperty::get(),
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputIsHiddenProperty::get(),
+			InputProperty\InputKeyProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			InputProperty\InputNameProperty::get(),
+			InputProperty\InputPlaceholderProperty::get(),
 			[
-				'description' => __( 'An array containing the the individual properties for each element of the name field.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputCustomLabelProperty::get(),
-					InputProperty\InputDefaultValueProperty::get(),
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputIsHiddenProperty::get(),
-					InputProperty\InputKeyProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					InputProperty\InputNameProperty::get(),
-					InputProperty\InputPlaceholderProperty::get(),
-					[
-						'choices' => [
-							'type'        => [ 'list_of' => ChoiceProperty::TYPE ],
-							'description' => __( 'This array only exists when the Prefix field is used. It holds the prefix options that display in the drop down. These have been chosen in the admin.', 'wp-graphql-gravity-forms' ),
-						],
-					],
-					[
-						'enableChoiceValue' => [
-							'type'        => 'Boolean',
-							'description' => __( 'Indicates whether the choice has a value, not just the text. This is only available for the Prefix field.', 'wp-graphql-gravity-forms' ),
-						],
-					],
-				),
+				'choices' => [
+					'type'        => [ 'list_of' => ChoiceProperty::$type ],
+					'description' => __( 'This array only exists when the Prefix field is used. It holds the prefix options that display in the drop down. These have been chosen in the admin.', 'wp-graphql-gravity-forms' ),
+				],
+			],
+			[
+				'enableChoiceValue' => [
+					'type'        => 'Boolean',
+					'description' => __( 'Indicates whether the choice has a value, not just the text. This is only available for the Prefix field.', 'wp-graphql-gravity-forms' ),
+				],
 			],
 		);
 	}

--- a/src/Types/Field/FieldProperty/PasswordInputProperty.php
+++ b/src/Types/Field/FieldProperty/PasswordInputProperty.php
@@ -13,42 +13,38 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\InputProperty;
 
 /**
  * Class - PasswordInputProperty
  */
-class PasswordInputProperty implements Hookable, Type {
+class PasswordInputProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'PasswordInputProperty';
+	public static $type = 'PasswordInputProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'An array containing the the individual properties for each element of the password field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
-			[
-				'description' => __( 'An array containing the the individual properties for each element of the password field.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					InputProperty\InputCustomLabelProperty::get(),
-					InputProperty\InputIdProperty::get(),
-					InputProperty\InputIsHiddenProperty::get(),
-					InputProperty\InputLabelProperty::get(),
-					InputProperty\InputPlaceholderProperty::get(),
-				),
-			]
+	protected function get_properties() : array {
+		return array_merge(
+			InputProperty\InputCustomLabelProperty::get(),
+			InputProperty\InputIdProperty::get(),
+			InputProperty\InputIsHiddenProperty::get(),
+			InputProperty\InputLabelProperty::get(),
+			InputProperty\InputPlaceholderProperty::get(),
 		);
 	}
 }

--- a/src/Types/Field/FieldProperty/RadioChoiceProperty.php
+++ b/src/Types/Field/FieldProperty/RadioChoiceProperty.php
@@ -9,45 +9,41 @@
 
 namespace WPGraphQLGravityForms\Types\Field\FieldProperty;
 
-use WPGraphQLGravityForms\Interfaces\Hookable;
-use WPGraphQLGravityForms\Interfaces\Type;
 use WPGraphQLGravityForms\Types\Field\FieldProperty\ChoiceProperty;
 
 /**
  * Class - RadioChoiceProperty
  */
-class RadioChoiceProperty implements Hookable, Type {
+class RadioChoiceProperty extends AbstractProperty {
 	/**
 	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
 	 */
-	const TYPE = 'RadioChoiceProperty';
+	public static $type = 'RadioChoiceProperty';
 
 	/**
-	 * Register hooks to WordPress.
+	 * Sets the field type description.
 	 */
-	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+	protected function get_type_description() : string {
+		return __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
-	 * Register Object type to GraphQL schema.
+	 * Gets the properties for the Field.
+	 *
+	 * @return array
 	 */
-	public function register_type() : void {
-		register_graphql_object_type(
-			self::TYPE,
+	protected function get_properties() : array {
+		return array_merge(
+			ChoiceProperty\ChoiceIsSelectedProperty::get(),
+			ChoiceProperty\ChoiceTextProperty::get(),
+			ChoiceProperty\ChoiceValueProperty::get(),
 			[
-				'description' => __( 'Gravity Forms Chained Select field choice property.', 'wp-graphql-gravity-forms' ),
-				'fields'      => array_merge(
-					ChoiceProperty\ChoiceIsSelectedProperty::get(),
-					ChoiceProperty\ChoiceTextProperty::get(),
-					ChoiceProperty\ChoiceValueProperty::get(),
-					[
-						'isOtherChoice' => [
-							'type'        => 'Boolean',
-							'description' => __( 'Indicates the radio button item is the “Other” choice.', 'wp-graphql-gravity-forms' ),
-						],
-					],
-				),
+				'isOtherChoice' => [
+					'type'        => 'Boolean',
+					'description' => __( 'Indicates the radio button item is the “Other” choice.', 'wp-graphql-gravity-forms' ),
+				],
 			],
 		);
 	}

--- a/src/Types/Field/ListField.php
+++ b/src/Types/Field/ListField.php
@@ -66,7 +66,7 @@ class ListField extends AbstractField {
 					'description' => __( 'The URL of the image to be used for the add row button.', 'wp-graphql-gravity-forms' ),
 				],
 				'choices'       => [
-					'type'        => [ 'list_of' => FieldProperty\ListChoiceProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\ListChoiceProperty::$type ],
 					'description' => __( 'The column labels. Only used when enableColumns is true.', 'wp-graphql-gravity-forms' ),
 				],
 				'deleteIconUrl' => [

--- a/src/Types/Field/NameField.php
+++ b/src/Types/Field/NameField.php
@@ -62,7 +62,7 @@ class NameField extends AbstractField {
 			FieldProperty\VisibilityProperty::get(),
 			[
 				'inputs'     => [
-					'type'        => [ 'list_of' => FieldProperty\NameInputProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\NameInputProperty::$type ],
 					'description' => __( 'An array containing the the individual properties for each element of the name field.', 'wp-graphql-gravity-forms' ),
 				],
 				'nameFormat' => [

--- a/src/Types/Field/PasswordField.php
+++ b/src/Types/Field/PasswordField.php
@@ -61,7 +61,7 @@ class PasswordField extends AbstractField {
 			FieldProperty\SubLabelPlacementProperty::get(),
 			[
 				'inputs'                  => [
-					'type'        => [ 'list_of' => FieldProperty\PasswordInputProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\PasswordInputProperty::$type ],
 					'description' => __( 'Individual properties for each element of the password field.', 'wp-graphql-gravity-forms' ),
 				],
 				'minPasswordStrength'     => [

--- a/src/Types/Field/RadioField.php
+++ b/src/Types/Field/RadioField.php
@@ -63,7 +63,7 @@ class RadioField extends AbstractField {
 			FieldProperty\VisibilityProperty::get(),
 			[
 				'choices'           => [
-					'type'        => [ 'list_of' => FieldProperty\RadioChoiceProperty::TYPE ],
+					'type'        => [ 'list_of' => FieldProperty\RadioChoiceProperty::$type ],
 					'description' => __( 'Choices used to populate the dropdown field. These can be nested multiple levels deep.', 'wp-graphql-gravity-forms' ),
 				],
 				'enableOtherChoice' => [

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -14,12 +14,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => '0.4.0.x-dev',
-    'version' => '0.4.0.9999999-dev',
+    'pretty_version' => 'dev-develop',
+    'version' => 'dev-develop',
     'aliases' => 
     array (
     ),
-    'reference' => '41c2eb4fbedfdb211792fb90d65c9fbbc2027a3e',
+    'reference' => '9b2ad5dfb07df0d2020a5d997a57a046de127781',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -245,12 +245,12 @@ private static $installed = array (
     ),
     'harness-software/wp-graphql-gravity-forms' => 
     array (
-      'pretty_version' => '0.4.0.x-dev',
-      'version' => '0.4.0.9999999-dev',
+      'pretty_version' => 'dev-develop',
+      'version' => 'dev-develop',
       'aliases' => 
       array (
       ),
-      'reference' => '41c2eb4fbedfdb211792fb90d65c9fbbc2027a3e',
+      'reference' => '9b2ad5dfb07df0d2020a5d997a57a046de127781',
     ),
     'hautelook/phpass' => 
     array (

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -116,6 +116,7 @@ return array(
     'WPGraphQLGravityForms\\Types\\Field\\ConsentField' => $baseDir . '/src/Types/Field/ConsentField.php',
     'WPGraphQLGravityForms\\Types\\Field\\DateField' => $baseDir . '/src/Types/Field/DateField.php',
     'WPGraphQLGravityForms\\Types\\Field\\EmailField' => $baseDir . '/src/Types/Field/EmailField.php',
+    'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AbstractProperty' => $baseDir . '/src/Types/Field/FieldProperty/AbstractProperty.php',
     'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AddressInputProperty' => $baseDir . '/src/Types/Field/FieldProperty/AddressInputProperty.php',
     'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AdminLabelProperty' => $baseDir . '/src/Types/Field/FieldProperty/AdminLabelProperty.php',
     'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AdminOnlyProperty' => $baseDir . '/src/Types/Field/FieldProperty/AdminOnlyProperty.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -131,6 +131,7 @@ class ComposerStaticInitbfbf9175b8255d015875c8ce55751c20
         'WPGraphQLGravityForms\\Types\\Field\\ConsentField' => __DIR__ . '/../..' . '/src/Types/Field/ConsentField.php',
         'WPGraphQLGravityForms\\Types\\Field\\DateField' => __DIR__ . '/../..' . '/src/Types/Field/DateField.php',
         'WPGraphQLGravityForms\\Types\\Field\\EmailField' => __DIR__ . '/../..' . '/src/Types/Field/EmailField.php',
+        'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AbstractProperty' => __DIR__ . '/../..' . '/src/Types/Field/FieldProperty/AbstractProperty.php',
         'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AddressInputProperty' => __DIR__ . '/../..' . '/src/Types/Field/FieldProperty/AddressInputProperty.php',
         'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AdminLabelProperty' => __DIR__ . '/../..' . '/src/Types/Field/FieldProperty/AdminLabelProperty.php',
         'WPGraphQLGravityForms\\Types\\Field\\FieldProperty\\AdminOnlyProperty' => __DIR__ . '/../..' . '/src/Types/Field/FieldProperty/AdminOnlyProperty.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => '0.4.0.x-dev',
-    'version' => '0.4.0.9999999-dev',
+    'pretty_version' => 'dev-develop',
+    'version' => 'dev-develop',
     'aliases' => 
     array (
     ),
-    'reference' => '41c2eb4fbedfdb211792fb90d65c9fbbc2027a3e',
+    'reference' => '9b2ad5dfb07df0d2020a5d997a57a046de127781',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -232,12 +232,12 @@
     ),
     'harness-software/wp-graphql-gravity-forms' => 
     array (
-      'pretty_version' => '0.4.0.x-dev',
-      'version' => '0.4.0.9999999-dev',
+      'pretty_version' => 'dev-develop',
+      'version' => 'dev-develop',
       'aliases' => 
       array (
       ),
-      'reference' => '41c2eb4fbedfdb211792fb90d65c9fbbc2027a3e',
+      'reference' => '9b2ad5dfb07df0d2020a5d997a57a046de127781',
     ),
     'hautelook/phpass' => 
     array (


### PR DESCRIPTION
## Description
Refactors `FieldProperty` types to use AbstractProperty.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- Housekeeping: Refactors `FieldProperty` types to use AbstractProperty.

<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
