### PR TITLE
fix: check for post-formats before adding them to `PostFormatTypeEnum`

### DIFF
--- a/src/Type/Enum/PostFormatTypeEnum.php
+++ b/src/Type/Enum/PostFormatTypeEnum.php
@@ -32,8 +32,6 @@ class PostFormatTypeEnum extends AbstractEnum {
 	 * {@inheritDoc}
 	 */
 	public static function get_values() : array {
-		$post_formats = get_theme_support( 'post-formats' );
-
 		$values = [
 			'STANDARD' => [
 				'value'       => '0',
@@ -41,12 +39,17 @@ class PostFormatTypeEnum extends AbstractEnum {
 			],
 		];
 
-		foreach ( $post_formats[0] as $type ) {
-			$values[ WPEnumType::get_safe_name( $type ) ] = [
-				'value'       => $type,
-				// translators: Post format.
-				'description' => sprintf( __( 'A %s post format.', 'wp-graphql-gravity-forms' ), $type ),
-			];
+		// If post formats are enabled for the site, add them as enum values.
+		$post_formats = get_theme_support( 'post-formats' );
+
+		if ( isset( $post_formats[0] ) && is_array( $post_formats[0] ) ) {
+			foreach ( $post_formats[0] as $type ) {
+				$values[ WPEnumType::get_safe_name( $type ) ] = [
+					'value'       => $type,
+					// translators: Post format.
+					'description' => sprintf( __( 'A %s post format.', 'wp-graphql-gravity-forms' ), $type ),
+				];
+			}
 		}
 
 		return $values;

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -32,7 +32,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => '81ad52ad16c9eef081b21fad377cca28c6b8239f',
+    'reference' => 'e58ae7c5c4e4be99cf24e5f07ed9fc7e0314e1a8',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -272,7 +272,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => '81ad52ad16c9eef081b21fad377cca28c6b8239f',
+      'reference' => 'e58ae7c5c4e4be99cf24e5f07ed9fc7e0314e1a8',
     ),
     'hautelook/phpass' => 
     array (

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => '81ad52ad16c9eef081b21fad377cca28c6b8239f',
+    'reference' => 'e58ae7c5c4e4be99cf24e5f07ed9fc7e0314e1a8',
     'name' => 'harness-software/wp-graphql-gravity-forms',
   ),
   'versions' => 
@@ -246,7 +246,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => '81ad52ad16c9eef081b21fad377cca28c6b8239f',
+      'reference' => 'e58ae7c5c4e4be99cf24e5f07ed9fc7e0314e1a8',
     ),
     'hautelook/phpass' => 
     array (


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Prevents a PHP notice when `post-formats` aren't supported by the WP theme.

h/t @noshoesplease

Fixes #210 


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: Prevent a PHP notice caused when `post-formats` aren't supported by the WP theme.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
