### PR TITLE
fix: check for resumeToken before entryId and set $ip to ''

### DIFF
--- a/src/Mutations/AbstractDraftEntryUpdater.php
+++ b/src/Mutations/AbstractDraftEntryUpdater.php
@@ -181,7 +181,7 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 				$this->submission['page_number'] ?? 1, // @TODO: Maybe get from request.
 				$this->submission['files'] ?? [],
 				$this->submission['gform_unique_id'] ?? null,
-				$this->submission['partial_entry']['ip'] ?? null,
+				$this->submission['partial_entry']['ip'] ?? '',
 				$this->submission['partial_entry']['source_url'] ?? '',
 				$resume_token
 			);


### PR DESCRIPTION
## Description
This PR fixes two bugs with draft submissions.

## Types of changes
- Bugfix: check for `resumeToken` before `entryId`, in the (rare) case that both are returned.
- Bugfix: ensure unset `$ip` is set to an empty string instead of `null`.