### PR TITLE
Fix/defaults for enums

### DIFF
--- a/src/DataManipulators/FieldsDataManipulator.php
+++ b/src/DataManipulators/FieldsDataManipulator.php
@@ -72,6 +72,15 @@ class FieldsDataManipulator implements DataManipulator {
 	private function convert_value_to_expected_type( GF_Field $field ) : GF_Field {
 		$field->layoutGridColumnSpan = ! empty( $field->layoutGridColumnSpan ) ? (int) $field->layoutGridColumnSpan : null;
 
+		// Set all empty strings to `null`.
+		$arr = (array) $field;
+		foreach ( $arr as $key => $value ) {
+			if ( '' !== $value ) {
+				continue;
+			}
+			$field->$key = null;
+		}
+
 		return $field;
 	}
 

--- a/tests/_support/Helper/GFHelpers/GFHelpers.php
+++ b/tests/_support/Helper/GFHelpers/GFHelpers.php
@@ -172,10 +172,14 @@ abstract class GFHelpers {
 	 * Converts a string value to its Enum equivalent
 	 *
 	 * @param string $enumName Name of the Enum registered in GraphQL.
-	 * @param string $value .
-	 * @return string
+	 * @param string|null $value .
+	 * @return string|null
 	 */
-	public function get_enum_for_value( string $enumName, string $value ) : string {
+	public function get_enum_for_value( string $enumName, $value )  {
+		if( null === $value ){
+			return null;
+		}
+
 		$typeRegistry = \WPGraphQL::get_type_registry();
 		return $typeRegistry->get_type( $enumName )->serialize( $value );
 	}

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -630,10 +630,14 @@ class Wpunit extends \Codeception\Module {
 	 * Converts a string value to its Enum equivalent
 	 *
 	 * @param string $enumName Name of the Enum registered in GraphQL.
-	 * @param string $value .
-	 * @return string
+	 * @param string|null $value .
+	 * @return string|null
 	 */
-	public function get_enum_for_value( string $enumName, string $value ) : string {
+	public function get_enum_for_value( string $enumName, $value ) {
+		if( null === $value ){
+			return null;
+		}
+
 		$typeRegistry = \WPGraphQL::get_type_registry();
 		return $typeRegistry->get_type( $enumName )->serialize( $value );
 	}


### PR DESCRIPTION
## Description
Sets empty `$field` values to null. Fixes issues with unset field properties throwing type errors. (h/t @natac13 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: Sets empty `$field` values to null.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
