### PR TITLE
Post image field mutations

### DIFF
--- a/src/Mutations/SubmitForm.php
+++ b/src/Mutations/SubmitForm.php
@@ -160,6 +160,9 @@ class SubmitForm extends AbstractMutation {
 			$created_by    = isset( $input['createdBy'] ) ? absint( $input['createdBy'] ) : null;
 			$source_url    = esc_url_raw( Utils::truncate( $_SERVER['HTTP_REFERER'] ?? '', 250 ) );
 
+			// Initialize $_FILES with fileupload inputs.
+			$this->initialize_files();
+
 			$field_values = $this->get_field_values( $input['fieldValues'] );
 
 			add_filter( 'gform_field_validation', [ $this, 'disable_validation_for_unsupported_fields' ], 10, 4 );

--- a/src/Types/Field/FieldProperty/ValueProperty/PostImageFieldValueProperty.php
+++ b/src/Types/Field/FieldProperty/ValueProperty/PostImageFieldValueProperty.php
@@ -57,10 +57,11 @@ class PostImageFieldValueProperty extends AbstractValueProperty {
 		$value = array_pad( explode( '|:|', $entry[ $field->id ] ), 4, false );
 
 		return [
-			'url'         => $value[0] ?: null,
-			'title'       => $value[1] ?: null,
+			'altText'     => $value[4] ?: null,
 			'caption'     => $value[2] ?: null,
 			'description' => $value[3] ?: null,
+			'title'       => $value[1] ?: null,
+			'url'         => $value[0] ?: null,
 		];
 	}
 }

