### PR TITLE
fix: Draft submission edge cases.

### DIFF
--- a/src/Mutations/AbstractDraftEntryUpdater.php
+++ b/src/Mutations/AbstractDraftEntryUpdater.php
@@ -181,7 +181,7 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 				$this->submission['page_number'] ?? 1, // @TODO: Maybe get from request.
 				$this->submission['files'] ?? [],
 				$this->submission['gform_unique_id'] ?? null,
-				$this->submission['partial_entry']['ip'] ?? null,
+				$this->submission['partial_entry']['ip'] ?? '',
 				$this->submission['partial_entry']['source_url'] ?? '',
 				$resume_token
 			);

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -190,7 +190,7 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			return $values + $value_to_add;
 		}
 
-		$values[ $values['id'] ] = $value_to_add;
+		$values[ $field->id ] = $value_to_add;
 		return $values;
 	}
 


### PR DESCRIPTION
## Description
This PR fixes two bugs with draft submissions.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Bugfix: check for resumeToken before entryId, in the (rare) case that both are returned.
- Bugfix: ensure unset `$ip` is set to an empty string instead of `null`.