### PR TITLE
feat: add `conditionalLogic` to `formConfirmation` object type.

### DIFF
--- a/src/Types/Form/FormConfirmation.php
+++ b/src/Types/Form/FormConfirmation.php
@@ -11,6 +11,7 @@
 namespace WPGraphQLGravityForms\Types\Form;
 
 use WPGraphQLGravityForms\Types\AbstractObject;
+use WPGraphQLGravityForms\Types\ConditionalLogic\ConditionalLogic;
 use WPGraphQLGravityForms\Types\Enum\ConfirmationTypeEnum;
 
 /**
@@ -38,37 +39,41 @@ class FormConfirmation extends AbstractObject {
 	 */
 	public function get_type_fields() : array {
 		return [
-			'id'          => [
+			'conditionalLogic' => [
+				'type'        => ConditionalLogic::$type,
+				'description' => __( 'Controls which form confirmation message should be displayed.', 'wp-graphql-gravity-forms' ),
+			],
+			'id'               => [
 				'type'        => 'String',
 				'description' => __( 'ID.', 'wp-graphql-gravity-forms' ),
 			],
-			'name'        => [
-				'type'        => 'String',
-				'description' => __( 'Name.', 'wp-graphql-gravity-forms' ),
-			],
-			'isDefault'   => [
+			'isDefault'        => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is the default confirmation.', 'wp-graphql-gravity-forms' ),
 			],
-			'type'        => [
-				'type'        => ConfirmationTypeEnum::$type,
-				'description' => __( 'Determines the type of confirmation to be used.', 'wp-graphql-gravity-forms' ),
-			],
-			'message'     => [
+			'message'          => [
 				'type'        => 'String',
 				'description' => __( 'Contains the confirmation message that will be displayed. Only applicable when type is set to "MESSAGE".', 'wp-graphql-gravity-forms' ),
 			],
-			'url'         => [
+			'name'             => [
 				'type'        => 'String',
-				'description' => __( 'Contains the URL that the browser will be redirected to. Only applicable when type is set to "REDIRECT".', 'wp-graphql-gravity-forms' ),
+				'description' => __( 'The confirmation name.', 'wp-graphql-gravity-forms' ),
 			],
-			'pageId'      => [
+			'pageId'           => [
 				'type'        => 'Integer',
 				'description' => __( 'Contains the Id of the WordPress page that the browser will be redirected to. Only applicable when type is set to "PAGE".', 'wp-graphql-gravity-forms' ),
 			],
-			'queryString' => [
+			'queryString'      => [
 				'type'        => 'String',
 				'description' => __( 'Contains the query string to be appended to the redirection url. Only applicable when type is set to redirect.', 'wp-graphql-gravity-forms' ),
+			],
+			'type'             => [
+				'type'        => ConfirmationTypeEnum::$type,
+				'description' => __( 'Determines the type of confirmation to be used.', 'wp-graphql-gravity-forms' ),
+			],
+			'url'              => [
+				'type'        => 'String',
+				'description' => __( 'Contains the URL that the browser will be redirected to. Only applicable when type is set to "REDIRECT".', 'wp-graphql-gravity-forms' ),
 			],
 		];
 	}

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -664,14 +664,30 @@ class Wpunit extends \Codeception\Module {
 			],
 			'confirmations'              => [
 				'5cfec9464e7d7' => [
-					'id'          => '5cfec9464e7d7',
-					'isDefault'   => true,
-					'message'     => 'Thanks for contacting us! We will get in touch with you shortly.',
-					'name'        => 'Default Confirmation',
-					'pageId'      => 1,
-					'queryString' => 'text={Single Line Text:1}&textarea={Text Area:2}',
-					'type'        => 'message',
-					'url'         => 'https://example.com/',
+					'id'               => '5cfec9464e7d7',
+					'isDefault'        => true,
+					'message'          => 'Thanks for contacting us! We will get in touch with you shortly.',
+					'name'             => 'Default Confirmation',
+					'pageId'           => null,
+					'queryString'      => 'text={Single Line Text:1}&textarea={Text Area:2}',
+					'type'             => 'message',
+					'url'              => 'https://example.com/',
+					'conditionalLogic' => [
+						'actionType' => 'show',
+						'logicType'  => 'any',
+						'rules'      => [
+							[
+								'fieldId'  => 1,
+								'operator' => 'is',
+								'value'    => 'value1',
+							],
+							[
+								'fieldId'  => 1,
+								'operator' => 'is',
+								'value'    => 'value2',
+							],
+						],
+					],
 				],
 			],
 			'cssClass'                   => 'css-class-1 css-class-2',

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -91,14 +91,30 @@ class FormQueriesTest extends GFGraphQLTestCase {
 				],
 				'confirmations'              => [
 					[
-						'id'          => $form['confirmations']['5cfec9464e7d7']['id'],
-						'isDefault'   => $form['confirmations']['5cfec9464e7d7']['isDefault'],
-						'message'     => $form['confirmations']['5cfec9464e7d7']['message'],
-						'name'        => $form['confirmations']['5cfec9464e7d7']['name'],
-						'pageId'      => $form['confirmations']['5cfec9464e7d7']['pageId'],
-						'queryString' => $form['confirmations']['5cfec9464e7d7']['queryString'],
-						'type'        => $this->tester->get_enum_for_value( Enum\ConfirmationTypeEnum::$type, $form['confirmations']['5cfec9464e7d7']['type'] ),
-						'url'         => $form['confirmations']['5cfec9464e7d7']['url'],
+						'id'               => $form['confirmations']['5cfec9464e7d7']['id'],
+						'isDefault'        => $form['confirmations']['5cfec9464e7d7']['isDefault'],
+						'message'          => $form['confirmations']['5cfec9464e7d7']['message'],
+						'name'             => $form['confirmations']['5cfec9464e7d7']['name'],
+						'pageId'           => $form['confirmations']['5cfec9464e7d7']['pageId'],
+						'queryString'      => $form['confirmations']['5cfec9464e7d7']['queryString'],
+						'type'             => $this->tester->get_enum_for_value( Enum\ConfirmationTypeEnum::$type, $form['confirmations']['5cfec9464e7d7']['type'] ),
+						'url'              => $form['confirmations']['5cfec9464e7d7']['url'],
+						'conditionalLogic' => [
+							'actionType' => $this->tester->get_enum_for_value( Enum\ConditionalLogicActionTypeEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['actionType'] ),
+							'logicType'  => $this->tester->get_enum_for_value( Enum\ConditionalLogicLogicTypeEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['logicType'] ),
+							'rules'      => [
+								[
+									'fieldId'  => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['fieldId'],
+									'operator' => $this->tester->get_enum_for_value( Enum\RuleOperatorEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['operator'] ),
+									'value'    => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['value'],
+								],
+								[
+									'fieldId'  => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['fieldId'],
+									'operator' => $this->tester->get_enum_for_value( Enum\RuleOperatorEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['operator'] ),
+									'value'    => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['value'],
+								],
+							],
+						],
 					],
 				],
 				'cssClass'                   => $form['cssClass'],
@@ -265,14 +281,30 @@ class FormQueriesTest extends GFGraphQLTestCase {
 					'button'                     => null,
 					'confirmations'              => [
 						[
-							'id'          => $form['confirmations'][ $confirmation_key ]['id'],
-							'isDefault'   => $form['confirmations'][ $confirmation_key ]['isDefault'],
-							'message'     => $form['confirmations'][ $confirmation_key ]['message'],
-							'name'        => $form['confirmations'][ $confirmation_key ]['name'],
-							'pageId'      => $form['confirmations'][ $confirmation_key ]['pageId'],
-							'queryString' => $form['confirmations'][ $confirmation_key ]['queryString'],
-							'type'        => $this->tester->get_enum_for_value( Enum\ConfirmationTypeEnum::$type, $form['confirmations'][ $confirmation_key ]['type'] ),
-							'url'         => $form['confirmations'][ $confirmation_key ]['url'],
+							'id'               => $form['confirmations'][ $confirmation_key ]['id'],
+							'isDefault'        => $form['confirmations'][ $confirmation_key ]['isDefault'],
+							'message'          => $form['confirmations'][ $confirmation_key ]['message'],
+							'name'             => $form['confirmations'][ $confirmation_key ]['name'],
+							'pageId'           => $form['confirmations'][ $confirmation_key ]['pageId'],
+							'queryString'      => $form['confirmations'][ $confirmation_key ]['queryString'],
+							'type'             => $this->tester->get_enum_for_value( Enum\ConfirmationTypeEnum::$type, $form['confirmations'][ $confirmation_key ]['type'] ),
+							'url'              => $form['confirmations'][ $confirmation_key ]['url'],
+							'conditionalLogic' => [
+								'actionType' => $this->tester->get_enum_for_value( Enum\ConditionalLogicActionTypeEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['actionType'] ),
+								'logicType'  => $this->tester->get_enum_for_value( Enum\ConditionalLogicLogicTypeEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['logicType'] ),
+								'rules'      => [
+									[
+										'fieldId'  => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['fieldId'],
+										'operator' => $this->tester->get_enum_for_value( Enum\RuleOperatorEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['operator'] ),
+										'value'    => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][0]['value'],
+									],
+									[
+										'fieldId'  => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['fieldId'],
+										'operator' => $this->tester->get_enum_for_value( Enum\RuleOperatorEnum::$type, $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['operator'] ),
+										'value'    => $form['notifications']['5cfec9464e529']['conditionalLogic']['rules'][1]['value'],
+									],
+								],
+							],
 						],
 					],
 					'cssClass'                   => null,
@@ -489,7 +521,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 			'last'   => 2,
 			'before' => $response['data']['gravityFormsForms']['pageInfo']['endCursor'],
 		];
-		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$response  = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayNotHasKey( 'errors', $response, 'Last/before #2 array has errors.' );
 		$this->assertCount( 2, $response['data']['gravityFormsForms']['nodes'], 'last/before does not return correct amount.' );
@@ -611,6 +643,15 @@ class FormQueriesTest extends GFGraphQLTestCase {
 						queryString
 						type
 						url
+						conditionalLogic {
+							actionType
+							logicType
+							rules {
+								fieldId
+								operator
+								value
+							}
+						}
 					}
 					cssClass
 					customRequiredIndicator


### PR DESCRIPTION
## Description
Adds the `conditionalLogic` GraphQL field to `gravityFormsForm.confirmations` type.

GF supports this in the GUI, even though its (not listed in the docs)[https://docs.gravityforms.com/confirmation-object/].

h/t @natac13 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- feat: add `conditionalLogic` to `formConfirmation` object type.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