--- a/src/Types/Field/FieldProperty/ValueProperty/PostImageValueProperty.php
+++ b/src/Types/Field/FieldProperty/ValueProperty/PostImageValueProperty.php
@@ -36,6 +36,10 @@ class PostImageValueProperty extends AbstractObject {
 	 */
 	public function get_type_fields(): array {
 		return [
+			'altText'     => [
+				'type'        => 'String',
+				'description' => __( 'The image alt text.', 'wp-graphql-gravity-forms' ),
+			],
 			'caption'     => [
 				'type'        => 'String',
 				'description' => __( 'The image caption.', 'wp-graphql-gravity-forms' ),

--- a/src/Types/Field/FieldValue/PostImageFieldValue.php
+++ b/src/Types/Field/FieldValue/PostImageFieldValue.php
@@ -37,6 +37,10 @@ class PostImageFieldValue extends AbstractObject implements FieldValue {
 	 */
 	public function get_type_fields() : array {
 		return [
+			'altText'     => [
+				'type'        => 'String',
+				'description' => __( 'The image alt text.', 'wp-graphql-gravity-forms' ),
+			],
 			'caption'     => [
 				'type'        => 'String',
 				'description' => __( 'The image caption.', 'wp-graphql-gravity-forms' ),

--- a/src/Types/Field/PostImageField.php
+++ b/src/Types/Field/PostImageField.php
@@ -12,6 +12,7 @@
 namespace WPGraphQLGravityForms\Types\Field;
 
 use WPGraphQLGravityForms\Types\Field\FieldProperty;
+use WPGraphQLGravityForms\Utils\Utils;
 
 /**
  * Class - PostImageField

--- a/src/Types/Field/PostImageField.php
+++ b/src/Types/Field/PostImageField.php
@@ -45,17 +45,14 @@ class PostImageField extends AbstractFormField {
 		return array_merge(
 			$this->get_global_properties(),
 			$this->get_custom_properties(),
-			FieldProperty\AllowedExtensionsProperty::get(),
 			FieldProperty\AdminLabelProperty::get(),
-			FieldProperty\AdminOnlyProperty::get(),
-			FieldProperty\AllowsPrepopulateProperty::get(),
+			FieldProperty\AllowedExtensionsProperty::get(),
+			FieldProperty\ErrorMessageProperty::get(),
+			FieldProperty\IsRequiredProperty::get(),
 			FieldProperty\DescriptionPlacementProperty::get(),
 			FieldProperty\DescriptionProperty::get(),
-			FieldProperty\ErrorMessageProperty::get(),
-			FieldProperty\InputNameProperty::get(),
-			FieldProperty\IsRequiredProperty::get(),
 			FieldProperty\LabelProperty::get(),
-			FieldProperty\SizeProperty::get(),
+			FieldProperty\SubLabelPlacementProperty::get(),
 			FieldProperty\VisibilityProperty::get(),
 			[
 				'displayAlt'         => [
@@ -78,7 +75,20 @@ class PostImageField extends AbstractFormField {
 					'type'        => 'Boolean',
 					'description' => __( "Whether the image field should be used to set the post's Featured Image", 'wp-graphql-gravity-forms' ),
 				],
-			]
+			],
+			/**
+			* Deprecated field properties.
+			*
+			* @since 0.7.0
+			*/
+			// translators: Gravity Forms Field type.
+			Utils::deprecate_property( FieldProperty\AdminOnlyProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field type.
+			Utils::deprecate_property( FieldProperty\AllowsPrepopulateProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field type.
+			Utils::deprecate_property( FieldProperty\InputNameProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
+			// translators: Gravity Forms Field type.
+			Utils::deprecate_property( FieldProperty\SizeProperty::get(), sprintf( __( 'This property is not associated with the Gravity Forms %s type.', 'wp-graphql-gravity-forms' ), self::$type ) ),
 		);
 	}
 }

--- a/src/Types/GraphQLInterface/FormFieldInterface.php
+++ b/src/Types/GraphQLInterface/FormFieldInterface.php
@@ -168,7 +168,7 @@ class FormFieldInterface implements Hookable, Type {
 		/**
 		 * Filter to add custom Gravity Forms field types to the GraphQL schema.
 		 *
-		 * @param array The field types.
+		 * @param array $type The field types.
 		 */
 		$types = apply_filters_deprecated( 'wp_graphql_gf_field_types', [ $types ], '0.7.0', 'wp_graphql_gf_instances', __( 'Please remove your code, and use `wp_graphql_gf_instances` hook to register your custom fields instead', 'wp-graphql-gravity-forms' ) );
 

--- a/src/Types/Input/FieldValuesInput.php
+++ b/src/Types/Input/FieldValuesInput.php
@@ -74,9 +74,15 @@ class FieldValuesInput extends AbstractInput {
 		if ( class_exists( 'WPGraphQL\Upload\Type\Upload' ) ) {
 			$fields['fileUploadValues'] = [
 				'type'        => [ 'list_of' => 'Upload' ],
-				'description' => __( 'The form field values for file uploads', 'wp-graphql-gravity-forms' ),
+				'description' => __( 'The form field values for file upload fields.', 'wp-graphql-gravity-forms' ),
+			];
+			$fields['postImageValues']  = [
+				'type'        => PostImageInput::$type,
+				'description' => __( 'The form field values for post image fields.', 'wp-graphql-gravity-forms' ),
 			];
 		}
+
+		ksort( $fields );
 
 		return $fields;
 	}

--- a/src/Types/Input/PostImageInput.php
+++ b/src/Types/Input/PostImageInput.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * GraphQL Input Type - PostImageInput
+ * Input fields for a single Post Image.
+ *
+ * @package WPGraphQLGravityForms\Types\Input
+ * @since   0.0.1
+ */
+
+namespace WPGraphQLGravityForms\Types\Input;
+
+/**
+ * Class - PostImageInput
+ */
+class PostImageInput extends AbstractInput {
+	/**
+	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
+	 */
+	public static $type = 'ImageInput';
+
+	/**
+	 * Sets the field type description.
+	 */
+	public function get_type_description() : string {
+		return __( 'Input fields for a single post Image.', 'wp-graphql-gravity-forms' );
+	}
+
+	/**
+	 * Gets the properties for the Field.
+	 */
+	public function get_type_fields() : array {
+		return [
+			'image'       => [
+				'type'        => [ 'non_null' => 'Upload' ],
+				'description' => __( 'The image to be uploaded.', 'wp-graphql-gravity-forms' ),
+			],
+			'altText'     => [
+				'type'        => 'String',
+				'description' => __( 'The image alt text.', 'wp-graphql-gravity-forms' ),
+			],
+			'title'       => [
+				'type'        => 'String',
+				'description' => __( 'The image title.', 'wp-graphql-gravity-forms' ),
+			],
+			'caption'     => [
+				'type'        => 'String',
+				'description' => __( 'The image caption.', 'wp-graphql-gravity-forms' ),
+			],
+			'description' => [
+				'type'        => 'String',
+				'description' => __( 'The image description.', 'wp-graphql-gravity-forms' ),
+			],
+		];
+	}
+}

--- a/src/Types/Union/ObjectFieldValueUnion.php
+++ b/src/Types/Union/ObjectFieldValueUnion.php
@@ -74,7 +74,7 @@ class ObjectFieldValueUnion implements Hookable {
 		 *
 		 * @since 0.7.0
 		 */
-		$fields = apply_filters_deprecated( 'wp_graphql_gf_field_value_instances', [ $fields ], '0.7.0', 'wp_graphql_gf_instances' );
+		$field_values = apply_filters_deprecated( 'wp_graphql_gf_field_value_instances', [ $field_values ], '0.7.0', 'wp_graphql_gf_instances' );
 
 		// Filter the array a second time to guarantee that any classes added are instances of FieldValue.
 		return array_filter( $field_values, $is_field_value_instance );

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -213,6 +213,7 @@ final class WPGraphQLGravityForms {
 		self::$instances['email_input']                = new Input\EmailInput();
 		self::$instances['list_input']                 = new Input\ListInput();
 		self::$instances['name_input']                 = new Input\NameInput();
+		self::$instances['post_image_input']           = new Input\PostImageInput();
 		self::$instances['entries_date_fiters_input']  = new Input\EntriesDateFiltersInput();
 		self::$instances['entries_field_fiters_input'] = new Input\EntriesFieldFiltersInput();
 		self::$instances['entries_sorting_input']      = new Input\EntriesSortingInput();

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -281,6 +281,7 @@ return array(
     'WPGraphQLGravityForms\\Types\\Input\\FormsSortingInput' => $baseDir . '/src/Types/Input/FormsSortingInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\ListInput' => $baseDir . '/src/Types/Input/ListInput.php',
     'WPGraphQLGravityForms\\Types\\Input\\NameInput' => $baseDir . '/src/Types/Input/NameInput.php',
+    'WPGraphQLGravityForms\\Types\\Input\\PostImageInput' => $baseDir . '/src/Types/Input/PostImageInput.php',
     'WPGraphQLGravityForms\\Types\\Union\\ObjectFieldValueUnion' => $baseDir . '/src/Types/Union/ObjectFieldValueUnion.php',
     'WPGraphQLGravityForms\\Utils\\GFUtils' => $baseDir . '/src/Utils/GFUtils.php',
     'WPGraphQLGravityForms\\Utils\\Utils' => $baseDir . '/src/Utils/Utils.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -296,6 +296,7 @@ class ComposerStaticInit1d07b8283f09e5e28f18143f5cd7774a
         'WPGraphQLGravityForms\\Types\\Input\\FormsSortingInput' => __DIR__ . '/../..' . '/src/Types/Input/FormsSortingInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\ListInput' => __DIR__ . '/../..' . '/src/Types/Input/ListInput.php',
         'WPGraphQLGravityForms\\Types\\Input\\NameInput' => __DIR__ . '/../..' . '/src/Types/Input/NameInput.php',
+        'WPGraphQLGravityForms\\Types\\Input\\PostImageInput' => __DIR__ . '/../..' . '/src/Types/Input/PostImageInput.php',
         'WPGraphQLGravityForms\\Types\\Union\\ObjectFieldValueUnion' => __DIR__ . '/../..' . '/src/Types/Union/ObjectFieldValueUnion.php',
         'WPGraphQLGravityForms\\Utils\\GFUtils' => __DIR__ . '/../..' . '/src/Utils/GFUtils.php',
         'WPGraphQLGravityForms\\Utils\\Utils' => __DIR__ . '/../..' . '/src/Utils/Utils.php',


### PR DESCRIPTION
## Description
Adds mutation support for post images

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
dev: Deprecated `adminOnly`, `allowsPrepopulate` and `inputName` on `PostImageField`.
feat: add `altText` to PostImage field values.
feat: add support for submitting and updating post image field values.
fix: Update linked posts on entry updates.
fix: passing wrong variable to deprecated `wp_graphql_gf_field_value_instances` filter.

<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
