### PR TITLE
Release/0.6.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.6.2.2 - Hotfix
+- Fixes `submitGravityFormsForms` not saving signature field value after v0.6.2.1.
+
 ## v0.6.2.1 - Hotfix
 - Fixes `updateGravityFormsEntry` not saving signature field value.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Project Status: Active.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 ![Packagist License](https://img.shields.io/packagist/l/harness-software/wp-graphql-gravity-forms?color=green)
 ![Packagist Version](https://img.shields.io/packagist/v/harness-software/wp-graphql-gravity-forms?label=stable)
-![GitHub commits since latest release (by SemVer)](https://img.shields.io/github/commits-since/harness-software/wp-graphql-gravity-forms/0.6.2.1)
+![GitHub commits since latest release (by SemVer)](https://img.shields.io/github/commits-since/harness-software/wp-graphql-gravity-forms/0.6.2.2)
 ![GitHub forks](https://img.shields.io/github/forks/harness-software/wp-graphql-gravity-forms?style=social)
 ![GitHub Repo stars](https://img.shields.io/github/stars/harness-software/wp-graphql-gravity-forms?style=social)
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 5.7.2
 Requires PHP: 7.4
 Requires Gravity Forms: 2.4.0+
 Requires WPGraphQL: 1.0.0+
-Stable tag: 0.6.2.1
+Stable tag: 0.6.2.2
 Maintained at: https://github.com/harness-software/wp-graphql-gravity-forms
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -649,7 +649,6 @@ abstract class AbstractMutation implements Hookable, Mutation {
 
 				// Save values to $_POST for GF validation.
 				if ( ! empty( $prepared_value ) ) {
-					$_POST[ 'input_' . $field->id ] = $prepared_value;
 					$_POST[ 'input_' . $field->formId . '_' . $field->id . '_signature_filname' ] = $prepared_value;
 					$_POST[ 'input_' . $field->formId . '_' . $field->id . '_valid' ]             = true;
 				}

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -202,6 +202,10 @@ class UpdateEntry extends AbstractMutation {
 			$prev_value = $entry[ $values['id'] ] ?? null;
 
 			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
+			// Signature field requires $_POST['input_{#}'] on update.
+			if ( 'signature' === $field->type ) {
+				$_POST[ 'input_' . $field->id ] = $value;
+			}
 
 			// Validate the field value.
 			$this->validate_field_value( $field, $value );

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -202,6 +202,7 @@ class UpdateEntry extends AbstractMutation {
 			$prev_value = $entry[ $values['id'] ] ?? null;
 
 			$value = $this->prepare_single_field_value( $values, $field, $prev_value );
+
 			// Signature field requires $_POST['input_{#}'] on update.
 			if ( 'signature' === $field->type ) {
 				$_POST[ 'input_' . $field->id ] = $value;

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -6,7 +6,7 @@
  * Description: Adds Gravity Forms functionality to the WPGraphQL schema.
  * Author: Harness Software
  * Author URI: https://www.harnessup.com
- * Version: 0.6.2.1
+ * Version: 0.6.2.2
  * Text Domain: wp-graphql-gravity-forms
  * Domain Path: /languages
  * Requires at least: 5.4.1


### PR DESCRIPTION
## Description
Fixes `submitGravityFormsForms` not saving signature field value after v0.6.2.1.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: only set Signature $_POST[ 'input_{#}' ] for update mutations.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->