### PR TITLE
Fix: Dont reregister duplicate fields (WPGraphQL 1.6.11 compat)

### DIFF
--- a/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldProperty/PropertyMapper.php
+++ b/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldProperty/PropertyMapper.php
@@ -64,9 +64,11 @@ class PropertyMapper {
 		$choice_fields += FieldProperties::choice_value();
 		$choice_fields += FieldProperties::choice_is_selected();
 
+		// Create the `choices` property.
 		$mapped_choice = ChoiceMapper::map_choices( $field, $choice_fields );
 		$properties   += $mapped_choice;
 
+		// Add field `choices.choices`.
 		ChoiceMapper::add_fields_to_choice( $field, $mapped_choice );
 
 		$input_fields  = FieldProperties::label();

--- a/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldProperty/PropertyMapper.php
+++ b/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldProperty/PropertyMapper.php
@@ -64,10 +64,10 @@ class PropertyMapper {
 		$choice_fields += FieldProperties::choice_value();
 		$choice_fields += FieldProperties::choice_is_selected();
 
-		// Nest choices.
-		$choice_fields += ChoiceMapper::map_choices( $field, $choice_fields );
+		$mapped_choice = ChoiceMapper::map_choices( $field, $choice_fields );
+		$properties   += $mapped_choice;
 
-		$properties += ChoiceMapper::map_choices( $field, $choice_fields );
+		ChoiceMapper::add_fields_to_choice( $field, $mapped_choice );
 
 		$input_fields  = FieldProperties::label();
 		$input_fields += FieldProperties::input_id();

--- a/src/Type/WPObject/FormField/FieldProperty/ChoiceMapper.php
+++ b/src/Type/WPObject/FormField/FieldProperty/ChoiceMapper.php
@@ -4,6 +4,8 @@
  *
  * @package WPGraphQL\GF\Type\WPObject\FormField\FieldProperty;
  * @since   0.10.0
+ *
+ * @todo maybe refactor to Trait?
  */
 
 namespace WPGraphQL\GF\Type\WPObject\FormField\FieldProperty;
@@ -38,6 +40,7 @@ class ChoiceMapper {
 
 		$name = Utils::get_safe_form_field_type_name( ( $field->type !== $input_type ? $field->type . '_' . $input_type : $field->type ) . 'FieldChoice' );
 
+		// Don't register duplicate fields.
 		if ( ! in_array( $name, self::$registered_types, true ) ) {
 			register_graphql_object_type(
 				$name,

--- a/src/Type/WPObject/FormField/FieldProperty/ChoiceMapper.php
+++ b/src/Type/WPObject/FormField/FieldProperty/ChoiceMapper.php
@@ -17,6 +17,15 @@ use WPGraphQL\GF\Utils\Utils;
  */
 class ChoiceMapper {
 	/**
+	 * An array of GraphQL type names registered by the class.
+	 *
+	 * Used to prevent reregistering duplicate types.
+	 *
+	 * @var array
+	 */
+	public static array $registered_types = [];
+
+	/**
 	 * Registers a GraphQL object type for the choice, and returns the GF Field `choices`.
 	 *
 	 * @todo use inputType names for inherited fields. Needs a way to handle unknown input types at registration.
@@ -29,19 +38,23 @@ class ChoiceMapper {
 
 		$name = Utils::get_safe_form_field_type_name( ( $field->type !== $input_type ? $field->type . '_' . $input_type : $field->type ) . 'FieldChoice' );
 
-		register_graphql_object_type(
-			$name,
-			[
-				// translators: GF field type.
-				'description' => sprintf( __( '%s choice values.', 'wp-graphql-gravity-forms' ), ucfirst( $field->type ) ),
-				'fields'      => $choice_fields,
-				'resolve'     => function( GF_Field $source, array $args, AppContext $context ) {
-					$context->gfField = $source;
+		if ( ! in_array( $name, self::$registered_types, true ) ) {
+			register_graphql_object_type(
+				$name,
+				[
+					// translators: GF field type.
+					'description' => sprintf( __( '%s choice values.', 'wp-graphql-gravity-forms' ), ucfirst( $field->type ) ),
+					'fields'      => $choice_fields,
+					'resolve'     => function( GF_Field $source, array $args, AppContext $context ) {
+						$context->gfField = $source;
 
-					return ! empty( $source->choices ) ? $source->choices : null;
-				},
-			]
-		);
+						return ! empty( $source->choices ) ? $source->choices : null;
+					},
+				]
+			);
+
+			self::$registered_types[] = $name;
+		}
 
 		return [
 			'choices' => [

--- a/src/Type/WPObject/FormField/FieldProperty/InputMapper.php
+++ b/src/Type/WPObject/FormField/FieldProperty/InputMapper.php
@@ -4,6 +4,8 @@
  *
  * @package WPGraphQL\GF\Type\WPObject\FormField\FieldProperty;
  * @since   0.10.0
+ *
+ * @todo maybe refactor to Trait?
  */
 
 namespace WPGraphQL\GF\Type\WPObject\FormField\FieldProperty;
@@ -19,7 +21,7 @@ class InputMapper {
 	/**
 	 * An array of GraphQL type names registered by the class.
 	 *
-	 * Used to prevent reregistering duplicate types.
+	 * Used to prevent reregistering duplicate types, since `graphql_register_types()` doesn't run until later.
 	 *
 	 * @var array
 	 */
@@ -34,6 +36,7 @@ class InputMapper {
 	public static function map_inputs( GF_Field $field, array $input_fields ) : array {
 		$name = Utils::get_safe_form_field_type_name( $field->type . 'InputProperty' );
 
+		// Don't register duplicate fields.
 		if ( ! in_array( $name, self::$registered_types, true ) ) {
 			register_graphql_object_type(
 				$name,

--- a/tests/_support/TestCase/FormFieldTestCase.php
+++ b/tests/_support/TestCase/FormFieldTestCase.php
@@ -14,6 +14,9 @@ use GFFormsModel;
 use GFAPI;
 use GF_Field;
 use Helper\GFHelpers\ExpectedFormFields;
+use ReflectionProperty;
+use WPGraphQL\GF\Type\WPObject\FormField\FieldProperty\ChoiceMapper;
+use WPGraphQL\GF\Type\WPObject\FormField\FieldProperty\InputMapper;
 use WPGraphQL\GF\Type\WPObject\FormField\FormFields;
 
 /**
@@ -106,6 +109,15 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 		$this->factory->draft_entry->delete( $this->draft_token );
 		$this->factory->form->delete( $this->form_id );
 		GFFormsModel::set_current_lead( null );
+
+		// Reset static properties.
+		$choices = new ReflectionProperty( ChoiceMapper::class, 'registered_types' );
+		$choices->setAccessible( true );
+		$choices->setValue( null, [] );
+		$inputs = new ReflectionProperty( InputMapper::class, 'registered_types' );
+		$inputs->setAccessible( true );
+		$inputs->setValue( null, [] );
+
 		// Then...
 		parent::tearDown();
 	}


### PR DESCRIPTION
## Description
WPGraphQL v1.6.11 causes `DUPLICATE_FIELD` errors to appear on formField queries.

This PR fixes those duplicate objects, by locally tracking which `{type}FieldChoice` /`{type}InputProperty` have already been queued to register.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: don't reregister GraphQL generated form field `{type}FieldChoice` and `{type}InputProperty`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
