### PR TITLE
fix: make `formField.type` nullable (for gatsby-source-wordpressl)

### DIFF
--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -119,6 +119,7 @@ class FormField implements Registrable, Type, TypeWithFields {
 				'type'        => 'Int',
 				'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
 			],
+			// @todo make non-null once gatsby-source-wordpress supports it: https://github.com/gatsbyjs/gatsby/issues/34489 .
 			'type'                       => [
 				'type'        => FormFieldTypeEnum::$type,
 				'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -120,7 +120,7 @@ class FormField implements Registrable, Type, TypeWithFields {
 				'description' => __( 'The form page this field is located on. Default is 1.', 'wp-graphql-gravity-forms' ),
 			],
 			'type'                       => [
-				'type'        => [ 'non_null' => FormFieldTypeEnum::$type ],
+				'type'        => FormFieldTypeEnum::$type,
 				'description' => __( 'The type of field to be displayed.', 'wp-graphql-gravity-forms' ),
 			],
 			'visibility'                 => [


### PR DESCRIPTION
## Description
`gatsby-source-wordpress` currently [can't handle non-nullable enums](https://github.com/gatsbyjs/gatsby/issues/34489).

Until that gets fixed, field `type` on interface `FormField` has been changed to a nullable type.

This _is not_ a breaking change. However, reverting the field back to `non_null` **would be considered breaking**  

Fixes #202 .

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: make `formField.type` nullable, to play nicely with `gatbsy-source-wordpress`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
