### PR TITLE
feat: filter `formFields` by page

### DIFF
--- a/src/Connection/FormFieldConnections.php
+++ b/src/Connection/FormFieldConnections.php
@@ -95,7 +95,10 @@ class FormFieldConnections extends AbstractConnection {
 				'type'        => [ 'list_of' => FormFieldsEnum::$type ],
 				'description' => __( 'Array of Gravity Forms Field types to return.', 'wp-graphql-gravity-forms' ),
 			],
-			// @todo PageNumber
+			'page'        => [
+				'type'        => 'Int',
+				'description' => __( 'The form page number to return', 'wp-graphql-gravity-forms' ),
+			],
 		];
 	}
 
@@ -133,6 +136,12 @@ class FormFieldConnections extends AbstractConnection {
 			}
 
 			$fields = array_filter( $fields, fn( $field ) => in_array( $field['type'], $args['where']['types'], true ) );
+		}
+
+		if ( isset( $args['where']['page'] ) ) {
+			$page = absint( $args['where']['page'] );
+
+			$fields = array_filter( $fields, fn( $field ) => $page === (int) $field['pageNumber'] );
 		}
 
 		return $fields;


### PR DESCRIPTION
## Description
Adds a `page` arg to all `formField` connections, allowing filtering form fields by page.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- feat: add `page` filter to `formFields`.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
