### PR TITLE
Fix: WPGraphQL v1.6.x compatibility

### DIFF
--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -54,7 +54,7 @@ abstract class AbstractMutation implements Hookable, Mutation {
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_mutation' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_mutation' ] );
 	}
 
 	/**

--- a/src/Mutations/SubmitForm.php
+++ b/src/Mutations/SubmitForm.php
@@ -207,11 +207,7 @@ class SubmitForm extends AbstractMutation {
 	 * @throws UserError .
 	 */
 	private function update_entry_properties( array $submission, string $ip, string $source_url, int $created_by = null ) : void {
-		if ( ! $submission['entry_id'] || empty( $submission['resume_token'] ) ) {
-			return;
-		}
-
-		if ( $submission['resume_token'] ) {
+		if ( ! empty( $submission['resume_token'] ) ) {
 			$draft_entry        = GFUtils::get_draft_entry( $submission['resume_token'] );
 			$decoded_submission = json_decode( $draft_entry['submission'], true );
 
@@ -224,23 +220,31 @@ class SubmitForm extends AbstractMutation {
 			return;
 		}
 
-		if ( ! empty( $ip ) ) {
+		if ( empty( $submission['entry_id'] ) ) {
+			return;
+		}
+
+		$entry = GFUtils::get_entry( $submission['entry_id'] );
+
+		if ( ! empty( $ip ) && $entry['ip'] !== $ip ) {
 			$is_updated = GFAPI::update_entry_property( $submission['entry_id'], 'ip', $ip );
 			if ( ! $is_updated ) {
 				throw new UserError( __( 'Unable to update the entry IP address', 'wp-graphql-gravity-forms' ) );
 			}
 		}
 
-		if ( null !== $created_by ) {
+		if ( null !== $created_by && $entry['created_by'] !== $created_by ) {
 			$is_updated = GFAPI::update_entry_property( $submission['entry_id'], 'created_by', $created_by );
 			if ( ! $is_updated ) {
 				throw new UserError( __( 'Unable to update the entry createdBy id.', 'wp-graphql-gravity-forms' ) );
 			}
 		}
 
-		$is_updated = GFAPI::update_entry_property( $submission['entry_id'], 'source_url', $source_url );
-		if ( ! $is_updated ) {
-			throw new UserError( __( 'Unable to update the entry source url', 'wp-graphql-gravity-forms' ) );
+		if ( ! empty( $source_url ) && $entry['source_url'] !== $source_url ) {
+			$is_updated = GFAPI::update_entry_property( $submission['entry_id'], 'source_url', $source_url );
+			if ( ! $is_updated ) {
+				throw new UserError( __( 'Unable to update the entry source url', 'wp-graphql-gravity-forms' ) );
+			}
 		}
 	}
 

--- a/src/Types/AbstractObject.php
+++ b/src/Types/AbstractObject.php
@@ -20,8 +20,9 @@ abstract class AbstractObject extends AbstractType {
 			static::$type,
 			$this->get_type_config(
 				[
-					'description' => $this->get_type_description(),
-					'fields'      => $this->prepare_fields(),
+					'description'     => $this->get_type_description(),
+					'fields'          => $this->prepare_fields(),
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/AbstractType.php
+++ b/src/Types/AbstractType.php
@@ -23,6 +23,15 @@ abstract class AbstractType implements Hookable, Type {
 	public static $type;
 
 	/**
+	 * Whether the type should be loaded eagerly by WPGraphQL. Defaults to false.
+	 *
+	 * Eager load should only be necessary for types that are not referenced directly (e.g. in Unions, Interfaces ).
+	 *
+	 * @var boolean
+	 */
+	public static $should_load_eagerly = false;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function register_hooks() : void {

--- a/src/Types/AbstractType.php
+++ b/src/Types/AbstractType.php
@@ -35,7 +35,7 @@ abstract class AbstractType implements Hookable, Type {
 	 * {@inheritDoc}
 	 */
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_type' ] );
 	}
 
 	/**

--- a/src/Types/Entry/Entry.php
+++ b/src/Types/Entry/Entry.php
@@ -74,7 +74,7 @@ class Entry extends AbstractObject implements Field {
 	 */
 	public function register_hooks() : void {
 		parent::register_hooks();
-		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_field' ] );
 	}
 
 	/**

--- a/src/Types/Entry/EntryForm.php
+++ b/src/Types/Entry/EntryForm.php
@@ -54,7 +54,7 @@ class EntryForm extends AbstractObject implements Field {
 	 */
 	public function register_hooks() : void {
 		parent::register_hooks();
-		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_field' ] );
 	}
 
 	/**

--- a/src/Types/Entry/EntryUser.php
+++ b/src/Types/Entry/EntryUser.php
@@ -39,7 +39,7 @@ class EntryUser extends AbstractObject implements Field {
 	 */
 	public function register_hooks() : void {
 		parent::register_hooks();
-		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_field' ] );
 	}
 
 	/**

--- a/src/Types/Enum/AbstractEnum.php
+++ b/src/Types/Enum/AbstractEnum.php
@@ -29,8 +29,9 @@ abstract class AbstractEnum extends AbstractType {
 			static::$type,
 			$this->get_type_config(
 				[
-					'description' => $this->get_type_description(),
-					'values'      => $this->prepare_values(),
+					'description'     => $this->get_type_description(),
+					'values'          => $this->prepare_values(),
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/Field/AbstractFormField.php
+++ b/src/Types/Field/AbstractFormField.php
@@ -25,6 +25,13 @@ abstract class AbstractFormField extends AbstractObject {
 	public static $gf_type;
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @var boolean
+	 */
+	public static $should_load_eagerly = true;
+
+	/**
 	 * Register Object type to GraphQL schema.
 	 */
 	public function register_type() : void {
@@ -32,9 +39,11 @@ abstract class AbstractFormField extends AbstractObject {
 			static::$type,
 			$this->get_type_config(
 				[
-					'description' => $this->get_type_description(),
-					'interfaces'  => [ FormFieldInterface::$type ],
-					'fields'      => $this->prepare_fields(),
+					'description'     => $this->get_type_description(),
+					'interfaces'      => [ FormFieldInterface::$type ],
+					'fields'          => $this->prepare_fields(),
+					'eagerlyLoadType' => static::$should_load_eagerly,
+
 				]
 			)
 		);

--- a/src/Types/Field/AddressField.php
+++ b/src/Types/Field/AddressField.php
@@ -75,7 +75,7 @@ class AddressField extends AbstractFormField {
 					'description' => __( 'The field id of the field being used as the copy source.', 'wp-graphql-gravity-forms' ),
 				],
 				'copyValuesOptionLabel'   => [
-					'type'        => 'Stting',
+					'type'        => 'String',
 					'description' => __( 'The label that appears next to the copy values option when the form is displayed. The default value is “Same as previous”.', 'wp-graphql-gravity-forms' ),
 				],
 				'defaultCountry'          => [

--- a/src/Types/Field/FieldProperty/ValueProperty/AbstractValueProperty.php
+++ b/src/Types/Field/FieldProperty/ValueProperty/AbstractValueProperty.php
@@ -25,6 +25,13 @@ abstract class AbstractValueProperty extends AbstractType {
 	public static $field_name;
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @var boolean
+	 */
+	public static $should_load_eagerly = true;
+
+	/**
 	 * Register Object type to GraphQL schema.
 	 */
 	public function register_type() : void {
@@ -33,9 +40,9 @@ abstract class AbstractValueProperty extends AbstractType {
 			static::$field_name,
 			$this->get_type_config(
 				[
-					'type'        => $this->get_field_type(),
-					'description' => $this->get_type_description(),
-					'resolve'     => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
+					'type'            => $this->get_field_type(),
+					'description'     => $this->get_type_description(),
+					'resolve'         => function( $root, array $args, AppContext $context, ResolveInfo $info ) {
 						if ( ! isset( $root['source'] ) || ! is_array( $root['source'] ) ) {
 							return null;
 						}
@@ -43,6 +50,7 @@ abstract class AbstractValueProperty extends AbstractType {
 						$value = static::get( $root['source'], $root );
 						return $value;
 					},
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/Form/Form.php
+++ b/src/Types/Form/Form.php
@@ -59,7 +59,7 @@ class Form extends AbstractObject implements Field {
 	 */
 	public function register_hooks() : void {
 		parent::register_hooks();
-		add_action( 'graphql_register_types', [ $this, 'register_field' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_field' ] );
 	}
 
 	/**

--- a/src/Types/GraphQLInterface/FormFieldInterface.php
+++ b/src/Types/GraphQLInterface/FormFieldInterface.php
@@ -29,6 +29,13 @@ class FormFieldInterface implements Hookable, Type {
 	 * @var string
 	 */
 	public static $type = 'FormField';
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var boolean
+	 */
+	public static $should_load_eagerly = false;
 	/**
 	 * WPGraphQL for Gravity Forms plugin's class instances.
 	 *
@@ -108,9 +115,9 @@ class FormFieldInterface implements Hookable, Type {
 			self::$type,
 			$this->get_type_config(
 				[
-					'description' => $this->get_type_description(),
-					'fields'      => self::get_type_fields(),
-					'resolveType' => function( $value ) use ( $type_registry ) {
+					'description'     => $this->get_type_description(),
+					'fields'          => self::get_type_fields(),
+					'resolveType'     => function( $value ) use ( $type_registry ) {
 						$possible_types = $this->get_registered_form_field_types();
 						if ( isset( $possible_types[ $value->type ] ) ) {
 							return $type_registry->get_type( $possible_types[ $value->type ] );
@@ -123,6 +130,7 @@ class FormFieldInterface implements Hookable, Type {
 							)
 						);
 					},
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/GraphQLInterface/FormFieldInterface.php
+++ b/src/Types/GraphQLInterface/FormFieldInterface.php
@@ -47,7 +47,7 @@ class FormFieldInterface implements Hookable, Type {
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ] );
+		add_action( get_graphql_register_action(), [ $this, 'register_type' ] );
 	}
 
 	/**

--- a/src/Types/Input/AbstractInput.php
+++ b/src/Types/Input/AbstractInput.php
@@ -22,8 +22,9 @@ abstract class AbstractInput extends AbstractType {
 			static::$type,
 			$this->get_type_config(
 				[
-					'description' => $this->get_type_description(),
-					'fields'      => $this->prepare_fields(),
+					'description'     => $this->get_type_description(),
+					'fields'          => $this->prepare_fields(),
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/Union/ObjectFieldValueUnion.php
+++ b/src/Types/Union/ObjectFieldValueUnion.php
@@ -26,6 +26,13 @@ class ObjectFieldValueUnion implements Hookable {
 	public static $type = 'ObjectFieldValueUnion';
 
 	/**
+	 * {@inheritDoc}
+	 *
+	 * @var boolean
+	 */
+	public static $should_load_eagerly = true;
+
+	/**
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
@@ -42,10 +49,11 @@ class ObjectFieldValueUnion implements Hookable {
 			self::$type,
 			$this->get_type_config(
 				[
-					'typeNames'   => $this->get_field_value_type_names(),
-					'resolveType' => function( $object ) use ( $type_registry ) {
+					'typeNames'       => $this->get_field_value_type_names(),
+					'resolveType'     => function( $object ) use ( $type_registry ) {
 						return $type_registry->get_type( $object['value_class']::$type );
 					},
+					'eagerlyLoadType' => static::$should_load_eagerly,
 				]
 			)
 		);

--- a/src/Types/Union/ObjectFieldValueUnion.php
+++ b/src/Types/Union/ObjectFieldValueUnion.php
@@ -36,7 +36,7 @@ class ObjectFieldValueUnion implements Hookable {
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types', [ $this, 'register_type' ], 11 );
+		add_action( get_graphql_register_action(), [ $this, 'register_type' ], 11 );
 	}
 
 	/**

--- a/tests/wpunit/AddressFieldTest.php
+++ b/tests/wpunit/AddressFieldTest.php
@@ -87,6 +87,13 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 				'fieldValues' => $this->property_helper->get_field_values( $this->value ),
 			]
 		);
+
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -99,6 +106,7 @@ class AddressFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -155,7 +155,6 @@ class CaptchaFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			],
 		];
-		codecept_debug( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual, 'Test form has error.' );
 		$this->assertEquals( $expected, $actual['data'], 'Test form is not equal.' );
 	}

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -71,6 +71,7 @@ class CaptchaFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -83,6 +84,7 @@ class CaptchaFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/ChainedSelectFieldTest.php
+++ b/tests/wpunit/ChainedSelectFieldTest.php
@@ -95,6 +95,7 @@ class ChainedSelectFieldTest extends \Codeception\TestCase\WPTestCase {
 				'fieldValues' => $this->property_helper->get_field_values( $this->value ),
 			]
 		);
+		\WPGraphQL::clear_schema();
 	}
 
 
@@ -108,6 +109,7 @@ class ChainedSelectFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/CheckboxFieldTest.php
+++ b/tests/wpunit/CheckboxFieldTest.php
@@ -92,6 +92,7 @@ class CheckboxFieldTest extends \Codeception\TestCase\WPTestCase {
 				'fieldValues' => $this->property_helper->get_field_values( $this->value ),
 			]
 		);
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -104,6 +105,7 @@ class CheckboxFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/ConsentFieldTest.php
+++ b/tests/wpunit/ConsentFieldTest.php
@@ -79,6 +79,7 @@ class ConsentFieldTest extends \Codeception\TestCase\WPTestCase {
 				'fieldValues' => $this->property_helper->get_field_values( $this->value ),
 			]
 		);
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -91,6 +92,7 @@ class ConsentFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/CreateDraftEntryMutationTest.php
+++ b/tests/wpunit/CreateDraftEntryMutationTest.php
@@ -34,6 +34,7 @@ class CreateDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->form_id            = $this->factory->form->create( array_merge( [ 'fields' => $this->fields ], $this->tester->getFormDefaultArgs() ) );
 		$this->client_mutation_id = 'someUniqueId';
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -42,6 +43,7 @@ class CreateDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 	public function tearDown(): void {
 		// Your tear down methods here.
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
 
 		// Then...
 		parent::tearDown();

--- a/tests/wpunit/DateFieldTest.php
+++ b/tests/wpunit/DateFieldTest.php
@@ -72,6 +72,7 @@ class DateFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -84,6 +85,7 @@ class DateFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/DeleteDraftEntryMutationTest.php
+++ b/tests/wpunit/DeleteDraftEntryMutationTest.php
@@ -50,6 +50,7 @@ class DeleteDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 			[ 'form_id' => $this->form_id ]
 		);
 		$this->client_mutation_id = 'someUniqueId';
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -59,6 +60,8 @@ class DeleteDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 		// Your tear down methods here.
 		wp_delete_user( $this->admin->id );
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/DeleteEntryMutationTest.php
+++ b/tests/wpunit/DeleteEntryMutationTest.php
@@ -52,6 +52,7 @@ class DeleteEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$this->client_mutation_id = 'someUniqueId';
+		\WPGraphQL::clear_schema();
 	}
 
 	/**
@@ -61,6 +62,8 @@ class DeleteEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 		// Your tear down methods here.
 		wp_delete_user( $this->admin->id );
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/EntryQueriesTest.php
+++ b/tests/wpunit/EntryQueriesTest.php
@@ -55,6 +55,8 @@ class EntryQueriesTest extends \Codeception\TestCase\WPTestCase {
 				$this->fields[0]['id'] => 'This is a default Text entry.',
 			]
 		);
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -65,6 +67,8 @@ class EntryQueriesTest extends \Codeception\TestCase\WPTestCase {
 		wp_delete_user( $this->admin->id );
 		$this->factory->entry->delete( $this->entry_ids );
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -42,6 +42,8 @@ class FormQueriesTest extends \Codeception\TestCase\WPTestCase {
 			2,
 			array_merge( [ 'fields' => $this->fields ], $this->tester->getFormDefaultArgs() )
 		);
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -50,6 +52,8 @@ class FormQueriesTest extends \Codeception\TestCase\WPTestCase {
 	public function tearDown(): void {
 		// Your tear down methods here.
 		$this->factory->form->delete( $this->form_ids );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/GFUtilsTest.php
+++ b/tests/wpunit/GFUtilsTest.php
@@ -44,6 +44,8 @@ class GFUtilsTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$this->draft_token       = $this->factory->draft->create( [ 'form_id' => $this->form_id ] );
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -54,6 +56,8 @@ class GFUtilsTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->entry->delete( $this->entry_id );
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/SubmitDraftEntryMutationTest.php
+++ b/tests/wpunit/SubmitDraftEntryMutationTest.php
@@ -47,6 +47,8 @@ class SubmitDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 		$this->client_mutation_id = 'someUniqueId';
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -56,6 +58,8 @@ class SubmitDraftEntryMutationTest extends \Codeception\TestCase\WPTestCase {
 		// Your tear down methods here.
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/TextAreaFieldTest.php
+++ b/tests/wpunit/TextAreaFieldTest.php
@@ -72,6 +72,8 @@ class TextAreaFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -84,6 +86,8 @@ class TextAreaFieldTest extends \Codeception\TestCase\WPTestCase {
 		$this->factory->draft->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/tests/wpunit/TextFieldTest.php
+++ b/tests/wpunit/TextFieldTest.php
@@ -72,6 +72,8 @@ class TextFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
+		\WPGraphQL::clear_schema();
+
 	}
 
 	/**
@@ -204,6 +206,7 @@ class TextFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
+		codecept_debug( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual, 'Test draft entry has error.' );
 		$this->assertEquals( $expected, $actual['data'], 'Test draft entry is not equal.' );
 	}

--- a/tests/wpunit/TextFieldTest.php
+++ b/tests/wpunit/TextFieldTest.php
@@ -206,7 +206,6 @@ class TextFieldTest extends \Codeception\TestCase\WPTestCase {
 				],
 			]
 		);
-		codecept_debug( $actual );
 		$this->assertArrayNotHasKey( 'errors', $actual, 'Test draft entry has error.' );
 		$this->assertEquals( $expected, $actual['data'], 'Test draft entry is not equal.' );
 	}

--- a/tests/wpunit/WPGraphQLGravityFormsTest.php
+++ b/tests/wpunit/WPGraphQLGravityFormsTest.php
@@ -14,7 +14,7 @@ class WPGraphQLGravityFormsTest extends \Codeception\TestCase\WPTestCase {
 	public function setUp(): void {
 		// Before...
 		parent::setUp();
-
+		\WPGraphQL::clear_schema();
 		$this->instance = new WPGraphQLGravityForms();
 	}
 
@@ -22,6 +22,8 @@ class WPGraphQLGravityFormsTest extends \Codeception\TestCase\WPTestCase {
 		// Your tear down methods here.
 
 		unset( $this->wPGraphQLGravityForms );
+		\WPGraphQL::clear_schema();
+
 		// Then...
 		parent::tearDown();
 	}

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -27,12 +27,12 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-main',
+    'version' => 'dev-main',
     'aliases' => 
     array (
     ),
-    'reference' => 'c07cebb7dfeccae367cfcd6debf146ec2b9fcac7',
+    'reference' => '74278c70b81c15bd793f9f77b3a540141b640dfe',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -258,12 +258,12 @@ private static $installed = array (
     ),
     'harness-software/wp-graphql-gravity-forms' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-main',
+      'version' => 'dev-main',
       'aliases' => 
       array (
       ),
-      'reference' => 'c07cebb7dfeccae367cfcd6debf146ec2b9fcac7',
+      'reference' => '74278c70b81c15bd793f9f77b3a540141b640dfe',
     ),
     'hautelook/phpass' => 
     array (
@@ -276,17 +276,17 @@ private static $installed = array (
     ),
     'illuminate/collections' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'f9311a35779750f38bed47456c031c4dc4962274',
+      'reference' => '78d853243fc046f83a1d2b1e60420257d3e732e4',
     ),
     'illuminate/contracts' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
@@ -294,8 +294,8 @@ private static $installed = array (
     ),
     'illuminate/macroable' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
@@ -303,21 +303,21 @@ private static $installed = array (
     ),
     'illuminate/support' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => '0ecdbb8e61919e972c120c0956fb1c0a3b085967',
+      'reference' => 'ee397b851a411ad490363a47df7476a24f93ca2e',
     ),
     'justinrainbow/json-schema' => 
     array (
-      'pretty_version' => '5.2.10',
-      'version' => '5.2.10.0',
+      'pretty_version' => '5.2.11',
+      'version' => '5.2.11.0',
       'aliases' => 
       array (
       ),
-      'reference' => '2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b',
+      'reference' => '2ab6744b7296ded80f8cc4f9509abbff393399aa',
     ),
     'lucatume/wp-browser' => 
     array (
@@ -374,30 +374,30 @@ private static $installed = array (
     ),
     'nesbot/carbon' => 
     array (
-      'pretty_version' => '2.50.0',
-      'version' => '2.50.0.0',
+      'pretty_version' => '2.51.1',
+      'version' => '2.51.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'f47f17d17602b2243414a44ad53d9f8b9ada5fdb',
+      'reference' => '8619c299d1e0d4b344e1f98ca07a1ce2cfbf1922',
     ),
     'nikic/php-parser' => 
     array (
-      'pretty_version' => 'v4.11.0',
-      'version' => '4.11.0.0',
+      'pretty_version' => 'v4.12.0',
+      'version' => '4.12.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fe14cf3672a149364fb66dfe11bf6549af899f94',
+      'reference' => '6608f01670c3cc5079e18c1dab1104e002579143',
     ),
     'phar-io/manifest' => 
     array (
-      'pretty_version' => '2.0.1',
-      'version' => '2.0.1.0',
+      'pretty_version' => '2.0.3',
+      'version' => '2.0.3.0',
       'aliases' => 
       array (
       ),
-      'reference' => '85265efd3af7ba3ca4b2a2c34dbfc5788dd29133',
+      'reference' => '97803eca37d319dfa7826cc2437fc020857acb53',
     ),
     'phar-io/version' => 
     array (
@@ -410,12 +410,12 @@ private static $installed = array (
     ),
     'php-stubs/wordpress-stubs' => 
     array (
-      'pretty_version' => 'v5.7.2',
-      'version' => '5.7.2.0',
+      'pretty_version' => 'v5.8.0',
+      'version' => '5.8.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'beda02c58f1c4689d42c8dde6a84f7f0c9c93f42',
+      'reference' => '794e6eedfd5f2a334d581214c007fc398be588fe',
     ),
     'php-webdriver/webdriver' => 
     array (
@@ -446,12 +446,12 @@ private static $installed = array (
     ),
     'phpcompatibility/phpcompatibility-wp' => 
     array (
-      'pretty_version' => '2.1.1',
-      'version' => '2.1.1.0',
+      'pretty_version' => '2.1.2',
+      'version' => '2.1.2.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e',
+      'reference' => 'a792ab623069f0ce971b2417edef8d9632e32f75',
     ),
     'phpdocumentor/reflection-common' => 
     array (
@@ -500,12 +500,12 @@ private static $installed = array (
     ),
     'phpstan/phpstan' => 
     array (
-      'pretty_version' => '0.12.91',
-      'version' => '0.12.91.0',
+      'pretty_version' => '0.12.94',
+      'version' => '0.12.94.0',
       'aliases' => 
       array (
       ),
-      'reference' => '8226701cd228a0d63c2df995de7ab6070c69ac6a',
+      'reference' => '3d0ba4c198a24e3c3fc489f3ec6ac9612c4be5d6',
     ),
     'phpunit/php-code-coverage' => 
     array (
@@ -554,12 +554,12 @@ private static $installed = array (
     ),
     'phpunit/phpunit' => 
     array (
-      'pretty_version' => '9.5.6',
-      'version' => '9.5.6.0',
+      'pretty_version' => '9.5.8',
+      'version' => '9.5.8.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb',
+      'reference' => '191768ccd5c85513b4068bdbe99bb6390c7d54fb',
     ),
     'psr/container' => 
     array (
@@ -615,7 +615,7 @@ private static $installed = array (
     array (
       'provided' => 
       array (
-        0 => '1.0',
+        0 => '1.0|2.0',
       ),
     ),
     'psr/simple-cache' => 
@@ -818,39 +818,39 @@ private static $installed = array (
     ),
     'symfony/browser-kit' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '379984e25eee9811b0a25a2105e1a2b3b8d9b734',
+      'reference' => 'c1e3f64fcc631c96e2c5843b666db66679ced11c',
     ),
     'symfony/config' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'a69e0c55528b47df88d3c4067ddedf32d485d662',
+      'reference' => '4268f3059c904c61636275182707f81645517a37',
     ),
     'symfony/console' => 
     array (
-      'pretty_version' => 'v5.3.2',
-      'version' => '5.3.2.0',
+      'pretty_version' => 'v5.3.6',
+      'version' => '5.3.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '649730483885ff2ca99ca0560ef0e5f6b03f2ac1',
+      'reference' => '51b71afd6d2dc8f5063199357b9880cea8d8bfe2',
     ),
     'symfony/css-selector' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fcd0b29a7a0b1bb5bfbedc6231583d77fea04814',
+      'reference' => '7fb120adc7f600a59027775b224c13a33530dd90',
     ),
     'symfony/deprecation-contracts' => 
     array (
@@ -863,21 +863,21 @@ private static $installed = array (
     ),
     'symfony/dom-crawler' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '55fff62b19f413f897a752488ade1bc9c8a19cdd',
+      'reference' => '2dd8890bd01be59a5221999c05ccf0fcafcb354f',
     ),
     'symfony/event-dispatcher' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '67a5f354afa8e2f231081b3fa11a5912f933c3ce',
+      'reference' => 'f2fd2208157553874560f3645d4594303058c4bd',
     ),
     'symfony/event-dispatcher-contracts' => 
     array (
@@ -897,21 +897,21 @@ private static $installed = array (
     ),
     'symfony/filesystem' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '19b71c8f313b411172dd5f470fd61f24466d79a9',
+      'reference' => '343f4fe324383ca46792cae728a3b6e2f708fb32',
     ),
     'symfony/finder' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6',
+      'reference' => '17f50e06018baec41551a71a15731287dbaab186',
     ),
     'symfony/polyfill-ctype' => 
     array (
@@ -924,12 +924,12 @@ private static $installed = array (
     ),
     'symfony/polyfill-intl-grapheme' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '24b72c6baa32c746a4d0840147c9715e42bb68ab',
+      'reference' => '16880ba9c5ebe3642d1995ab866db29270b36535',
     ),
     'symfony/polyfill-intl-idn' => 
     array (
@@ -951,12 +951,12 @@ private static $installed = array (
     ),
     'symfony/polyfill-mbstring' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '2df51500adbaebdc4c38dea4c89a2e131c45c8a1',
+      'reference' => '9174a3d80210dca8daa7f31fec659150bbeabfc6',
     ),
     'symfony/polyfill-php72' => 
     array (
@@ -978,12 +978,12 @@ private static $installed = array (
     ),
     'symfony/polyfill-php80' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'eca0bf41ed421bed1b57c4958bab16aa86b757d0',
+      'reference' => '1100343ed1a92e3a38f9ae122fc0eb21602547be',
     ),
     'symfony/polyfill-php81' => 
     array (
@@ -996,12 +996,12 @@ private static $installed = array (
     ),
     'symfony/process' => 
     array (
-      'pretty_version' => 'v5.3.2',
-      'version' => '5.3.2.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '714b47f9196de61a196d86c4bad5f09201b307df',
+      'reference' => 'd16634ee55b895bd85ec714dadc58e4428ecf030',
     ),
     'symfony/service-contracts' => 
     array (
@@ -1014,12 +1014,12 @@ private static $installed = array (
     ),
     'symfony/stopwatch' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '313d02f59d6543311865007e5ff4ace05b35ee65',
+      'reference' => 'b24c6a92c6db316fee69e38c80591e080e41536c',
     ),
     'symfony/string' => 
     array (
@@ -1032,12 +1032,12 @@ private static $installed = array (
     ),
     'symfony/translation' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '380b8c9e944d0e364b25f28e8e555241eb49c01c',
+      'reference' => 'd89ad7292932c2699cbe4af98d72c5c6bbc504c1',
     ),
     'symfony/translation-contracts' => 
     array (
@@ -1057,30 +1057,30 @@ private static $installed = array (
     ),
     'symfony/yaml' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.6',
+      'version' => '5.3.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '485c83a2fb5893e2ff21bf4bfc7fdf48b4967229',
+      'reference' => '4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7',
     ),
     'szepeviktor/phpstan-wordpress' => 
     array (
-      'pretty_version' => 'v0.7.6',
-      'version' => '0.7.6.0',
+      'pretty_version' => 'v0.7.7',
+      'version' => '0.7.7.0',
       'aliases' => 
       array (
       ),
-      'reference' => '3721127a9ddc62c8dc14fc8726cbfb3e47529bbe',
+      'reference' => 'bdbea69b2ba4a69998c3b6fe2b7106d78a23bd72',
     ),
     'theseer/tokenizer' => 
     array (
-      'pretty_version' => '1.2.0',
-      'version' => '1.2.0.0',
+      'pretty_version' => '1.2.1',
+      'version' => '1.2.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '75a63c33a8577608444246075ea0af0d052e452a',
+      'reference' => '34a41e998c2183e22995f158c581e7b5e755ab9e',
     ),
     'voku/portable-ascii' => 
     array (
@@ -1120,12 +1120,12 @@ private static $installed = array (
     ),
     'wp-cli/php-cli-tools' => 
     array (
-      'pretty_version' => 'v0.11.12',
-      'version' => '0.11.12.0',
+      'pretty_version' => 'v0.11.13',
+      'version' => '0.11.13.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'e472e08489f7504d9e8c5c5a057e1419cd1b2b3e',
+      'reference' => 'a2866855ac1abc53005c102e901553ad5772dc04',
     ),
     'wp-cli/wp-cli' => 
     array (
@@ -1147,12 +1147,12 @@ private static $installed = array (
     ),
     'zordius/lightncandy' => 
     array (
-      'pretty_version' => 'v1.2.5',
-      'version' => '1.2.5.0',
+      'pretty_version' => 'v1.2.6',
+      'version' => '1.2.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '37aa381e0f27d411a630062070c7a5a2174c62e7',
+      'reference' => 'b451f73e8b5c73e62e365997ba3c993a0376b72a',
     ),
   ),
 );

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1416,17 +1416,17 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.49.2",
-            "version_normalized": "8.49.2.0",
+            "version": "v8.52.0",
+            "version_normalized": "8.52.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "f9311a35779750f38bed47456c031c4dc4962274"
+                "reference": "78d853243fc046f83a1d2b1e60420257d3e732e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/f9311a35779750f38bed47456c031c4dc4962274",
-                "reference": "f9311a35779750f38bed47456c031c4dc4962274",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/78d853243fc046f83a1d2b1e60420257d3e732e4",
+                "reference": "78d853243fc046f83a1d2b1e60420257d3e732e4",
                 "shasum": ""
             },
             "require": {
@@ -1437,7 +1437,7 @@
             "suggest": {
                 "symfony/var-dumper": "Required to use the dump method (^5.1.4)."
             },
-            "time": "2021-06-28T13:56:26+00:00",
+            "time": "2021-07-21T12:14:50+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1473,8 +1473,8 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.49.2",
-            "version_normalized": "8.49.2.0",
+            "version": "v8.52.0",
+            "version_normalized": "8.52.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1524,8 +1524,8 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.49.2",
-            "version_normalized": "8.49.2.0",
+            "version": "v8.52.0",
+            "version_normalized": "8.52.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1573,17 +1573,17 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.49.2",
-            "version_normalized": "8.49.2.0",
+            "version": "v8.52.0",
+            "version_normalized": "8.52.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "0ecdbb8e61919e972c120c0956fb1c0a3b085967"
+                "reference": "ee397b851a411ad490363a47df7476a24f93ca2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/0ecdbb8e61919e972c120c0956fb1c0a3b085967",
-                "reference": "0ecdbb8e61919e972c120c0956fb1c0a3b085967",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/ee397b851a411ad490363a47df7476a24f93ca2e",
+                "reference": "ee397b851a411ad490363a47df7476a24f93ca2e",
                 "shasum": ""
             },
             "require": {
@@ -1602,13 +1602,13 @@
             },
             "suggest": {
                 "illuminate/filesystem": "Required to use the composer class (^8.0).",
-                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3|^2.0).",
                 "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
                 "symfony/process": "Required to use the composer class (^5.1.4).",
                 "symfony/var-dumper": "Required to use the dd function (^5.1.4).",
                 "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
             },
-            "time": "2021-07-02T16:40:19+00:00",
+            "time": "2021-07-16T12:34:54+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1644,17 +1644,17 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.10",
-            "version_normalized": "5.2.10.0",
+            "version": "5.2.11",
+            "version_normalized": "5.2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+                "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ab6744b7296ded80f8cc4f9509abbff393399aa",
+                "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa",
                 "shasum": ""
             },
             "require": {
@@ -1665,7 +1665,7 @@
                 "json-schema/json-schema-test-suite": "1.2.0",
                 "phpunit/phpunit": "^4.8.35"
             },
-            "time": "2020-05-27T16:41:55+00:00",
+            "time": "2021-07-22T09:24:00+00:00",
             "bin": [
                 "bin/validate-json"
             ],
@@ -1711,7 +1711,7 @@
             ],
             "support": {
                 "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.11"
             },
             "install-path": "../justinrainbow/json-schema"
         },
@@ -2047,23 +2047,24 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.50.0",
-            "version_normalized": "2.50.0.0",
+            "version": "2.51.1",
+            "version_normalized": "2.51.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb"
+                "reference": "8619c299d1e0d4b344e1f98ca07a1ce2cfbf1922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
-                "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/8619c299d1e0d4b344e1f98ca07a1ce2cfbf1922",
+                "reference": "8619c299d1e0d4b344e1f98ca07a1ce2cfbf1922",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
@@ -2076,15 +2077,15 @@
                 "phpunit/phpunit": "^7.5.20 || ^8.5.14",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "time": "2021-06-28T22:38:45+00:00",
+            "time": "2021-07-28T13:16:28+00:00",
             "bin": [
                 "bin/carbon"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
-                    "dev-3.x": "3.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "2.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -2143,17 +2144,17 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.11.0",
-            "version_normalized": "4.11.0.0",
+            "version": "v4.12.0",
+            "version_normalized": "4.12.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -2164,7 +2165,7 @@
                 "ircmaxell/php-yacc": "^0.0.7",
                 "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
-            "time": "2021-07-03T13:36:55+00:00",
+            "time": "2021-07-21T10:44:31+00:00",
             "bin": [
                 "bin/php-parse"
             ],
@@ -2196,23 +2197,23 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
             "install-path": "../nikic/php-parser"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
-            "version_normalized": "2.0.1.0",
+            "version": "2.0.3",
+            "version_normalized": "2.0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -2222,7 +2223,7 @@
                 "phar-io/version": "^3.0.1",
                 "php": "^7.2 || ^8.0"
             },
-            "time": "2020-06-27T14:33:11+00:00",
+            "time": "2021-07-20T11:28:43+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2259,7 +2260,7 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
             "install-path": "../phar-io/manifest"
         },
@@ -2319,17 +2320,17 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.7.2",
-            "version_normalized": "5.7.2.0",
+            "version": "v5.8.0",
+            "version_normalized": "5.8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42"
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/794e6eedfd5f2a334d581214c007fc398be588fe",
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe",
                 "shasum": ""
             },
             "replace": {
@@ -2344,7 +2345,7 @@
                 "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
-            "time": "2021-05-13T07:54:04+00:00",
+            "time": "2021-07-21T02:34:37+00:00",
             "type": "library",
             "installation-source": "dist",
             "notification-url": "https://packagist.org/downloads/",
@@ -2360,7 +2361,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.8.0"
             },
             "install-path": "../php-stubs/wordpress-stubs"
         },
@@ -2559,17 +2560,17 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.1",
-            "version_normalized": "2.1.1.0",
+            "version": "2.1.2",
+            "version_normalized": "2.1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
                 "shasum": ""
             },
             "require": {
@@ -2583,7 +2584,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
-            "time": "2021-02-15T12:58:46+00:00",
+            "time": "2021-07-21T11:09:57+00:00",
             "type": "phpcodesniffer-standard",
             "installation-source": "dist",
             "notification-url": "https://packagist.org/downloads/",
@@ -2901,17 +2902,17 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.91",
-            "version_normalized": "0.12.91.0",
+            "version": "0.12.94",
+            "version_normalized": "0.12.94.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8226701cd228a0d63c2df995de7ab6070c69ac6a"
+                "reference": "3d0ba4c198a24e3c3fc489f3ec6ac9612c4be5d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8226701cd228a0d63c2df995de7ab6070c69ac6a",
-                "reference": "8226701cd228a0d63c2df995de7ab6070c69ac6a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3d0ba4c198a24e3c3fc489f3ec6ac9612c4be5d6",
+                "reference": "3d0ba4c198a24e3c3fc489f3ec6ac9612c4be5d6",
                 "shasum": ""
             },
             "require": {
@@ -2920,7 +2921,7 @@
             "conflict": {
                 "phpstan/phpstan-shim": "*"
             },
-            "time": "2021-07-04T15:31:48+00:00",
+            "time": "2021-07-30T09:05:27+00:00",
             "bin": [
                 "phpstan",
                 "phpstan.phar"
@@ -2944,7 +2945,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.91"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.94"
             },
             "funding": [
                 {
@@ -3301,17 +3302,17 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.6",
-            "version_normalized": "9.5.6.0",
+            "version": "9.5.8",
+            "version_normalized": "9.5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
+                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/191768ccd5c85513b4068bdbe99bb6390c7d54fb",
+                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb",
                 "shasum": ""
             },
             "require": {
@@ -3323,7 +3324,7 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
@@ -3352,7 +3353,7 @@
                 "ext-soap": "*",
                 "ext-xdebug": "*"
             },
-            "time": "2021-06-23T05:14:38+00:00",
+            "time": "2021-07-31T15:17:34+00:00",
             "bin": [
                 "phpunit"
             ],
@@ -3391,7 +3392,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.8"
             },
             "funding": [
                 {
@@ -5012,22 +5013,23 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "379984e25eee9811b0a25a2105e1a2b3b8d9b734"
+                "reference": "c1e3f64fcc631c96e2c5843b666db66679ced11c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/379984e25eee9811b0a25a2105e1a2b3b8d9b734",
-                "reference": "379984e25eee9811b0a25a2105e1a2b3b8d9b734",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/c1e3f64fcc631c96e2c5843b666db66679ced11c",
+                "reference": "c1e3f64fcc631c96e2c5843b666db66679ced11c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/dom-crawler": "^4.4|^5.0"
+                "symfony/dom-crawler": "^4.4|^5.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
                 "symfony/css-selector": "^4.4|^5.0",
@@ -5038,7 +5040,7 @@
             "suggest": {
                 "symfony/process": ""
             },
-            "time": "2021-05-26T17:43:10+00:00",
+            "time": "2021-07-21T12:40:44+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5066,7 +5068,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v5.3.0"
+                "source": "https://github.com/symfony/browser-kit/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5086,17 +5088,17 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.3.3",
-            "version_normalized": "5.3.3.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "a69e0c55528b47df88d3c4067ddedf32d485d662"
+                "reference": "4268f3059c904c61636275182707f81645517a37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/a69e0c55528b47df88d3c4067ddedf32d485d662",
-                "reference": "a69e0c55528b47df88d3c4067ddedf32d485d662",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4268f3059c904c61636275182707f81645517a37",
+                "reference": "4268f3059c904c61636275182707f81645517a37",
                 "shasum": ""
             },
             "require": {
@@ -5104,7 +5106,7 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/filesystem": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
@@ -5120,7 +5122,7 @@
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
             },
-            "time": "2021-06-24T08:13:00+00:00",
+            "time": "2021-07-21T12:40:44+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5148,7 +5150,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.3.3"
+                "source": "https://github.com/symfony/config/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5168,17 +5170,17 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.2",
-            "version_normalized": "5.3.2.0",
+            "version": "v5.3.6",
+            "version_normalized": "5.3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+                "reference": "51b71afd6d2dc8f5063199357b9880cea8d8bfe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/51b71afd6d2dc8f5063199357b9880cea8d8bfe2",
+                "reference": "51b71afd6d2dc8f5063199357b9880cea8d8bfe2",
                 "shasum": ""
             },
             "require": {
@@ -5186,11 +5188,12 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2",
                 "symfony/string": "^5.1"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -5198,10 +5201,10 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^4.4|^5.0",
@@ -5215,7 +5218,7 @@
                 "symfony/lock": "",
                 "symfony/process": ""
             },
-            "time": "2021-06-12T09:42:48+00:00",
+            "time": "2021-07-27T19:10:22+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5249,7 +5252,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.2"
+                "source": "https://github.com/symfony/console/tree/v5.3.6"
             },
             "funding": [
                 {
@@ -5269,23 +5272,24 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814"
+                "reference": "7fb120adc7f600a59027775b224c13a33530dd90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
-                "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/7fb120adc7f600a59027775b224c13a33530dd90",
+                "reference": "7fb120adc7f600a59027775b224c13a33530dd90",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
             },
-            "time": "2021-05-26T17:40:38+00:00",
+            "time": "2021-07-21T12:38:00+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5317,7 +5321,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.3.0"
+                "source": "https://github.com/symfony/css-selector/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5407,17 +5411,17 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "55fff62b19f413f897a752488ade1bc9c8a19cdd"
+                "reference": "2dd8890bd01be59a5221999c05ccf0fcafcb354f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/55fff62b19f413f897a752488ade1bc9c8a19cdd",
-                "reference": "55fff62b19f413f897a752488ade1bc9c8a19cdd",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2dd8890bd01be59a5221999c05ccf0fcafcb354f",
+                "reference": "2dd8890bd01be59a5221999c05ccf0fcafcb354f",
                 "shasum": ""
             },
             "require": {
@@ -5425,7 +5429,7 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
                 "masterminds/html5": "<2.6"
@@ -5437,7 +5441,7 @@
             "suggest": {
                 "symfony/css-selector": ""
             },
-            "time": "2021-05-26T17:43:10+00:00",
+            "time": "2021-07-23T15:55:36+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5465,7 +5469,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.3.0"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5485,24 +5489,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce"
+                "reference": "f2fd2208157553874560f3645d4594303058c4bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67a5f354afa8e2f231081b3fa11a5912f933c3ce",
-                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f2fd2208157553874560f3645d4594303058c4bd",
+                "reference": "f2fd2208157553874560f3645d4594303058c4bd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/event-dispatcher-contracts": "^2",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
                 "symfony/dependency-injection": "<4.4"
@@ -5512,7 +5516,7 @@
                 "symfony/event-dispatcher-implementation": "2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2|^3",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/error-handler": "^4.4|^5.0",
@@ -5525,7 +5529,7 @@
                 "symfony/dependency-injection": "",
                 "symfony/http-kernel": ""
             },
-            "time": "2021-05-26T17:43:10+00:00",
+            "time": "2021-07-23T15:55:36+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5553,7 +5557,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5655,24 +5659,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.3.3",
-            "version_normalized": "5.3.3.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9"
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/19b71c8f313b411172dd5f470fd61f24466d79a9",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/343f4fe324383ca46792cae728a3b6e2f708fb32",
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
-            "time": "2021-06-30T07:27:52+00:00",
+            "time": "2021-07-21T12:40:44+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5700,7 +5705,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.3.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5720,23 +5725,24 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
+                "reference": "17f50e06018baec41551a71a15731287dbaab186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/17f50e06018baec41551a71a15731287dbaab186",
+                "reference": "17f50e06018baec41551a71a15731287dbaab186",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
             },
-            "time": "2021-05-26T12:52:38+00:00",
+            "time": "2021-07-23T15:54:19+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -5764,7 +5770,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.3.0"
+                "source": "https://github.com/symfony/finder/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5866,17 +5872,17 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.0",
-            "version_normalized": "1.23.0.0",
+            "version": "v1.23.1",
+            "version_normalized": "1.23.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
                 "shasum": ""
             },
             "require": {
@@ -5885,7 +5891,7 @@
             "suggest": {
                 "ext-intl": "For best performance"
             },
-            "time": "2021-05-27T09:17:38+00:00",
+            "time": "2021-05-27T12:26:48+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -5930,7 +5936,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -6127,17 +6133,17 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
-            "version_normalized": "1.23.0.0",
+            "version": "v1.23.1",
+            "version_normalized": "1.23.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -6146,7 +6152,7 @@
             "suggest": {
                 "ext-mbstring": "For best performance"
             },
-            "time": "2021-05-27T09:27:20+00:00",
+            "time": "2021-05-27T12:26:48+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6190,7 +6196,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -6371,23 +6377,23 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
-            "version_normalized": "1.23.0.0",
+            "version": "v1.23.1",
+            "version_normalized": "1.23.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
             },
-            "time": "2021-02-19T12:13:01+00:00",
+            "time": "2021-07-28T13:41:28+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6437,7 +6443,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -6539,24 +6545,24 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.3.2",
-            "version_normalized": "5.3.2.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "714b47f9196de61a196d86c4bad5f09201b307df"
+                "reference": "d16634ee55b895bd85ec714dadc58e4428ecf030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/714b47f9196de61a196d86c4bad5f09201b307df",
-                "reference": "714b47f9196de61a196d86c4bad5f09201b307df",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d16634ee55b895bd85ec714dadc58e4428ecf030",
+                "reference": "d16634ee55b895bd85ec714dadc58e4428ecf030",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16"
             },
-            "time": "2021-06-12T10:15:01+00:00",
+            "time": "2021-07-23T15:54:19+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -6584,7 +6590,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.3.2"
+                "source": "https://github.com/symfony/process/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -6686,24 +6692,24 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.3.0",
-            "version_normalized": "5.3.0.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65"
+                "reference": "b24c6a92c6db316fee69e38c80591e080e41536c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/313d02f59d6543311865007e5ff4ace05b35ee65",
-                "reference": "313d02f59d6543311865007e5ff4ace05b35ee65",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b24c6a92c6db316fee69e38c80591e080e41536c",
+                "reference": "b24c6a92c6db316fee69e38c80591e080e41536c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/service-contracts": "^1.0|^2"
             },
-            "time": "2021-05-26T17:43:10+00:00",
+            "time": "2021-07-10T08:58:57+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -6731,7 +6737,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.3.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -6837,24 +6843,24 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v5.3.3",
-            "version_normalized": "5.3.3.0",
+            "version": "v5.3.4",
+            "version_normalized": "5.3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "380b8c9e944d0e364b25f28e8e555241eb49c01c"
+                "reference": "d89ad7292932c2699cbe4af98d72c5c6bbc504c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/380b8c9e944d0e364b25f28e8e555241eb49c01c",
-                "reference": "380b8c9e944d0e364b25f28e8e555241eb49c01c",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/d89ad7292932c2699cbe4af98d72c5c6bbc504c1",
+                "reference": "d89ad7292932c2699cbe4af98d72c5c6bbc504c1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/translation-contracts": "^2.3"
             },
             "conflict": {
@@ -6868,7 +6874,7 @@
                 "symfony/translation-implementation": "2.3"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2|^3",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/console": "^4.4|^5.0",
                 "symfony/dependency-injection": "^5.0",
@@ -6884,7 +6890,7 @@
                 "symfony/config": "",
                 "symfony/yaml": ""
             },
-            "time": "2021-06-27T12:22:47+00:00",
+            "time": "2021-07-25T09:39:16+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -6915,7 +6921,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.3.3"
+                "source": "https://github.com/symfony/translation/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -7016,17 +7022,17 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.3.3",
-            "version_normalized": "5.3.3.0",
+            "version": "v5.3.6",
+            "version_normalized": "5.3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229"
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
-                "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
                 "shasum": ""
             },
             "require": {
@@ -7043,7 +7049,7 @@
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
             },
-            "time": "2021-06-24T08:13:00+00:00",
+            "time": "2021-07-29T06:20:01+00:00",
             "bin": [
                 "Resources/bin/yaml-lint"
             ],
@@ -7074,7 +7080,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.3.3"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.6"
             },
             "funding": [
                 {
@@ -7094,17 +7100,17 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v0.7.6",
-            "version_normalized": "0.7.6.0",
+            "version": "v0.7.7",
+            "version_normalized": "0.7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "3721127a9ddc62c8dc14fc8726cbfb3e47529bbe"
+                "reference": "bdbea69b2ba4a69998c3b6fe2b7106d78a23bd72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/3721127a9ddc62c8dc14fc8726cbfb3e47529bbe",
-                "reference": "3721127a9ddc62c8dc14fc8726cbfb3e47529bbe",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/bdbea69b2ba4a69998c3b6fe2b7106d78a23bd72",
+                "reference": "bdbea69b2ba4a69998c3b6fe2b7106d78a23bd72",
                 "shasum": ""
             },
             "require": {
@@ -7120,7 +7126,7 @@
                 "phpstan/phpstan-strict-rules": "^0.12",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.6"
             },
-            "time": "2021-06-19T15:51:50+00:00",
+            "time": "2021-07-14T09:19:15+00:00",
             "type": "phpstan-extension",
             "extra": {
                 "phpstan": {
@@ -7132,7 +7138,7 @@
             "installation-source": "dist",
             "autoload": {
                 "psr-4": {
-                    "PHPStan\\WordPress\\": "src/"
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7149,7 +7155,7 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.6"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v0.7.7"
             },
             "funding": [
                 {
@@ -7161,17 +7167,17 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
-            "version_normalized": "1.2.0.0",
+            "version": "1.2.1",
+            "version_normalized": "1.2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -7180,7 +7186,7 @@
                 "ext-xmlwriter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "time": "2020-07-12T23:59:07+00:00",
+            "time": "2021-07-28T10:34:58+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -7202,7 +7208,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -7462,23 +7468,23 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.12",
-            "version_normalized": "0.11.12.0",
+            "version": "v0.11.13",
+            "version_normalized": "0.11.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e"
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a2866855ac1abc53005c102e901553ad5772dc04",
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04",
                 "shasum": ""
             },
             "require": {
                 "php": ">= 5.3.0"
             },
-            "time": "2021-03-03T12:43:49+00:00",
+            "time": "2021-07-01T15:08:16+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -7513,7 +7519,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.12"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.13"
             },
             "install-path": "../wp-cli/php-cli-tools"
         },
@@ -7647,26 +7653,26 @@
         },
         {
             "name": "zordius/lightncandy",
-            "version": "v1.2.5",
-            "version_normalized": "1.2.5.0",
+            "version": "v1.2.6",
+            "version_normalized": "1.2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zordius/lightncandy.git",
-                "reference": "37aa381e0f27d411a630062070c7a5a2174c62e7"
+                "reference": "b451f73e8b5c73e62e365997ba3c993a0376b72a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zordius/lightncandy/zipball/37aa381e0f27d411a630062070c7a5a2174c62e7",
-                "reference": "37aa381e0f27d411a630062070c7a5a2174c62e7",
+                "url": "https://api.github.com/repos/zordius/lightncandy/zipball/b451f73e8b5c73e62e365997ba3c993a0376b72a",
+                "reference": "b451f73e8b5c73e62e365997ba3c993a0376b72a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7"
+                "phpunit/phpunit": ">=7"
             },
-            "time": "2020-03-08T06:00:24+00:00",
+            "time": "2021-07-11T04:52:41+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -7700,7 +7706,7 @@
             ],
             "support": {
                 "issues": "https://github.com/zordius/lightncandy/issues",
-                "source": "https://github.com/zordius/lightncandy/tree/master"
+                "source": "https://github.com/zordius/lightncandy/tree/v1.2.6"
             },
             "install-path": "../zordius/lightncandy"
         }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,12 +1,12 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-main',
+    'version' => 'dev-main',
     'aliases' => 
     array (
     ),
-    'reference' => 'c07cebb7dfeccae367cfcd6debf146ec2b9fcac7',
+    'reference' => '74278c70b81c15bd793f9f77b3a540141b640dfe',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -232,12 +232,12 @@
     ),
     'harness-software/wp-graphql-gravity-forms' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-main',
+      'version' => 'dev-main',
       'aliases' => 
       array (
       ),
-      'reference' => 'c07cebb7dfeccae367cfcd6debf146ec2b9fcac7',
+      'reference' => '74278c70b81c15bd793f9f77b3a540141b640dfe',
     ),
     'hautelook/phpass' => 
     array (
@@ -250,17 +250,17 @@
     ),
     'illuminate/collections' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'f9311a35779750f38bed47456c031c4dc4962274',
+      'reference' => '78d853243fc046f83a1d2b1e60420257d3e732e4',
     ),
     'illuminate/contracts' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
@@ -268,8 +268,8 @@
     ),
     'illuminate/macroable' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
@@ -277,21 +277,21 @@
     ),
     'illuminate/support' => 
     array (
-      'pretty_version' => 'v8.49.2',
-      'version' => '8.49.2.0',
+      'pretty_version' => 'v8.52.0',
+      'version' => '8.52.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => '0ecdbb8e61919e972c120c0956fb1c0a3b085967',
+      'reference' => 'ee397b851a411ad490363a47df7476a24f93ca2e',
     ),
     'justinrainbow/json-schema' => 
     array (
-      'pretty_version' => '5.2.10',
-      'version' => '5.2.10.0',
+      'pretty_version' => '5.2.11',
+      'version' => '5.2.11.0',
       'aliases' => 
       array (
       ),
-      'reference' => '2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b',
+      'reference' => '2ab6744b7296ded80f8cc4f9509abbff393399aa',
     ),
     'lucatume/wp-browser' => 
     array (
@@ -348,30 +348,30 @@
     ),
     'nesbot/carbon' => 
     array (
-      'pretty_version' => '2.50.0',
-      'version' => '2.50.0.0',
+      'pretty_version' => '2.51.1',
+      'version' => '2.51.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'f47f17d17602b2243414a44ad53d9f8b9ada5fdb',
+      'reference' => '8619c299d1e0d4b344e1f98ca07a1ce2cfbf1922',
     ),
     'nikic/php-parser' => 
     array (
-      'pretty_version' => 'v4.11.0',
-      'version' => '4.11.0.0',
+      'pretty_version' => 'v4.12.0',
+      'version' => '4.12.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fe14cf3672a149364fb66dfe11bf6549af899f94',
+      'reference' => '6608f01670c3cc5079e18c1dab1104e002579143',
     ),
     'phar-io/manifest' => 
     array (
-      'pretty_version' => '2.0.1',
-      'version' => '2.0.1.0',
+      'pretty_version' => '2.0.3',
+      'version' => '2.0.3.0',
       'aliases' => 
       array (
       ),
-      'reference' => '85265efd3af7ba3ca4b2a2c34dbfc5788dd29133',
+      'reference' => '97803eca37d319dfa7826cc2437fc020857acb53',
     ),
     'phar-io/version' => 
     array (
@@ -384,12 +384,12 @@
     ),
     'php-stubs/wordpress-stubs' => 
     array (
-      'pretty_version' => 'v5.7.2',
-      'version' => '5.7.2.0',
+      'pretty_version' => 'v5.8.0',
+      'version' => '5.8.0.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'beda02c58f1c4689d42c8dde6a84f7f0c9c93f42',
+      'reference' => '794e6eedfd5f2a334d581214c007fc398be588fe',
     ),
     'php-webdriver/webdriver' => 
     array (
@@ -420,12 +420,12 @@
     ),
     'phpcompatibility/phpcompatibility-wp' => 
     array (
-      'pretty_version' => '2.1.1',
-      'version' => '2.1.1.0',
+      'pretty_version' => '2.1.2',
+      'version' => '2.1.2.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e',
+      'reference' => 'a792ab623069f0ce971b2417edef8d9632e32f75',
     ),
     'phpdocumentor/reflection-common' => 
     array (
@@ -474,12 +474,12 @@
     ),
     'phpstan/phpstan' => 
     array (
-      'pretty_version' => '0.12.91',
-      'version' => '0.12.91.0',
+      'pretty_version' => '0.12.94',
+      'version' => '0.12.94.0',
       'aliases' => 
       array (
       ),
-      'reference' => '8226701cd228a0d63c2df995de7ab6070c69ac6a',
+      'reference' => '3d0ba4c198a24e3c3fc489f3ec6ac9612c4be5d6',
     ),
     'phpunit/php-code-coverage' => 
     array (
@@ -528,12 +528,12 @@
     ),
     'phpunit/phpunit' => 
     array (
-      'pretty_version' => '9.5.6',
-      'version' => '9.5.6.0',
+      'pretty_version' => '9.5.8',
+      'version' => '9.5.8.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb',
+      'reference' => '191768ccd5c85513b4068bdbe99bb6390c7d54fb',
     ),
     'psr/container' => 
     array (
@@ -589,7 +589,7 @@
     array (
       'provided' => 
       array (
-        0 => '1.0',
+        0 => '1.0|2.0',
       ),
     ),
     'psr/simple-cache' => 
@@ -792,39 +792,39 @@
     ),
     'symfony/browser-kit' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '379984e25eee9811b0a25a2105e1a2b3b8d9b734',
+      'reference' => 'c1e3f64fcc631c96e2c5843b666db66679ced11c',
     ),
     'symfony/config' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'a69e0c55528b47df88d3c4067ddedf32d485d662',
+      'reference' => '4268f3059c904c61636275182707f81645517a37',
     ),
     'symfony/console' => 
     array (
-      'pretty_version' => 'v5.3.2',
-      'version' => '5.3.2.0',
+      'pretty_version' => 'v5.3.6',
+      'version' => '5.3.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '649730483885ff2ca99ca0560ef0e5f6b03f2ac1',
+      'reference' => '51b71afd6d2dc8f5063199357b9880cea8d8bfe2',
     ),
     'symfony/css-selector' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'fcd0b29a7a0b1bb5bfbedc6231583d77fea04814',
+      'reference' => '7fb120adc7f600a59027775b224c13a33530dd90',
     ),
     'symfony/deprecation-contracts' => 
     array (
@@ -837,21 +837,21 @@
     ),
     'symfony/dom-crawler' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '55fff62b19f413f897a752488ade1bc9c8a19cdd',
+      'reference' => '2dd8890bd01be59a5221999c05ccf0fcafcb354f',
     ),
     'symfony/event-dispatcher' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '67a5f354afa8e2f231081b3fa11a5912f933c3ce',
+      'reference' => 'f2fd2208157553874560f3645d4594303058c4bd',
     ),
     'symfony/event-dispatcher-contracts' => 
     array (
@@ -871,21 +871,21 @@
     ),
     'symfony/filesystem' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '19b71c8f313b411172dd5f470fd61f24466d79a9',
+      'reference' => '343f4fe324383ca46792cae728a3b6e2f708fb32',
     ),
     'symfony/finder' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6',
+      'reference' => '17f50e06018baec41551a71a15731287dbaab186',
     ),
     'symfony/polyfill-ctype' => 
     array (
@@ -898,12 +898,12 @@
     ),
     'symfony/polyfill-intl-grapheme' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '24b72c6baa32c746a4d0840147c9715e42bb68ab',
+      'reference' => '16880ba9c5ebe3642d1995ab866db29270b36535',
     ),
     'symfony/polyfill-intl-idn' => 
     array (
@@ -925,12 +925,12 @@
     ),
     'symfony/polyfill-mbstring' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '2df51500adbaebdc4c38dea4c89a2e131c45c8a1',
+      'reference' => '9174a3d80210dca8daa7f31fec659150bbeabfc6',
     ),
     'symfony/polyfill-php72' => 
     array (
@@ -952,12 +952,12 @@
     ),
     'symfony/polyfill-php80' => 
     array (
-      'pretty_version' => 'v1.23.0',
-      'version' => '1.23.0.0',
+      'pretty_version' => 'v1.23.1',
+      'version' => '1.23.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'eca0bf41ed421bed1b57c4958bab16aa86b757d0',
+      'reference' => '1100343ed1a92e3a38f9ae122fc0eb21602547be',
     ),
     'symfony/polyfill-php81' => 
     array (
@@ -970,12 +970,12 @@
     ),
     'symfony/process' => 
     array (
-      'pretty_version' => 'v5.3.2',
-      'version' => '5.3.2.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '714b47f9196de61a196d86c4bad5f09201b307df',
+      'reference' => 'd16634ee55b895bd85ec714dadc58e4428ecf030',
     ),
     'symfony/service-contracts' => 
     array (
@@ -988,12 +988,12 @@
     ),
     'symfony/stopwatch' => 
     array (
-      'pretty_version' => 'v5.3.0',
-      'version' => '5.3.0.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '313d02f59d6543311865007e5ff4ace05b35ee65',
+      'reference' => 'b24c6a92c6db316fee69e38c80591e080e41536c',
     ),
     'symfony/string' => 
     array (
@@ -1006,12 +1006,12 @@
     ),
     'symfony/translation' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.4',
+      'version' => '5.3.4.0',
       'aliases' => 
       array (
       ),
-      'reference' => '380b8c9e944d0e364b25f28e8e555241eb49c01c',
+      'reference' => 'd89ad7292932c2699cbe4af98d72c5c6bbc504c1',
     ),
     'symfony/translation-contracts' => 
     array (
@@ -1031,30 +1031,30 @@
     ),
     'symfony/yaml' => 
     array (
-      'pretty_version' => 'v5.3.3',
-      'version' => '5.3.3.0',
+      'pretty_version' => 'v5.3.6',
+      'version' => '5.3.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '485c83a2fb5893e2ff21bf4bfc7fdf48b4967229',
+      'reference' => '4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7',
     ),
     'szepeviktor/phpstan-wordpress' => 
     array (
-      'pretty_version' => 'v0.7.6',
-      'version' => '0.7.6.0',
+      'pretty_version' => 'v0.7.7',
+      'version' => '0.7.7.0',
       'aliases' => 
       array (
       ),
-      'reference' => '3721127a9ddc62c8dc14fc8726cbfb3e47529bbe',
+      'reference' => 'bdbea69b2ba4a69998c3b6fe2b7106d78a23bd72',
     ),
     'theseer/tokenizer' => 
     array (
-      'pretty_version' => '1.2.0',
-      'version' => '1.2.0.0',
+      'pretty_version' => '1.2.1',
+      'version' => '1.2.1.0',
       'aliases' => 
       array (
       ),
-      'reference' => '75a63c33a8577608444246075ea0af0d052e452a',
+      'reference' => '34a41e998c2183e22995f158c581e7b5e755ab9e',
     ),
     'voku/portable-ascii' => 
     array (
@@ -1094,12 +1094,12 @@
     ),
     'wp-cli/php-cli-tools' => 
     array (
-      'pretty_version' => 'v0.11.12',
-      'version' => '0.11.12.0',
+      'pretty_version' => 'v0.11.13',
+      'version' => '0.11.13.0',
       'aliases' => 
       array (
       ),
-      'reference' => 'e472e08489f7504d9e8c5c5a057e1419cd1b2b3e',
+      'reference' => 'a2866855ac1abc53005c102e901553ad5772dc04',
     ),
     'wp-cli/wp-cli' => 
     array (
@@ -1121,12 +1121,12 @@
     ),
     'zordius/lightncandy' => 
     array (
-      'pretty_version' => 'v1.2.5',
-      'version' => '1.2.5.0',
+      'pretty_version' => 'v1.2.6',
+      'version' => '1.2.6.0',
       'aliases' => 
       array (
       ),
-      'reference' => '37aa381e0f27d411a630062070c7a5a2174c62e7',
+      'reference' => 'b451f73e8b5c73e62e365997ba3c993a0376b72a',
     ),
   ),
 );


### PR DESCRIPTION
## Description
Fixes compatibility with WPGraphQL's new usage of lazy/eager type loading.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: Add `eagerlyLoadType` to WPGraphQL type registration.
- fix: Hook type registration on `get_graphql_register_action()`.
- fix: Typo in `addressField.copyValueOptionsLabel` type definition.
- fix: Check entry values before updating them in `SubmitGravityFormsForm` mutation.
- dev: Update composer dependencies.
- tests: Clear WPGraphQL schema before/after each test.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
