### PR TITLE
fix: use get_form() wrapper to include filters and error checks

### DIFF
--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -95,7 +95,7 @@ class GFUtils {
 		$forms = [];
 
 		foreach ( $form_ids as $form_id ) {
-			$forms[] = GFAPI::get_form( $form_id );
+			$forms[] = self::get_form( $form_id );
 		}
 
 		return $forms;


### PR DESCRIPTION
## Description
`GFUtils::get_forms()` was incorrectly using `GFAPI::get_form()` instead of `GFUtils::get_form()`. The latter is required so we can apply the gf filters on the return object, and catch graphql errors.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: consistently apply GF filters and error-checking to `GFUtils::get_forms()`
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
