### PR TITLE
dev: make DataManipulator functions static

### DIFF
--- a/src/Connections/FieldConnections.php
+++ b/src/Connections/FieldConnections.php
@@ -44,7 +44,7 @@ class FieldConnections extends AbstractConnection {
 					'connectionArgs' => self::get_connection_args(),
 					'resolve'        => static function( $root, array $args, AppContext $context, ResolveInfo $info ) {
 							$fields              = static::filter_form_fields_by_connection_args( $root['fields'], $args );
-							$fields              = ( new FieldsDataManipulator() )->manipulate( $fields );
+							$fields              = FieldsDataManipulator::manipulate( $fields );
 							$connection          = Relay::connectionFromArray( $fields, $args );
 							$nodes               = array_map( fn( $edge ) => $edge['node'] ?? null, $connection['edges'] );
 							$connection['nodes'] = $nodes ?: null;
@@ -68,7 +68,7 @@ class FieldConnections extends AbstractConnection {
 
 						$fields = self::filter_form_fields_by_connection_args( $form['fields'], $args );
 
-						$fields = ( new FieldsDataManipulator() )->manipulate( $fields );
+						$fields = FieldsDataManipulator::manipulate( $fields );
 
 						$connection = Relay::connectionFromArray( $fields, $args );
 

--- a/src/Data/Loader/EntriesLoader.php
+++ b/src/Data/Loader/EntriesLoader.php
@@ -45,11 +45,10 @@ class EntriesLoader extends AbstractDataLoader {
 			return $keys;
 		}
 
-		$gf_query               = new GF_Query();
-		$entries_from_db        = $gf_query->get_entries( $keys );
-		$entry_data_manipulator = new EntryDataManipulator();
+		$gf_query        = new GF_Query();
+		$entries_from_db = $gf_query->get_entries( $keys );
 
-		$entries = array_map( fn( array $entry ) => $entry_data_manipulator->manipulate( $entry ), $entries_from_db );
+		$entries = array_map( fn( array $entry ) => EntryDataManipulator::manipulate( $entry ), $entries_from_db );
 
 		return array_combine( $keys, $entries );
 	}

--- a/src/Data/Loader/FormsLoader.php
+++ b/src/Data/Loader/FormsLoader.php
@@ -11,7 +11,6 @@
 namespace WPGraphQLGravityForms\Data\Loader;
 
 use WPGraphQL\Data\Loader\AbstractDataLoader;
-use WPGraphQLGravityForms\DataManipulators\FieldsDataManipulator;
 use WPGraphQLGravityForms\DataManipulators\FormDataManipulator;
 use WPGraphQLGravityForms\Utils\GFUtils;
 
@@ -46,10 +45,9 @@ class FormsLoader extends AbstractDataLoader {
 			return $keys;
 		}
 
-		$forms_from_db         = GFUtils::get_forms( $keys );
-		$form_data_manipulator = new FormDataManipulator( new FieldsDataManipulator() );
+		$forms_from_db = GFUtils::get_forms( $keys );
 
-		$forms = array_map( fn( $form ) => $form_data_manipulator->manipulate( $form ), $forms_from_db );
+		$forms = array_map( fn( $form ) => FormDataManipulator::manipulate( $form ), $forms_from_db );
 
 		return array_combine( $keys, $forms );
 	}

--- a/src/DataManipulators/DraftEntryDataManipulator.php
+++ b/src/DataManipulators/DraftEntryDataManipulator.php
@@ -15,22 +15,6 @@ namespace WPGraphQLGravityForms\DataManipulators;
  */
 class DraftEntryDataManipulator {
 	/**
-	 * EntryDataManipulator instance.
-	 *
-	 * @var EntryDataManipulator
-	 */
-	private $entry_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param EntryDataManipulator $entry_data_manipulator .
-	 */
-	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
-		$this->entry_data_manipulator = $entry_data_manipulator;
-	}
-
-	/**
 	 * Manipulate draft entry data.
 	 *
 	 * @param array  $draft_entry  The draft entry data to be manipulated.
@@ -38,10 +22,10 @@ class DraftEntryDataManipulator {
 	 *
 	 * @return array Manipulated entry data.
 	 */
-	public function manipulate( array $draft_entry, string $resume_token ) : array {
-		$draft_entry = $this->set_resume_token_value( $draft_entry, $resume_token );
+	public static function manipulate( array $draft_entry, string $resume_token ) : array {
+		$draft_entry = self::set_resume_token_value( $draft_entry, $resume_token );
 
-		return $this->entry_data_manipulator->manipulate( $draft_entry );
+		return EntryDataManipulator::manipulate( $draft_entry );
 	}
 
 	/**
@@ -52,7 +36,7 @@ class DraftEntryDataManipulator {
 	 *
 	 * @return array Manipulated entry data.
 	 */
-	private function set_resume_token_value( array $draft_entry, string $resume_token ) : array {
+	private static function set_resume_token_value( array $draft_entry, string $resume_token ) : array {
 		$draft_entry['resumeToken'] = $resume_token;
 		return $draft_entry;
 	}

--- a/src/DataManipulators/EntryDataManipulator.php
+++ b/src/DataManipulators/EntryDataManipulator.php
@@ -21,11 +21,11 @@ class EntryDataManipulator implements DataManipulator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function manipulate( array $data ) : array {
-		$data = $this->set_is_draft_value( $data );
-		$data = $this->set_global_and_entry_ids( $data );
+	public static function manipulate( array $data ) : array {
+		$data = self::set_is_draft_value( $data );
+		$data = self::set_global_and_entry_ids( $data );
 
-		return $this->convert_keys_to_camelcase( $data );
+		return self::convert_keys_to_camelcase( $data );
 	}
 
 	/**
@@ -35,7 +35,7 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @return array $entry Entry data, with the isDraft value set.
 	 */
-	private function set_is_draft_value( array $entry ) : array {
+	private static function set_is_draft_value( array $entry ) : array {
 		$entry['isDraft'] = ! empty( $entry['resumeToken'] );
 		return $entry;
 	}
@@ -47,9 +47,9 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function set_global_and_entry_ids( array $entry ) : array {
+	private static function set_global_and_entry_ids( array $entry ) : array {
 		$entry['entryId'] = $entry['id'];
-		$entry['id']      = Relay::toGlobalId( Entry::$type, $this->get_id_for_global_id_generation( $entry ) );
+		$entry['id']      = Relay::toGlobalId( Entry::$type, self::get_id_for_global_id_generation( $entry ) );
 
 		return $entry;
 	}
@@ -61,7 +61,7 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @return string
 	 */
-	private function get_id_for_global_id_generation( array $entry ) : string {
+	private static function get_id_for_global_id_generation( array $entry ) : string {
 		return $entry['isDraft'] ? $entry['resumeToken'] : $entry['entryId'];
 	}
 
@@ -72,8 +72,8 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function convert_keys_to_camelcase( array $entry ) : array {
-		foreach ( $this->get_key_mappings() as $snake_case_key => $camel_case_key ) {
+	private static function convert_keys_to_camelcase( array $entry ) : array {
+		foreach ( self::get_key_mappings() as $snake_case_key => $camel_case_key ) {
 			if ( ! isset( $entry[ $snake_case_key ] ) ) {
 				continue;
 			}
@@ -90,7 +90,7 @@ class EntryDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function get_key_mappings() : array {
+	private static function get_key_mappings() : array {
 		return [
 			'form_id'          => 'formId',
 			'post_id'          => 'postId',

--- a/src/DataManipulators/FieldsDataManipulator.php
+++ b/src/DataManipulators/FieldsDataManipulator.php
@@ -21,12 +21,12 @@ class FieldsDataManipulator implements DataManipulator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function manipulate( array $data ) : array {
-		$data = array_map( [ $this, 'set_all_field_values' ], $data );
-		$data = $this->set_is_hidden_values( $data );
-		$data = $this->set_list_choice_empty_values( $data );
-		$data = $this->add_keys_to_inputs( $data, 'address' );
-		$data = $this->add_keys_to_inputs( $data, 'name' );
+	public static function manipulate( array $data ) : array {
+		$data = array_map( [ __CLASS__, 'set_all_field_values' ], $data );
+		$data = self::set_is_hidden_values( $data );
+		$data = self::set_list_choice_empty_values( $data );
+		$data = self::add_keys_to_inputs( $data, 'address' );
+		$data = self::add_keys_to_inputs( $data, 'name' );
 
 		return $data;
 	}
@@ -37,9 +37,9 @@ class FieldsDataManipulator implements DataManipulator {
 	 * @param GF_Field $field .
 	 * @return GF_Field
 	 */
-	private function set_all_field_values( GF_Field $field ) : GF_Field {
-		$field = $this->set_css_class_list_for_field( $field );
-		$field = $this->convert_value_to_expected_type( $field );
+	private static function set_all_field_values( GF_Field $field ) : GF_Field {
+		$field = self::set_css_class_list_for_field( $field );
+		$field = self::convert_value_to_expected_type( $field );
 
 		return $field;
 	}
@@ -51,7 +51,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return GF_Field
 	 */
-	private function set_css_class_list_for_field( GF_Field $field ) : GF_Field {
+	private static function set_css_class_list_for_field( GF_Field $field ) : GF_Field {
 		$field->cssClassList = array_filter(
 			explode( ' ', $field->cssClass ),
 			function( $css_class ) {
@@ -69,7 +69,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return GF_Field
 	 */
-	private function convert_value_to_expected_type( GF_Field $field ) : GF_Field {
+	private static function convert_value_to_expected_type( GF_Field $field ) : GF_Field {
 		$field->layoutGridColumnSpan = ! empty( $field->layoutGridColumnSpan ) ? (int) $field->layoutGridColumnSpan : null;
 
 		foreach ( $field as $key => $value ) {
@@ -90,7 +90,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return array $fields Form fields with address 'isHidden' values coerced to booleans.
 	 */
-	private function set_is_hidden_values( array $fields ) : array {
+	private static function set_is_hidden_values( array $fields ) : array {
 		$fields_to_modify = array_filter(
 			$fields,
 			function( $field ) {
@@ -124,7 +124,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return array $fields Form fields with the list `choices` values defined.
 	 */
-	private function set_list_choice_empty_values( array $fields ) {
+	private static function set_list_choice_empty_values( array $fields ) {
 		$empty_choices = [
 			'text'       => null,
 			'value'      => null,
@@ -154,8 +154,8 @@ class FieldsDataManipulator implements DataManipulator {
 	 * @param string $type .
 	 * @return array
 	 */
-	private function add_keys_to_inputs( array $fields, string $type ) : array {
-		$input_keys = $this->get_input_keys( $type );
+	private static function add_keys_to_inputs( array $fields, string $type ) : array {
+		$input_keys = self::get_input_keys( $type );
 
 		$fields_to_modify = array_filter(
 			$fields,
@@ -188,12 +188,12 @@ class FieldsDataManipulator implements DataManipulator {
 	 * @param string $type .
 	 * @return array
 	 */
-	private function get_input_keys( string $type ) : array {
+	private static function get_input_keys( string $type ) : array {
 		if ( 'address' === $type ) {
-			return $this->get_address_input_keys();
+			return self::get_address_input_keys();
 		}
 
-		return $this->get_name_input_keys();
+		return self::get_name_input_keys();
 	}
 
 	/**
@@ -201,7 +201,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function get_address_input_keys() {
+	private static function get_address_input_keys() {
 		return [
 			'street',
 			'lineTwo',
@@ -217,7 +217,7 @@ class FieldsDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function get_name_input_keys() {
+	private static function get_name_input_keys() {
 		return [
 			'prefix',
 			'first',

--- a/src/DataManipulators/FormDataManipulator.php
+++ b/src/DataManipulators/FormDataManipulator.php
@@ -20,31 +20,15 @@ use WPGraphQLGravityForms\Types\Form\Form;
  */
 class FormDataManipulator implements DataManipulator {
 	/**
-	 * FieldsDataManipulator instance.
-	 *
-	 * @var FieldsDataManipulator
-	 */
-	private $fields_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param FieldsDataManipulator $fields_data_manipulator .
-	 */
-	public function __construct( FieldsDataManipulator $fields_data_manipulator ) {
-		$this->fields_data_manipulator = $fields_data_manipulator;
-	}
-
-	/**
 	 * {@inheritDoc}
 	 */
-	public function manipulate( array $data ) : array {
-		$data = $this->set_global_and_form_ids( $data );
-		$data = $this->set_css_class_list( $data );
-		$data = $this->convert_form_keys_to_camelcase( $data );
-		$data = $this->prevent_missing_values( $data );
+	public static function manipulate( array $data ) : array {
+		$data = self::set_global_and_form_ids( $data );
+		$data = self::set_css_class_list( $data );
+		$data = self::convert_form_keys_to_camelcase( $data );
+		$data = self::prevent_missing_values( $data );
 
-		$data['fields'] = $this->fields_data_manipulator->manipulate( $data['fields'] );
+		$data['fields'] = FieldsDataManipulator::manipulate( $data['fields'] );
 
 		return $data;
 	}
@@ -56,7 +40,7 @@ class FormDataManipulator implements DataManipulator {
 	 *
 	 * @return array $form Form meta array with the form ID and global Relay ID set.
 	 */
-	private function set_global_and_form_ids( array $form ) : array {
+	private static function set_global_and_form_ids( array $form ) : array {
 		$form['formId'] = $form['id'];
 		$form['id']     = Relay::toGlobalId( Form::$type, $form['formId'] );
 
@@ -70,7 +54,7 @@ class FormDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function set_css_class_list( array $form ) : array {
+	private static function set_css_class_list( array $form ) : array {
 		if ( empty( $form['cssClass'] ) ) {
 			$form['cssClassList'] = null;
 			return $form;
@@ -95,7 +79,7 @@ class FormDataManipulator implements DataManipulator {
 	 *
 	 * @return array $form Form meta array with some values converted to null.
 	 */
-	private function prevent_missing_values( array $form ) : array {
+	private static function prevent_missing_values( array $form ) : array {
 		$form['limitEntriesCount']   = isset( $form['limitEntriesCount'] ) ? (int) $form['limitEntriesCount'] : false;
 		$form['scheduleStartHour']   = isset( $form['scheduleStartHour'] ) ? (int) $form['scheduleStartHour'] : null;
 		$form['scheduleStartMinute'] = isset( $form['scheduleStartMinute'] ) ? (int) $form['scheduleStartMinute'] : null;
@@ -103,7 +87,7 @@ class FormDataManipulator implements DataManipulator {
 		$form['scheduleEndMinute']   = isset( $form['scheduleEndMinute'] ) ? (int) $form['scheduleEndMinute'] : null;
 
 		if ( ! empty( $form['confirmations'] ) ) {
-			$form['confirmations'] = $this->nullify_confirmation_page_id_empty_strings( $form['confirmations'] );
+			$form['confirmations'] = static::nullify_confirmation_page_id_empty_strings( $form['confirmations'] );
 		}
 
 		return $form;
@@ -116,7 +100,7 @@ class FormDataManipulator implements DataManipulator {
 	 *
 	 * @return array Form confirmations with empty string pageId values converted to null.
 	 */
-	private function nullify_confirmation_page_id_empty_strings( array $confirmations ) : array {
+	private static function nullify_confirmation_page_id_empty_strings( array $confirmations ) : array {
 		return array_map(
 			function( $confirmation ) {
 				$confirmation['pageId'] = $confirmation['pageId'] ?: null;
@@ -133,7 +117,7 @@ class FormDataManipulator implements DataManipulator {
 	 *
 	 * @return array
 	 */
-	private function convert_form_keys_to_camelcase( array $form ) : array {
+	private static function convert_form_keys_to_camelcase( array $form ) : array {
 		$form['isActive']    = $form['is_active'];
 		$form['dateCreated'] = $form['date_created'];
 		$form['isTrash']     = $form['is_trash'];

--- a/src/Interfaces/DataManipulator.php
+++ b/src/Interfaces/DataManipulator.php
@@ -19,5 +19,5 @@ interface DataManipulator {
 	 *
 	 * @return array Manipulated data.
 	 */
-	public function manipulate( array $data ) : array;
+	public static function manipulate( array $data ) : array;
 }

--- a/src/Mutations/AbstractDraftEntryUpdater.php
+++ b/src/Mutations/AbstractDraftEntryUpdater.php
@@ -28,13 +28,6 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 	protected static $gf_type;
 
 	/**
-	 * DraftEntryDataManipulator instance.
-	 *
-	 * @var DraftEntryDataManipulator
-	 */
-	private $draft_entry_data_manipulator;
-
-	/**
 	 * The draft submission.
 	 *
 	 * @var array
@@ -54,15 +47,6 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 	 * @var mixed
 	 */
 	private $value = null;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param DraftEntryDataManipulator $draft_entry_data_manipulator .
-	 */
-	public function __construct( DraftEntryDataManipulator $draft_entry_data_manipulator ) {
-		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
-	}
 
 	/**
 	 * Defines the input field configuration.
@@ -106,7 +90,7 @@ abstract class AbstractDraftEntryUpdater extends AbstractMutation {
 				'description' => __( 'The draft entry after the update mutation has been applied. If a validation error occurred, the draft entry will NOT have been updated with the invalid value provided.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => function( array $payload ) : array {
 					$draft_submission = GFUtils::get_draft_submission( $payload['resumeToken'] );
-					return $this->draft_entry_data_manipulator->manipulate( $draft_submission['partial_entry'], $payload['resumeToken'] );
+					return DraftEntryDataManipulator::manipulate( $draft_submission['partial_entry'], $payload['resumeToken'] );
 				},
 			],
 			'errors'      => [

--- a/src/Mutations/SubmitDraftEntry.php
+++ b/src/Mutations/SubmitDraftEntry.php
@@ -32,22 +32,6 @@ class SubmitDraftEntry extends AbstractMutation {
 	public static $name = 'submitGravityFormsDraftEntry';
 
 	/**
-	 * EntryDataManipulator instance.
-	 *
-	 * @var EntryDataManipulator
-	 */
-	private $entry_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param EntryDataManipulator $entry_data_manipulator .
-	 */
-	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
-		$this->entry_data_manipulator = $entry_data_manipulator;
-	}
-
-	/**
 	 * Defines the input field configuration.
 	 *
 	 * @return array
@@ -82,7 +66,7 @@ class SubmitDraftEntry extends AbstractMutation {
 
 					$entry = GFUtils::get_entry( $payload['entryId'] );
 
-					return $this->entry_data_manipulator->manipulate( $entry );
+					return EntryDataManipulator::manipulate( $entry );
 				},
 			],
 			'errors'  => [

--- a/src/Mutations/SubmitForm.php
+++ b/src/Mutations/SubmitForm.php
@@ -36,29 +36,6 @@ class SubmitForm extends AbstractMutation {
 	public static $name = 'submitGravityFormsForm';
 
 	/**
-	 * EntryDataManipulator instance.
-	 *
-	 * @var EntryDataManipulator
-	 */
-	private $entry_data_manipulator;
-	/**
-	 * DraftEntryDataManipulator instance.
-	 *
-	 * @var DraftEntryDataManipulator
-	 */
-	private $draft_entry_data_manipulator;
-
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$instances                          = WPGraphQLGravityForms::instances();
-		$this->entry_data_manipulator       = $instances['entry_data_manipulator'];
-		$this->draft_entry_data_manipulator = $instances['draft_entry_data_manipulator'];
-	}
-
-	/**
 	 * Defines the input field configuration.
 	 */
 	public function get_input_fields() : array {
@@ -119,13 +96,13 @@ class SubmitForm extends AbstractMutation {
 					if ( $payload['resumeToken'] ) {
 						$submission = GFUtils::get_draft_submission( $payload['resumeToken'] );
 
-						return $this->draft_entry_data_manipulator->manipulate( $submission['partial_entry'], $payload['resumeToken'] );
+						return DraftEntryDataManipulator::manipulate( $submission['partial_entry'], $payload['resumeToken'] );
 					}
 
 					if ( $payload['entryId'] ) {
 						$entry = GFUtils::get_entry( $payload['entryId'] );
 
-						return $this->entry_data_manipulator->manipulate( $entry );
+						return EntryDataManipulator::manipulate( $entry );
 					}
 				},
 			],

--- a/src/Mutations/UpdateDraftEntry.php
+++ b/src/Mutations/UpdateDraftEntry.php
@@ -31,13 +31,6 @@ class UpdateDraftEntry extends AbstractMutation {
 	public static $name = 'updateGravityFormsDraftEntry';
 
 	/**
-	 * DraftEntryDataManipulator instance.
-	 *
-	 * @var DraftEntryDataManipulator
-	 */
-	private $draft_entry_data_manipulator;
-
-	/**
 	 * The draft submission.
 	 *
 	 * @var array
@@ -50,15 +43,6 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * @var array
 	 */
 	protected $errors = [];
-
-	/**
-	 * Constructor.
-	 *
-	 * @param DraftEntryDataManipulator $draft_entry_data_manipulator .
-	 */
-	public function __construct( DraftEntryDataManipulator $draft_entry_data_manipulator ) {
-		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
-	}
 
 	/**
 	 * Defines the input field configuration.
@@ -109,7 +93,7 @@ class UpdateDraftEntry extends AbstractMutation {
 						return null;
 					}
 					$draft_submission = GFUtils::get_draft_submission( $payload['resumeToken'] );
-					return $this->draft_entry_data_manipulator->manipulate( $draft_submission['partial_entry'], $payload['resumeToken'] );
+					return DraftEntryDataManipulator::manipulate( $draft_submission['partial_entry'], $payload['resumeToken'] );
 				},
 			],
 			'errors'      => [

--- a/src/Mutations/UpdateEntry.php
+++ b/src/Mutations/UpdateEntry.php
@@ -33,27 +33,11 @@ class UpdateEntry extends AbstractMutation {
 	public static $name = 'updateGravityFormsEntry';
 
 	/**
-	 * EntryDataManipulator instance.
-	 *
-	 * @var EntryDataManipulator
-	 */
-	private $entry_data_manipulator;
-
-	/**
 	 * Gravity Forms field validation errors.
 	 *
 	 * @var array
 	 */
 	protected $errors = [];
-
-	/**
-	 * Constructor
-	 *
-	 * @param EntryDataManipulator $entry_data_manipulator .
-	 */
-	public function __construct( EntryDataManipulator $entry_data_manipulator ) {
-		$this->entry_data_manipulator = $entry_data_manipulator;
-	}
 
 	/**
 	 * Defines the input field configuration.
@@ -114,7 +98,7 @@ class UpdateEntry extends AbstractMutation {
 
 					$entry = GFUtils::get_entry( $payload['entryId'] );
 
-					return $this->entry_data_manipulator->manipulate( $entry );
+					return EntryDataManipulator::manipulate( $entry );
 				},
 			],
 			'errors'  => [

--- a/src/Types/Entry/Entry.php
+++ b/src/Types/Entry/Entry.php
@@ -42,34 +42,6 @@ class Entry extends AbstractObject implements Field {
 	public static $field_name = 'gravityFormsEntry';
 
 	/**
-	 * EntryDataManipulator instance.
-	 *
-	 * @var EntryDataManipulator
-	 */
-	private $entry_data_manipulator;
-
-	/**
-	 * DraftEntryDataManipulator instance.
-	 *
-	 * @var DraftEntryDataManipulator
-	 */
-	private $draft_entry_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param EntryDataManipulator      $entry_data_manipulator .
-	 * @param DraftEntryDataManipulator $draft_entry_data_manipulator .
-	 */
-	public function __construct(
-		EntryDataManipulator $entry_data_manipulator,
-		DraftEntryDataManipulator $draft_entry_data_manipulator
-	) {
-		$this->entry_data_manipulator       = $entry_data_manipulator;
-		$this->draft_entry_data_manipulator = $draft_entry_data_manipulator;
-	}
-
-	/**
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
@@ -211,7 +183,7 @@ class Entry extends AbstractObject implements Field {
 						$entry = GFAPI::get_entry( $id );
 
 						if ( ! is_wp_error( $entry ) ) {
-							return $this->entry_data_manipulator->manipulate( $entry );
+							return EntryDataManipulator::manipulate( $entry );
 						}
 					}
 
@@ -219,7 +191,7 @@ class Entry extends AbstractObject implements Field {
 					$submission = GFUtils::get_draft_submission( (string) $id );
 
 					// @TODO: Evaluate if resume_token is actually needed.
-					return $this->draft_entry_data_manipulator->manipulate( $submission['partial_entry'], (string) $id );
+					return DraftEntryDataManipulator::manipulate( $submission['partial_entry'], (string) $id );
 				},
 			]
 		);

--- a/src/Types/Entry/EntryForm.php
+++ b/src/Types/Entry/EntryForm.php
@@ -34,22 +34,6 @@ class EntryForm extends AbstractObject implements Field {
 	public static $field_name = 'form';
 
 	/**
-	 * FormDataManipulator instance.
-	 *
-	 * @var FormDataManipulator
-	 */
-	private $form_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param FormDataManipulator $form_data_manipulator .
-	 */
-	public function __construct( FormDataManipulator $form_data_manipulator ) {
-		$this->form_data_manipulator = $form_data_manipulator;
-	}
-
-	/**
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
@@ -92,7 +76,7 @@ class EntryForm extends AbstractObject implements Field {
 					$form = GFUtils::get_form( $entry['formId'], false );
 
 					return [
-						'node' => $this->form_data_manipulator->manipulate( $form ),
+						'node' => FormDataManipulator::manipulate( $form ),
 					];
 				},
 			]

--- a/src/Types/Form/Form.php
+++ b/src/Types/Form/Form.php
@@ -39,22 +39,6 @@ class Form extends AbstractObject implements Field {
 	public static $field_name = 'gravityFormsForm';
 
 	/**
-	 * FormDataManipulator instance.
-	 *
-	 * @var FormDataManipulator
-	 */
-	private $form_data_manipulator;
-
-	/**
-	 * Constructor
-	 *
-	 * @param FormDataManipulator $form_data_manipulator .
-	 */
-	public function __construct( FormDataManipulator $form_data_manipulator ) {
-		$this->form_data_manipulator = $form_data_manipulator;
-	}
-
-	/**
 	 * {@inheritDoc}.
 	 */
 	public function register_hooks() : void {
@@ -331,7 +315,7 @@ class Form extends AbstractObject implements Field {
 
 					$form_raw = GFUtils::get_form( $id, false );
 
-					$form = $this->form_data_manipulator->manipulate( $form_raw );
+					$form = FormDataManipulator::manipulate( $form_raw );
 
 					/**
 					 * "wp_graphql_gf_form_object" filter

--- a/src/WPGraphQLGravityForms.php
+++ b/src/WPGraphQLGravityForms.php
@@ -59,12 +59,6 @@ final class WPGraphQLGravityForms {
 		// Settings.
 		self::$instances['wpgraphql_settings'] = new Settings\WPGraphQLSettings();
 
-		// Data manipulators.
-		self::$instances['fields_data_manipulator']      = new DataManipulators\FieldsDataManipulator();
-		self::$instances['form_data_manipulator']        = new DataManipulators\FormDataManipulator( self::$instances['fields_data_manipulator'] );
-		self::$instances['entry_data_manipulator']       = new DataManipulators\EntryDataManipulator();
-		self::$instances['draft_entry_data_manipulator'] = new DataManipulators\DraftEntryDataManipulator( self::$instances['entry_data_manipulator'] );
-
 		// Data loaders.
 		self::$instances['loader_registrar'] = new Data\Loader\LoadersRegistrar();
 
@@ -82,7 +76,7 @@ final class WPGraphQLGravityForms {
 		self::$instances['form_notification']         = new Form\FormNotification();
 		self::$instances['form_confirmation']         = new Form\FormConfirmation();
 		self::$instances['form_pagination']           = new Form\FormPagination();
-		self::$instances['form']                      = new Form\Form( self::$instances['form_data_manipulator'] );
+		self::$instances['form']                      = new Form\Form();
 
 		// Field Properties.
 		self::$instances['address_input_property']         = new FieldProperty\AddressInputProperty();
@@ -202,8 +196,8 @@ final class WPGraphQLGravityForms {
 		self::$instances['website_field_value_property']        = new ValueProperty\WebsiteFieldValueProperty();
 
 		// Entries.
-		self::$instances['entry']      = new Entry\Entry( self::$instances['entry_data_manipulator'], self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['entry_form'] = new Entry\EntryForm( self::$instances['form_data_manipulator'] );
+		self::$instances['entry']      = new Entry\Entry();
+		self::$instances['entry_form'] = new Entry\EntryForm();
 		self::$instances['entry_user'] = new Entry\EntryUser();
 
 		// Input.
@@ -274,35 +268,35 @@ final class WPGraphQLGravityForms {
 		self::$instances['create_draft_entry']                            = new Mutations\CreateDraftEntry();
 		self::$instances['delete_draft_entry']                            = new Mutations\DeleteDraftEntry();
 		self::$instances['delete_entry']                                  = new Mutations\DeleteEntry();
-		self::$instances['submit_draft_entry']                            = new Mutations\SubmitDraftEntry( self::$instances['entry_data_manipulator'] );
+		self::$instances['submit_draft_entry']                            = new Mutations\SubmitDraftEntry();
 		self::$instances['submit_form']                                   = new Mutations\SubmitForm();
-		self::$instances['update_draft_entry_address_field_value']        = new Mutations\UpdateDraftEntryAddressFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_chained_select_field_value'] = new Mutations\UpdateDraftEntryChainedSelectFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_checkbox_field_value']       = new Mutations\UpdateDraftEntryCheckboxFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_consent_field_value']        = new Mutations\UpdateDraftEntryConsentFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_date_field_value']           = new Mutations\UpdateDraftEntryDateFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_email_field_value']          = new Mutations\UpdateDraftEntryEmailFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_hidden_field_value']         = new Mutations\UpdateDraftEntryHiddenFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_list_field_value']           = new Mutations\UpdateDraftEntryListFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_multi_select_field_value']   = new Mutations\UpdateDraftEntryMultiSelectFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_name_field_value']           = new Mutations\UpdateDraftEntryNameFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_number_field_value']         = new Mutations\UpdateDraftEntryNumberFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_phone_field_value']          = new Mutations\UpdateDraftEntryPhoneFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_category_field_value']  = new Mutations\UpdateDraftEntryPostCategoryFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_content_field_value']   = new Mutations\UpdateDraftEntryPostContentFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_custom_field_value']    = new Mutations\UpdateDraftEntryPostCustomFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_excerpt_field_value']   = new Mutations\UpdateDraftEntryPostExcerptFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_tags_field_value']      = new Mutations\UpdateDraftEntryPostTagsFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_post_title_field_value']     = new Mutations\UpdateDraftEntryPostTitleFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_radio_field_value']          = new Mutations\UpdateDraftEntryRadioFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_select_field_value']         = new Mutations\UpdateDraftEntrySelectFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_signature_field_value']      = new Mutations\UpdateDraftEntrySignatureFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_text_area_field_value']      = new Mutations\UpdateDraftEntryTextAreaFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_text_field_value']           = new Mutations\UpdateDraftEntryTextFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_time_field_value']           = new Mutations\UpdateDraftEntryTimeFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry_website_field_value']        = new Mutations\UpdateDraftEntryWebsiteFieldValue( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_draft_entry']                            = new Mutations\UpdateDraftEntry( self::$instances['draft_entry_data_manipulator'] );
-		self::$instances['update_entry']                                  = new Mutations\UpdateEntry( self::$instances['entry_data_manipulator'] );
+		self::$instances['update_draft_entry_address_field_value']        = new Mutations\UpdateDraftEntryAddressFieldValue();
+		self::$instances['update_draft_entry_chained_select_field_value'] = new Mutations\UpdateDraftEntryChainedSelectFieldValue();
+		self::$instances['update_draft_entry_checkbox_field_value']       = new Mutations\UpdateDraftEntryCheckboxFieldValue();
+		self::$instances['update_draft_entry_consent_field_value']        = new Mutations\UpdateDraftEntryConsentFieldValue();
+		self::$instances['update_draft_entry_date_field_value']           = new Mutations\UpdateDraftEntryDateFieldValue();
+		self::$instances['update_draft_entry_email_field_value']          = new Mutations\UpdateDraftEntryEmailFieldValue();
+		self::$instances['update_draft_entry_hidden_field_value']         = new Mutations\UpdateDraftEntryHiddenFieldValue();
+		self::$instances['update_draft_entry_list_field_value']           = new Mutations\UpdateDraftEntryListFieldValue();
+		self::$instances['update_draft_entry_multi_select_field_value']   = new Mutations\UpdateDraftEntryMultiSelectFieldValue();
+		self::$instances['update_draft_entry_name_field_value']           = new Mutations\UpdateDraftEntryNameFieldValue();
+		self::$instances['update_draft_entry_number_field_value']         = new Mutations\UpdateDraftEntryNumberFieldValue();
+		self::$instances['update_draft_entry_phone_field_value']          = new Mutations\UpdateDraftEntryPhoneFieldValue();
+		self::$instances['update_draft_entry_post_category_field_value']  = new Mutations\UpdateDraftEntryPostCategoryFieldValue();
+		self::$instances['update_draft_entry_post_content_field_value']   = new Mutations\UpdateDraftEntryPostContentFieldValue();
+		self::$instances['update_draft_entry_post_custom_field_value']    = new Mutations\UpdateDraftEntryPostCustomFieldValue();
+		self::$instances['update_draft_entry_post_excerpt_field_value']   = new Mutations\UpdateDraftEntryPostExcerptFieldValue();
+		self::$instances['update_draft_entry_post_tags_field_value']      = new Mutations\UpdateDraftEntryPostTagsFieldValue();
+		self::$instances['update_draft_entry_post_title_field_value']     = new Mutations\UpdateDraftEntryPostTitleFieldValue();
+		self::$instances['update_draft_entry_radio_field_value']          = new Mutations\UpdateDraftEntryRadioFieldValue();
+		self::$instances['update_draft_entry_select_field_value']         = new Mutations\UpdateDraftEntrySelectFieldValue();
+		self::$instances['update_draft_entry_signature_field_value']      = new Mutations\UpdateDraftEntrySignatureFieldValue();
+		self::$instances['update_draft_entry_text_area_field_value']      = new Mutations\UpdateDraftEntryTextAreaFieldValue();
+		self::$instances['update_draft_entry_text_field_value']           = new Mutations\UpdateDraftEntryTextFieldValue();
+		self::$instances['update_draft_entry_time_field_value']           = new Mutations\UpdateDraftEntryTimeFieldValue();
+		self::$instances['update_draft_entry_website_field_value']        = new Mutations\UpdateDraftEntryWebsiteFieldValue();
+		self::$instances['update_draft_entry']                            = new Mutations\UpdateDraftEntry();
+		self::$instances['update_entry']                                  = new Mutations\UpdateEntry();
 
 		/**
 		 * Filter for instantiating custom WPGraphQLGF class instances.

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -32,7 +32,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => 'c4252fb9f4a69d48ba12be373e0d337ec534865b',
+    'reference' => 'b02dbb462963de7558327abddd1992d6bb268de7',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -272,7 +272,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => 'c4252fb9f4a69d48ba12be373e0d337ec534865b',
+      'reference' => 'b02dbb462963de7558327abddd1992d6bb268de7',
     ),
     'hautelook/phpass' => 
     array (

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => 'c4252fb9f4a69d48ba12be373e0d337ec534865b',
+    'reference' => 'b02dbb462963de7558327abddd1992d6bb268de7',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -246,7 +246,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => 'c4252fb9f4a69d48ba12be373e0d337ec534865b',
+      'reference' => 'b02dbb462963de7558327abddd1992d6bb268de7',
     ),
     'hautelook/phpass' => 
     array (


### PR DESCRIPTION
## Description
This PR converts data manipulators to static functions. This means we can call those `manipulate()` functions without passing an instantiated class. In addition to simplifying the code complexity, this will make it easier to switch those classes for WPGraphQL models.
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- dev: make DataManipulator functions static
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
