### PR TITLE
Cherry-picking bugfixes

### DIFF
--- a/src/Mutations/AbstractDraftEntryUpdater.php
+++ b/src/Mutations/AbstractDraftEntryUpdater.php
@@ -129,10 +129,10 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 
 			$this->submission = GFUtils::get_draft_submission( $resume_token );
 
-			$form = GFUtils::get_form( $this->submission['partial_entry']['form_id'] );
+			$this->form = GFUtils::get_form( $this->submission['partial_entry']['form_id'] );
 
 			$field_id    = absint( $input['fieldId'] );
-			$this->field = GFUtils::get_field_by_id( $form, $field_id );
+			$this->field = GFUtils::get_field_by_id( $this->form, $field_id );
 			if ( $this->field->type !== static::$gf_type ) {
 				throw new UserError(
 					sprintf(
@@ -150,7 +150,7 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 			}
 			$this->value = $this->prepare_field_value( $input['value'] );
 			// Validate the field.
-			$this->field->validate( $this->value, $form );
+			$this->field->validate( $this->value, $this->form );
 			if ( $this->field->failed_validation ) {
 				return [
 					'resumeToken' => $resume_token,
@@ -175,7 +175,7 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 			$this->submission['field_values'] = array_replace( $this->submission['field_values'] ?? [], $this->rename_keys_for_field_values( $value_array ) );
 
 			$resume_token = GFUtils::save_draft_submission(
-				$form,
+				$this->form,
 				$this->submission['partial_entry'],
 				$this->submission['field_values'],
 				$this->submission['page_number'] ?? 1, // @TODO: Maybe get from request.

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -630,7 +630,15 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			case 'post_content':
 				return $this->prepare_post_content_field_value( $value );
 			case 'signature':
-				return $this->prepare_signature_field_value( $value, $prev_value );
+				$prepared_value = $this->prepare_signature_field_value( $value, $prev_value );
+
+				// Save values to $_POST for GF validation.
+				if ( ! empty( $prepared_value ) ) {
+					$_POST[ 'input_' . $field->formId . '_' . $field->id . '_signature_filname' ] = $prepared_value;
+					$_POST[ 'input_' . $field->formId . '_' . $field->id . '_valid' ]             = true;
+				}
+
+				return $prepared_value;
 			case 'website':
 				return $this->prepare_website_field_value( $value );
 			case 'date':

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -224,41 +224,38 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	 * @throws UserError .
 	 */
 	protected function validate_field_value_type( GF_Field $field, array $values ) : void {
+		// Stores the name of the necessary field value type if it is missing from the mutation.
+		$value_type_name = false;
+
 		switch ( $field->type ) {
 			case 'address':
 				if ( ! isset( $values['addressValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `addressValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'addressValues';
 				}
 				break;
 			case 'chainedselect':
 				if ( ! isset( $values['chainedSelectValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `chainedSelectValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'chainedSelectValues';
 				}
 				break;
 			case 'checkbox':
 				if ( ! isset( $values['checkboxValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `checkboxValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'checkboxValues';
 				}
 				break;
 			case 'email':
 				if ( ! isset( $values['emailValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `emailValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'emailValues';
 				}
 				break;
 			case 'list':
 				if ( ! isset( $values['listValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `listValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'listValues';
 				}
 				break;
 			case 'name':
 				if ( ! isset( $values['nameValues'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `nameValues`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'nameValues';
 				}
 				break;
 			case 'multiselect':
@@ -266,16 +263,28 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			case 'post_custom':
 			case 'post_tags':
 				if ( ! isset( $values['values'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `values`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'values';
 				}
 				break;
 			default:
 				if ( ! isset( $values['value'] ) ) {
-					// translators: Gravity Forms field id.
-					throw new UserError( sprintf( __( 'Mutation not processed. Field %s requires the use of `value`.', 'wp-graphql-gravity-forms' ), $field->id ) );
+					$value_type_name = 'value';
 				}
 				break;
+		}
+
+		/**
+		 * Filter to set a custom valid fieldValue input type.
+		 *
+		 * @param string|false   $value_type_name The name of the missing input type. False if valid key exists.
+		 * @param GF_Field $field The gravity forms field.
+		 * @param array    $values the FieldValues input array.
+		 */
+		$value_type_name = apply_filters( 'wp_graphql_gf_field_value_type', $value_type_name, $field, $values );
+
+		if ( false !== $value_type_name ) {
+			// translators: Gravity Forms field id.
+			throw new UserError( sprintf( __( 'Mutation not processed. Field %1$s requires the use of `%2$s`.', 'wp-graphql-gravity-forms' ), $field->id, $value_type_name ) );
 		}
 	}
 

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -163,9 +163,19 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	public function prepare_single_field_value( array $values, GF_Field $field, $prev_value = null ) {
 		$this->validate_field_value_type( $field, $values );
 
-		$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['emailValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'];
+		$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['emailValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'] ?? null;
 
 		$value = $this->prepare_field_value_by_type( $value, $field, $prev_value );
+
+		/**
+		 * Filter to prepare the fieldValue for submissions to Gravity Forms.
+		 *
+		 * @param mixed $value the formatted value to be added to the GF submission object.
+		 * @param array $input_values the unformatted input values.
+		 * @param GF_Field $field .
+		 * @param mixed $prev_value The previous submission value, if exists.
+		 */
+		$value = apply_filters( 'wp_graphql_gf_prepare_field_value', $value, $values, $field, $prev_value );
 
 		return $value;
 	}
@@ -634,8 +644,9 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			case 'textarea':
 			case 'text':
 			case 'time':
-			default:
 				return $this->prepare_string_value( $value );
+			default:
+				return null;
 		}
 	}
 }

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -157,14 +157,15 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	 *
 	 * @param array    $values input values.
 	 * @param GF_Field $field .
+	 * @param mixed    $prev_value Optional.
 	 * @return mixed
 	 */
-	public function prepare_single_field_value( array $values, GF_Field $field ) {
+	public function prepare_single_field_value( array $values, GF_Field $field, $prev_value = null ) {
 		$this->validate_field_value_type( $field, $values );
 
 		$value = $values['addressValues'] ?? $values['chainedSelectValues'] ?? $values['checkboxValues'] ?? $values['emailValues'] ?? $values['listValues'] ?? $values['nameValues'] ?? $values['values'] ?? $values['value'];
 
-		$value = $this->prepare_field_value_by_type( $value, $field );
+		$value = $this->prepare_field_value_by_type( $value, $field, $prev_value );
 
 		return $value;
 	}
@@ -579,15 +580,15 @@ abstract class AbstractMutation implements Hookable, Mutation {
 		return strlen( $signature_decoded ) > wp_max_upload_size();
 	}
 
-
 	/**
 	 * Prepares the field value based on the field type.
 	 *
 	 * @param mixed    $value .
 	 * @param GF_Field $field .
+	 * @param mixed    $prev_value .
 	 * @return mixed
 	 */
-	public function prepare_field_value_by_type( $value, GF_Field $field ) {
+	public function prepare_field_value_by_type( $value, GF_Field $field, $prev_value = null ) {
 		switch ( $field->type ) {
 			case 'address':
 				return $this->prepare_address_field_value( $value, $field );
@@ -610,7 +611,7 @@ abstract class AbstractMutation implements Hookable, Mutation {
 			case 'post_content':
 				return $this->prepare_post_content_field_value( $value );
 			case 'signature':
-				return $this->prepare_signature_field_value( $value );
+				return $this->prepare_signature_field_value( $value, $prev_value );
 			case 'website':
 				return $this->prepare_website_field_value( $value );
 			case 'date':

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -41,7 +41,6 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	 */
 	protected $form;
 
-
 	/**
 	 * Register hooks to WordPress.
 	 */

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -35,6 +35,14 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	protected $errors;
 
 	/**
+	 * The form object.
+	 *
+	 * @var array
+	 */
+	protected $form;
+
+
+	/**
 	 * Register hooks to WordPress.
 	 */
 	public function register_hooks() : void {
@@ -208,14 +216,22 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	/**
 	 * Validates the Gravity Forms field value.
 	 *
-	 * @param array    $form .
 	 * @param GF_Field $field .
 	 * @param mixed    $value .
+	 * @param mixed    $deprecated As of 0.6.2.
 	 *
 	 * @return mixed
 	 */
-	protected function validate_field_value( array $form, GF_Field $field, $value ) {
-		$field->validate( $value, $form );
+	protected function validate_field_value( $field, $value, $deprecated = null ) {
+		if ( ! empty( $deprecated ) ) {
+			_doing_it_wrong( __FUNCTION__, 'This function no longer takes $form as its first argument.', '0.6.2' );
+
+			// Reassign variables to match expected syntax.
+			$field = $value;
+			$value = $deprecated;
+		}
+
+		$field->validate( $value, $this->form );
 		if ( $field->failed_validation ) {
 			$this->errors[] = [
 				'id'      => $field->id,

--- a/src/Mutations/CreateDraftEntry.php
+++ b/src/Mutations/CreateDraftEntry.php
@@ -82,19 +82,19 @@ class CreateDraftEntry extends AbstractMutation {
 		return function( $input, AppContext $context, ResolveInfo $info ) : array {
 			$this->check_required_inputs( $input );
 
-			$form_id = absint( $input['formId'] );
-			$form    = GFUtils::get_form( $form_id );
+			$form_id    = absint( $input['formId'] );
+			$this->form = GFUtils::get_form( $form_id );
 
 			$source_url  = esc_url_raw( Utils::truncate( $_SERVER['HTTP_REFERER'] ?? '', 250 ) );
 			$page_number = isset( $input['pageNumber'] ) ? absint( $input['pageNumber'] ) : 1;
 
-			$ip = empty( $form['personalData']['preventIP'] ) ? GFUtils::get_ip( $input['ip'] ?? '' ) : '';
+			$ip = empty( $this->form['personalData']['preventIP'] ) ? GFUtils::get_ip( $input['ip'] ?? '' ) : '';
 
 			// Get existing entry if `fromEntryId` is set, otherwise create new draft entry.
-			$entry = isset( $input['fromEntryId'] ) ? GFUtils::get_entry( $input['fromEntryId'] ) : $this->get_draft_entry_data( $form, $ip, $source_url );
+			$entry = isset( $input['fromEntryId'] ) ? GFUtils::get_entry( $input['fromEntryId'] ) : $this->get_draft_entry_data( $this->form, $ip, $source_url );
 
 			$resume_token = GFUtils::save_draft_submission(
-				$form,
+				$this->form,
 				$entry,
 				null,
 				$page_number,
@@ -106,7 +106,7 @@ class CreateDraftEntry extends AbstractMutation {
 
 			return [
 				'resumeToken' => $resume_token,
-				'resumeUrl'   => GFUtils::get_resume_url( $source_url, $resume_token, $form ),
+				'resumeUrl'   => GFUtils::get_resume_url( $source_url, $resume_token, $this->form ),
 			];
 		};
 	}

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -105,9 +105,9 @@ class SubmitDraftEntry extends AbstractMutation {
 			$submission   = GFUtils::get_draft_submission( $resume_token );
 			$form_id      = $submission['partial_entry']['form_id'];
 
-			$form = GFUtils::get_form( $form_id );
+			$this->form = GFUtils::get_form( $form_id );
 
-			$submission['page_number'] = GFUtils::get_last_form_page( $form );
+			$submission['page_number'] = GFUtils::get_last_form_page( $this->form );
 
 			add_filter( 'gform_field_validation', [ $this, 'disable_validation_for_unsupported_fields' ], 10, 4 );
 			$result = GFUtils::submit_form(

--- a/src/Mutations/SubmitForm.php
+++ b/src/Mutations/SubmitForm.php
@@ -47,13 +47,6 @@ class SubmitForm extends AbstractMutation {
 	 */
 	private $draft_entry_data_manipulator;
 
-	/**
-	 * The Gravity Forms form object.
-	 *
-	 * @var array
-	 */
-	private $form;
-
 
 	/**
 	 * Constructor

--- a/src/Mutations/UpdateDraftEntry.php
+++ b/src/Mutations/UpdateDraftEntry.php
@@ -142,7 +142,7 @@ class UpdateDraftEntry extends AbstractMutation {
 
 			$this->form = GFUtils::get_form( $this->submission['partial_entry']['form_id'] );
 
-			$values = $this->prepare_field_values( $input['fieldValues'] );
+			$values = $this->prepare_field_values( $input['fieldValues'], $this->submission['partial_entry'] );
 			if ( ! empty( $this->errors ) ) {
 				return [ 'errors' => $this->errors ];
 			}
@@ -178,15 +178,18 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * Converts the provided field values into a format that Gravity Forms can understand.
 	 *
 	 * @param array $field_values .
+	 * @param array $entry .
 	 * @return array
 	 */
-	private function prepare_field_values( array $field_values ) : array {
+	private function prepare_field_values( array $field_values, array $entry ) : array {
 		$formatted_values = [];
 
 		foreach ( $field_values as $values ) {
 			$field = GFUtils::get_field_by_id( $this->form, $values['id'] );
 
-			$value = $this->prepare_single_field_value( $values, $field );
+			$prev_value = $entry[ $values['id'] ] ?? null;
+
+			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
 
 			// Validate the field value.
 			$this->validate_field_value( $this->form, $field, $value );

--- a/src/Mutations/UpdateDraftEntry.php
+++ b/src/Mutations/UpdateDraftEntry.php
@@ -45,13 +45,6 @@ class UpdateDraftEntry extends AbstractMutation {
 	private $submission = [];
 
 	/**
-	 * The Gravity Forms Form object.
-	 *
-	 * @var array
-	 */
-	private $form;
-
-	/**
 	 * Gravity Forms field validation errors.
 	 *
 	 * @var array
@@ -192,7 +185,7 @@ class UpdateDraftEntry extends AbstractMutation {
 			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
 
 			// Validate the field value.
-			$this->validate_field_value( $this->form, $field, $value );
+			$this->validate_field_value( $field, $value );
 
 			// Add field values to submitted values.
 			$this->submission['submitted_values'][ $field->id ] = $value;

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -182,7 +182,8 @@ class UpdateEntry extends AbstractMutation {
 				],
 				fn( $property ) => (bool) strlen( $property )
 			);
-			$field_values     = $this->prepare_field_values( $input['fieldValues'] );
+
+			$field_values = $this->prepare_field_values( $input['fieldValues'], $entry );
 
 			return array_replace(
 				$entry,
@@ -195,15 +196,18 @@ class UpdateEntry extends AbstractMutation {
 	 * Converts the provided field values into a format that Gravity Forms can understand.
 	 *
 	 * @param array $field_values .
+	 * @param array $entry .
 	 * @return array
 	 */
-	private function prepare_field_values( array $field_values ) : array {
+	private function prepare_field_values( array $field_values, array $entry ) : array {
 		$formatted_values = [];
 
 		foreach ( $field_values as $values ) {
 			$field = GFUtils::get_field_by_id( $this->form, $values['id'] );
 
-			$value = $this->prepare_single_field_value( $values, $field );
+			$prev_value = $entry[ $values['id'] ] ?? null;
+
+			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
 
 			// Validate the field value.
 			$this->validate_field_value( $this->form, $field, $value );

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -39,13 +39,6 @@ class UpdateEntry extends AbstractMutation {
 	private $entry_data_manipulator;
 
 	/**
-	 * The Gravity Forms Form object.
-	 *
-	 * @var array
-	 */
-	private $form;
-
-	/**
 	 * Gravity Forms field validation errors.
 	 *
 	 * @var array
@@ -210,7 +203,7 @@ class UpdateEntry extends AbstractMutation {
 			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
 
 			// Validate the field value.
-			$this->validate_field_value( $this->form, $field, $value );
+			$this->validate_field_value( $field, $value );
 
 			// Add values to array based on field type.
 			$formatted_values = $this->add_value_to_array( $formatted_values, $field, $value );

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -10,6 +10,7 @@
 
 namespace WPGraphQLGravityForms\Mutations;
 
+use GFFormsModel;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -209,6 +210,8 @@ class UpdateEntry extends AbstractMutation {
 			$formatted_values = $this->add_value_to_array( $formatted_values, $field, $value );
 		}
 
+		$formatted_values = $this->prepare_field_values_for_save( $formatted_values, $entry );
+
 		return $formatted_values;
 	}
 
@@ -228,5 +231,24 @@ class UpdateEntry extends AbstractMutation {
 		if ( empty( $input['fieldValues'] ) ) {
 			throw new UserError( __( 'Mutation not processed. Field values not provided.', 'wp-graphql-gravity-forms' ) );
 		}
+	}
+
+	/**
+	 * Prepares field values before saving it to the entry.
+	 *
+	 * @param array $values the entry values.
+	 * @param array $entry the existing entry.
+	 * @return array
+	 */
+	public function prepare_field_values_for_save( array $values, array $entry ) : array {
+		foreach ( $values as $id => &$value ) {
+			$input_name = 'input_' . str_replace( '.', '_', $id );
+			$field_id   = strtok( $id, '.' );
+			$field      = GFUtils::get_field_by_id( $this->form, (int) $field_id );
+
+			$value = GFFormsModel::prepare_value( $this->form, $field, $value, $input_name, $entry['id'], $entry );
+		}
+
+		return $values;
 	}
 }

--- a/src/Settings/WPGraphQLSettings.php
+++ b/src/Settings/WPGraphQLSettings.php
@@ -8,8 +8,9 @@
 
 namespace WPGraphQLGravityForms\Settings;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQLGravityForms\Interfaces\Hookable;
-
 /**
  * WPGraphQL Settings.
  */
@@ -22,18 +23,24 @@ class WPGraphQLSettings implements Hookable {
 	 * @see: https://www.wpgraphql.com/filters/graphql_connection_max_query_amount/
 	 */
 	public function register_hooks() : void {
-		add_action( 'graphql_connection_max_query_amount', [ $this, 'set_max_query_amount' ], 11 );
+		add_filter( 'graphql_connection_max_query_amount', [ $this, 'set_max_query_amount' ], 11, 5 );
 	}
 
 	/**
 	 * Bump max query amount to account for forms with many fields.
 	 *
-	 * @param  int $max_query_amount Max query amount.
+	 * @param int         $max_query_amount Max query amount.
+	 * @param mixed       $source     source passed down from the resolve tree.
+	 * @param array       $args       array of arguments input in the field as part of the GraphQL query.
+	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree.
+	 * @param ResolveInfo $info       Info about fields passed down the resolve tree.
 	 *
 	 * @return int Max query amount, possibly bumped.
 	 */
-	public function set_max_query_amount( $max_query_amount ) : int {
-		// Original max amount or 600 - whichever is higher.
-		return (int) max( $max_query_amount, 600 );
+	public function set_max_query_amount( int $max_query_amount, $source, array $args, AppContext $context, ResolveInfo $info ) : int {
+		if ( 'formFields' === $info->fieldName ) {
+			return (int) max( $max_query_amount, 600 );
+		}
+		return $max_query_amount;
 	}
 }

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -42,6 +42,8 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
+    private $vendorDir;
+
     // PSR-4
     private $prefixLengthsPsr4 = array();
     private $prefixDirsPsr4 = array();
@@ -56,6 +58,13 @@ class ClassLoader
     private $classMapAuthoritative = false;
     private $missingClasses = array();
     private $apcuPrefix;
+
+    private static $registeredLoaders = array();
+
+    public function __construct($vendorDir = null)
+    {
+        $this->vendorDir = $vendorDir;
+    }
 
     public function getPrefixes()
     {
@@ -300,6 +309,17 @@ class ClassLoader
     public function register($prepend = false)
     {
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+
+        if (null === $this->vendorDir) {
+            return;
+        }
+
+        if ($prepend) {
+            self::$registeredLoaders = array($this->vendorDir => $this) + self::$registeredLoaders;
+        } else {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+            self::$registeredLoaders[$this->vendorDir] = $this;
+        }
     }
 
     /**
@@ -308,6 +328,10 @@ class ClassLoader
     public function unregister()
     {
         spl_autoload_unregister(array($this, 'loadClass'));
+
+        if (null !== $this->vendorDir) {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+        }
     }
 
     /**
@@ -365,6 +389,16 @@ class ClassLoader
         }
 
         return $file;
+    }
+
+    /**
+     * Returns the currently registered loaders indexed by their corresponding vendor directories.
+     *
+     * @return self[]
+     */
+    public static function getRegisteredLoaders()
+    {
+        return self::$registeredLoaders;
     }
 
     private function findFileWithExtension($class, $ext)

--- a/vendor/composer/autoload_real.php
+++ b/vendor/composer/autoload_real.php
@@ -25,7 +25,7 @@ class ComposerAutoloaderInitbfbf9175b8255d015875c8ce55751c20
         require __DIR__ . '/platform_check.php';
 
         spl_autoload_register(array('ComposerAutoloaderInitbfbf9175b8255d015875c8ce55751c20', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(\dirname(__FILE__)));
         spl_autoload_unregister(array('ComposerAutoloaderInitbfbf9175b8255d015875c8ce55751c20', 'loadClassLoader'));
 
         $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());


### PR DESCRIPTION
## Description
Backporting various bugfixes.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: `updateGravityFormsEntry` mutation now correctly saves complex field values.
- fix: Pass previous value to `SignatureField`, so it can be deleted correctly.
- fix: Correctly set `graphql_connection_max_query_amount` to a minimum of 600.
- fix: `AbstractMutation::prepare_field_value_by_type()` no longer defaults to a string value`. A new filter `wp_graphql_gf_prepare_field_value` can be used for preparing values for custom GF fields.
- fix: Signature fields now validate correctly.
- dev: Add `wp_graphql_field_value_type` filter for setting a custom valid `FieldValueInput` type. 
- dev: Mutations now use `$this->form` consistently. As a result the arguments for `AbstractMutation::validate_field_value()` have changed.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
