### PR TITLE
fix: use $field->id to add_value_to_array()

### DIFF
--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -190,7 +190,7 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			return $values + $value_to_add;
 		}
 
-		$values[ $values['id'] ] = $value_to_add;
+		$values[ $field->id ] = $value_to_add;
 		return $values;
 	}
 


### PR DESCRIPTION
## Description
This PR fixes a bug in the add_value_to_array() refactor, where `$values['id']` should have been `$field->id`.
