### PR TITLE
Expose entry to non-authenticated users in submit mutation

### DIFF
--- a/docs/actions-and-filters.md
+++ b/docs/actions-and-filters.md
@@ -11,7 +11,7 @@
 Fires after the plugin has been initialized.
 
 ```php
-apply_filters( 'graphql_gf_can_view_draft_entries', $instance );
+apply_filters( 'graphql_gf_init', $instance );
 ```
 
 #### Parameters
@@ -74,26 +74,31 @@ apply_filters( 'graphql_gf_after_register_types', $type_registry );
 Filter to control whether the user should be allowed to view draft entries.
 
 ```php
-apply_filters( 'graphql_gf_can_view_draft_entries', bool $can_view_entries, int|int[] $form_ids );
+apply_filters( 'graphql_gf_can_view_draft_entries', bool $can_view_entries, int $form_id, string $resume_token, array $draft_entry );
 ```
 
 #### Parameters
 
 * **`$can_view_entries`** _(bool)_ : Whether the user can view draft entries. By default this anyone. 
-* **`$form_ids`** _(array|int)_ : An array of the GF form ids being queried by GraphQL.
+* **`$form_id`** _(int)_ : The GF form ID being queried by GraphQL.
+* **`$resume_token`** _(string)_ : The draft entry resume token being queried by GraphQL.
+* **`$draft_entry`** _(array)_ : The Gravity Forms draft entry data array.
 
 ### `graphql_gf_can_view_entries`
 
 Filter to control whether the user should be allowed to view submitted entries.
 
 ```php
-apply_filters( 'graphql_gf_can_view_entries', bool $can_view_entries, int|int[] $form_ids );
+apply_filters( 'graphql_gf_can_view_entries', bool $can_view_entries, int $form_id, int $entry_id, array $entry );
 ```
 
 #### Parameters
 
 * **`$can_view_entries`** _(bool)_ : Whether the user can view draft entries. By default this is the user who submitted the entry, and any user with the `gravityforms_view_entries` and `gform_full_access` capabilities.
-* **`$form_ids`** _(array|int)_ : An array of the GF form ids being queried by GraphQL. `0` if all forms are being queried for entries.
+* **`$form_id`** _(int)_ : The GF form ID being queried by GraphQL.
+* **`$entry_id`** _(string)_ : The entry ID being queried by GraphQL.
+* **`$draft_entry`** _(array)_ : The Gravity Forms entry data array.
+
 
 ### `graphql_gf_entries_connection_query_args`
 

--- a/src/Model/DraftEntry.php
+++ b/src/Model/DraftEntry.php
@@ -66,9 +66,11 @@ class DraftEntry extends Model {
 		 * @since 0.10.0
 		 *
 		 * @param bool $can_view_entries Whether the current user should be allowed to view form entries.
-		 * @param int|int[] $form_ids List of he specific form ID being queried.
+		 * @param int  $form_ids The specific form ID being queried.
+		 * @param string $resume_token The specific resume token being queried.
+		 * @param array $draft_entry the current draft entry.
 		 */
-		$can_view = apply_filters( 'graphql_gf_can_view_draft_entries', $can_view, $this->data['form_id'] );
+		$can_view = apply_filters( 'graphql_gf_can_view_draft_entries', $can_view, $this->data['form_id'], $this->resume_token, $this->data );
 
 		return ! $can_view;
 	}

--- a/src/Model/SubmittedEntry.php
+++ b/src/Model/SubmittedEntry.php
@@ -54,10 +54,12 @@ class SubmittedEntry extends Model {
 		 *
 		 * @since 0.10.0
 		 *
-		 * @param bool $can_view_entries Whether the current user should be allowed to view form entries.
-		 * @param int|int[] $form_ids List of he specific form ID being queried.
+		 * @param bool      $can_view_entries Whether the current user should be allowed to view form entries.
+		 * @param int       $form_id The specific form ID being queried.
+		 * @param int       $entry_id The specific entry ID being queried.
+		 * @param array     $entry the current entry.
 		 */
-		$can_view = apply_filters( 'graphql_gf_can_view_entries', $can_view, $this->data['form_id'] );
+		$can_view = apply_filters( 'graphql_gf_can_view_entries', $can_view, $this->data['form_id'], (int) $this->data['id'], $this->data );
 
 		return ! $can_view;
 	}


### PR DESCRIPTION
## Description
This PR addresses an issue where GF permissions are enforced on the `submitGfForm` payload, preventing non-authenticated users from seeing their submitted entry.

Fixes #222 

## Types of changes
- feat: add `$resume_token` and `$draft_entry` arguments to `graphql_gf_can_view_draft_entries`.
- feat: add `$entry_id` and `$entry` arguments to `graphql_gf_can_view_entries`.
- fix: Use `graphql_gf_can_view_entries` filter to expose `submitGfFormMutation.entry` to non-authenticated users.

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [ x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
