### PR TITLE
feat: add field `isActive` to `FormConfirmation`

### DIFF
--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -57,8 +57,14 @@ class Form extends Model {
 					if ( empty( $this->data['confirmations'] ) ) {
 						return null;
 					}
+
+					// Set necessary fields before returning.
 					return array_map(
 						function( $confirmation ) {
+							// Default fields don't have the `isActive` array key.
+							$confirmation['isActive'] = ! empty( $confirmation['isDefault'] ) ? true : ! empty( $confirmation['isActive'] );
+
+							// Set empty pageIds to null.
 							$confirmation['pageId'] = $confirmation['pageId'] ?: null;
 							return $confirmation;
 						},

--- a/src/Type/WPObject/Form/FormConfirmation.php
+++ b/src/Type/WPObject/Form/FormConfirmation.php
@@ -45,6 +45,10 @@ class FormConfirmation extends AbstractObject {
 				'type'        => 'String',
 				'description' => __( 'ID.', 'wp-graphql-gravity-forms' ),
 			],
+			'isActive'         => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether the confirmation is active or inactive. The default confirmation is always active.', 'wp-graphql-gravity-forms' ),
+			],
 			'isDefault'        => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is the default confirmation.', 'wp-graphql-gravity-forms' ),

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -552,6 +552,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 						'confirmations',
 						[
 							$this->expectedField( 'id', $form['confirmations'][ $confirmation_key ]['id'] ),
+							$this->expectedField( 'isActive', true ),
 							$this->expectedField( 'isDefault', $form['confirmations'][ $confirmation_key ]['isDefault'] ),
 							$this->expectedField( 'message', $form['confirmations'][ $confirmation_key ]['message'] ),
 							$this->expectedField( 'name', $form['confirmations'][ $confirmation_key ]['name'] ),


### PR DESCRIPTION
## Description
Adds the `isActive` GraphQL field to `FormConfirmation`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- feat: add field `isActive` to `FormConfirmation`.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
