### PR TITLE
Feat/jamstack deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Our hope for this open source project is that it will enable more teams to lever
 
 ## System Requirements
 
-* PHP 7.4+ | 8.0
+* PHP 7.4+ || 8.0
 * WordPress 5.4.1+
 * WPGraphQL 1.6.4+
 * Gravity Forms 2.5+
@@ -40,6 +40,7 @@ Our hope for this open source project is that it will enable more teams to lever
 * Submitting forms.
 * Updating entries and draft entries.
 * Deleting entries and draft entries.
+* Triggering builds with [WPGatsby](https://wordpress.org/plugins/wp-gatsby/) and [Jamstack Deployments](https://wordpress.org/plugins/wp-jamstack-deployments/)
 
 ## Future Feature Enhancements
 

--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -180,7 +180,7 @@ install_gravityforms_signature() {
 
 install_gravityforms_chainedselects() {
 	if [ ! -d $WP_CORE_DIR/wp-content/plugins/gravityformschainedselects ]; then
-		echo "Cloning Gravity Forms Signature"
+		echo "Cloning Gravity Forms Chained Selects"
 			if [ -n "$GIT_USER" ] && [ -n "$GIT_TOKEN" ] && [ -n "$GF_CHAINEDSELECTS_REPO" ]; then
 		git clone https://$GIT_USER:$GIT_TOKEN@$GF_CHAINEDSELECTS_REPO $WP_CORE_DIR/wp-content/plugins/gravityformschainedselects
 		else
@@ -192,7 +192,7 @@ install_gravityforms_chainedselects() {
 
 install_gravityforms_quiz() {
 	if [ ! -d $WP_CORE_DIR/wp-content/plugins/gravityformsquiz ]; then
-		echo "Cloning Gravity Forms Signature"
+		echo "Cloning Gravity Forms Quiz"
 			if [ -n "$GIT_USER" ] && [ -n "$GIT_TOKEN" ] && [ -n "$GF_CHAINEDSELECTS_REPO" ]; then
 		git clone https://$GIT_USER:$GIT_TOKEN@$GF_QUIZ_REPO $WP_CORE_DIR/wp-content/plugins/gravityformsquiz
 		else
@@ -236,6 +236,10 @@ setup_plugin() {
 	# Install WPGatsby and Activate
 	wp plugin install wp-gatsby
 	wp plugin activate wp-gatsby
+
+	# Install WPJamstack Deployments and Activate
+	wp plugin install wp-jamstack-deployments
+	wp plugin activate wp-jamstack-deployments
 
 	# activate the plugin
 	wp plugin activate wp-graphql-gravity-forms

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,7 @@ parameters:
 			- ../gravityformschainedselects/
 			- ../gravityformsquiz/
 			- ../wp-gatsby/
+			- ../wp-jamstack-deployments/
 		ignoreErrors:
 			- '#^Function apply_filters(_ref_array)? invoked with ([1-9]|1[0-2]) parameters, 2 required\.$#'
 			- '#^Function gf_apply_filters(_ref_array)? invoked with ([1-9]|1[0-2]) parameters, 2 required\.$#'

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -4,3 +4,4 @@
  */
 
 define( 'WPGRAPHQL_GF_AUTOLOAD', true );
+define( 'CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY', 'wp-jamstack-deployments' );

--- a/src/Extensions/Extensions.php
+++ b/src/Extensions/Extensions.php
@@ -12,12 +12,12 @@ use WPGraphQL\GF\Extensions\GFChainedSelects\GFChainedSelects;
 use WPGraphQL\GF\Extensions\GFQuiz\GFQuiz;
 use WPGraphQL\GF\Extensions\GFSignature\GFSignature;
 use WPGraphQL\GF\Extensions\WPGatsby\WPGatsby;
+use WPGraphQL\GF\Extensions\WPJamstackDeployments\WPJamstackDeployments;
 
 /**
  * Class - GFSignature
  */
 class Extensions {
-
 	/**
 	 * Register Gravity Forms Extensions.
 	 */
@@ -26,5 +26,6 @@ class Extensions {
 		GFQuiz::register_hooks();
 		GFSignature::register_hooks();
 		WPGatsby::register_hooks();
+		WPJamstackDeployments::register_hooks();
 	}
 }

--- a/src/Extensions/WPGatsby/GravityFormsMonitor.php
+++ b/src/Extensions/WPGatsby/GravityFormsMonitor.php
@@ -46,7 +46,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 */
 	public function init() : void {
 		// Create form.
-		add_action( 'gform_after_duplicate_form', [ $this, 'after_save_form' ], 10, 2 );
+		add_action( 'gform_post_form_duplicated', [ $this, 'after_duplicate_form' ], 10, 2 );
 		// Create or update form.
 		add_action( 'gform_after_save_form', [ $this, 'after_save_form' ], 10, 2 );
 		// Update form.

--- a/src/Extensions/WPGatsby/Settings.php
+++ b/src/Extensions/WPGatsby/Settings.php
@@ -59,12 +59,12 @@ class Settings {
 				'label'   => __( 'Monitor Gravity Forms Actions', 'wp-graphql-gravity-forms' ),
 				'type'    => 'multicheck',
 				'options' => [
-					'create_form'        => 'Form Creation',
-					'update_form'        => 'Form Updates',
-					'delete_form'        => 'Form Deletions',
-					'create_entry'       => 'Entry Submission',
-					'update_entry'       => 'Entry Updates',
-					'create_draft_entry' => 'Draft Entry Creation',
+					'create_form'        => __( 'Form Creation', 'wp-graphql-gravity-forms' ),
+					'update_form'        => __( 'Form Updates', 'wp-graphql-gravity-forms' ),
+					'delete_form'        => __( 'Form Deletions', 'wp-graphql-gravity-forms' ),
+					'create_entry'       => __( 'Entry Submission', 'wp-graphql-gravity-forms' ),
+					'update_entry'       => __( 'Entry Updates', 'wp-graphql-gravity-forms' ),
+					'create_draft_entry' => __( 'Draft Entry Creation', 'wp-graphql-gravity-forms' ),
 				],
 				'default' => [
 					'create_form'        => 'create_form',

--- a/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
+++ b/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Enables and initializes the Gravity Forms Action Monitor
+ *
+ * @package WPGraphQL\GF\Extensions\WPJamstackDeployments
+ * @since @todo
+ */
+
+namespace WPGraphQL\GF\Extensions\WPJamstackDeployments;
+
+/**
+ * Class - WPJamstackDeployments
+ */
+class WPJamstackDeployments {
+	/**
+	 * The option named used in the settings API.
+	 *
+	 * @var string
+	 */
+	public static string $option_name = 'webhook_gf';
+
+	/**
+	 * The options array.
+	 *
+	 * @var array
+	 */
+	public static array $options;
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function register_hooks(): void {
+		if ( ! self::is_wp_jamstack_deployments_enabled() ) {
+			return;
+		}
+
+		// Register settings.
+		add_action( 'admin_init', [ __CLASS__, 'register_settings' ], 11 );
+		// Filters sanitization callback.
+		add_filter( 'sanitize_option_' . self::get_options_key(), [ __CLASS__, 'sanitize' ], 10 );
+
+		// Trigger deployments.
+		self::trigger_deployments();
+	}
+
+	/**
+	 * Returns whether WPJamstackDeployments is enabled.
+	 *
+	 * @return boolean
+	 */
+	public static function is_wp_jamstack_deployments_enabled() : bool {
+		return class_exists( 'Crgeary\JAMstackDeployments\App' );
+	}
+
+	/**
+	 * Returns the Options Key used by WPJamstackDeployments.
+	 */
+	public static function get_options_key() : string {
+		return defined( 'CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY' ) ? CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY : 'wp_jamstack_deployments';
+	}
+
+	/**
+	 * Returns the array of options.
+	 */
+	public static function get_options() : array {
+		if ( empty( self::$options ) ) {
+			self::$options = \jamstack_deployments_get_options();
+		}
+
+		return self::$options;
+	}
+
+	/**
+	 * Registers settings to enable/disable deployments.
+	 */
+	public static function register_settings() : void {
+		$key = self::get_options_key();
+
+		$option = self::get_options();
+
+		$option_name = self::$option_name;
+
+		add_settings_field(
+			$option_name,
+			__( 'Gravity Forms', 'wp-graphql-gravity-forms' ),
+			[ 'Crgeary\JAMstackDeployments\Field', 'checkboxes' ],
+			$key,
+			'general',
+			[
+				'name'        => "{$key}[{$option_name}]",
+				'value'       => isset( $option[ $option_name ] ) ? $option[ $option_name ] : [],
+				'choices'     => [
+					'create_form'        => __( 'Form Creation', 'wp-graphql-gravity-forms' ),
+					'update_form'        => __( 'Form Updates', 'wp-graphql-gravity-forms' ),
+					'delete_form'        => __( 'Form Deletions', 'wp-graphql-gravity-forms' ),
+					'create_entry'       => __( 'Entry Submission', 'wp-graphql-gravity-forms' ),
+					'update_entry'       => __( 'Entry Updates', 'wp-graphql-gravity-forms' ),
+					'create_draft_entry' => __( 'Draft Entry Creation', 'wp-graphql-gravity-forms' ),
+				],
+				'description' => __( 'Only selected Gravity Forms actions will trigger a deployment.', 'wp-graphql-gravity-forms' ),
+				'legend'      => __( 'Gravity Forms', 'wp-graphql-gravity-forms' ),
+			]
+		);
+	}
+
+	/**
+	 * Sanitize user input.
+	 *
+	 * @param array $input .
+	 */
+	public static function sanitize( array $input ) : array {
+		if ( ! isset( $input[ self::$option_name ] ) || ! is_array( $input[ self::$option_name ] ) ) {
+			$input[ self::$option_name ] = [];
+		}
+
+		return $input;
+	}
+
+	/**
+	 * Adds actions to trigger deployments based on the settings.
+	 */
+	public static function trigger_deployments() : void {
+		$options = self::get_options();
+		if ( empty( $options[ self::$option_name ] ) ) {
+			return;
+		}
+
+		foreach ( $options[ self::$option_name ] as $gf_hook ) {
+			switch ( $gf_hook ) {
+				case 'create_form':
+					add_action( 'gform_post_form_duplicated', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ], 10, 2 );
+					break;
+				case 'update_form':
+					// Only add action if it doenst already exist.
+					if ( ! has_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ] ) ) {
+						add_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ], 10, 2 );
+					}
+					add_action( 'gform_post_update_form_meta', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_post_form_activated', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_post_form_deactivated', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_post_form_restored', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_post_form_trashed', 'jamstack_deployments_fire_webhook' );
+					break;
+				case 'delete_form':
+					add_action( 'gform_after_delete_form', 'jamstack_deployments_fire_webhook' );
+					break;
+				case 'create_entry':
+					add_action( 'gform_after_submission', 'jamstack_deployments_fire_webhook' );
+					break;
+				case 'update_entry':
+					add_action( 'gform_after_update_entry', 'jamstack_deployments_fire_webhook' );
+					add_action( 'gform_post_update_entry', 'jamstack_deployments_fire_webhook' );
+					break;
+				case 'create_draft_entry':
+					add_action( 'gform_incomplete_submission_post_save', 'jamstack_deployments_fire_webhook' );
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Triggers the correct deployment when a form is saved.
+	 *
+	 * @param array   $form .
+	 * @param boolean $is_new .
+	 */
+	public static function after_save_form( array $form, bool $is_new ) : void {
+		$options = self::get_options();
+
+		if ( in_array( 'create_form', $options[ self::$option_name ], true ) && $is_new ) {
+			\jamstack_deployments_fire_webhook();
+		} elseif ( in_array( 'update_form', $options[ self::$option_name ], true ) && ! $is_new ) {
+			\jamstack_deployments_fire_webhook();
+		}
+	}
+}

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -102,7 +102,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 			query {
 				gfForms {
 					nodes {
-						formId
+						databaseId
 					}
 				}
 			}
@@ -133,11 +133,11 @@ class FormQueriesTest extends GFGraphQLTestCase {
 					edges {
 						cursor
 						node {
-							formId
+							databaseId
 						}
 					}
 					nodes {
-						formId
+						databaseId
 					}
 				}
 			}
@@ -156,8 +156,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $response, 'First array has errors.' );
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First does not return correct amount.' );
 
-		$this->assertSame( $form_ids[0], $response['data']['gfForms']['nodes'][0]['formId'], 'First - node 0 is not same.' );
-		$this->assertSame( $form_ids[1], $response['data']['gfForms']['nodes'][1]['formId'], 'First - node 1 is not same' );
+		$this->assertSame( $form_ids[0], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First - node 0 is not same.' );
+		$this->assertSame( $form_ids[1], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First - node 1 is not same' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First does not have next page.' );
 		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First has previous page.' );
 
@@ -172,8 +172,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayNotHasKey( 'errors', $response, 'First/after #1 array has errors.' );
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #1 does not return correct amount.' );
-		$this->assertSame( $form_ids[2], $response['data']['gfForms']['nodes'][0]['formId'], 'First/after #1 - node 0 is not same.' );
-		$this->assertSame( $form_ids[3], $response['data']['gfForms']['nodes'][1]['formId'], 'First/after #1- node 1 is not same.' );
+		$this->assertSame( $form_ids[2], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #1 - node 0 is not same.' );
+		$this->assertSame( $form_ids[3], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #1- node 1 is not same.' );
 
 		$variables = [
 			'first'  => 2,
@@ -185,8 +185,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #2 does not return correct amount.' );
-		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['formId'], 'First/after #2 - node 0 is not same' );
-		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['formId'], 'First/after #2 - node 1 is not same.' );
+		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #2 - node 0 is not same' );
+		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #2 - node 1 is not same.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #1 does not have next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #1 does not have previous page.' );
 
@@ -201,8 +201,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 
 		$this->assertArrayNotHasKey( 'errors', $response, 'First/after #2 array has errors.' );
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #2 does not return correct amount.' );
-		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['entryId'], 'First/after #2 - node 0 is not same' );
-		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['entryId'], 'First/after #2 - node 1 is not same.' );
+		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #2 - node 0 is not same' );
+		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #2 - node 1 is not same.' );
 		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #2 has next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #2 does not have previous page.' );
 
@@ -217,8 +217,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$response = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'Last does not return correct amount.' );
-		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['formId'], 'Last - node 0 is not same' );
-		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['formId'], 'Last - node 1 is not same.' );
+		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'Last - node 0 is not same' );
+		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'Last - node 1 is not same.' );
 		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'Last has next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'Last does not have previous page.' );
 
@@ -235,8 +235,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $response, 'Last array has errors.' );
 
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'last/before #1 does not return correct amount.' );
-		$this->assertSame( $form_ids[2], $response['data']['gfForms']['nodes'][0]['formId'], 'last/before #1 - node 0 is not same' );
-		$this->assertSame( $form_ids[3], $response['data']['gfForms']['nodes'][1]['formId'], 'last/before #1 - node 1 is not same' );
+		$this->assertSame( $form_ids[2], $response['data']['gfForms']['nodes'][0]['databaseId'], 'last/before #1 - node 0 is not same' );
+		$this->assertSame( $form_ids[3], $response['data']['gfForms']['nodes'][1]['databaseId'], 'last/before #1 - node 1 is not same' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'Last/before #1 does not have next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'Last/before #1 does not have previous page.' );
 
@@ -283,21 +283,21 @@ class FormQueriesTest extends GFGraphQLTestCase {
 			query {
 				inactive: gfForms(where: {status: INACTIVE}) {
 					nodes {
-						formId
+						databaseId
 						isActive
 						isTrash
 					}
 				}
 				trashed: gfForms(where: {status: TRASHED}) {
 					nodes {
-						formId
+						databaseId
 						isActive
 						isTrash
 					}
 				}
 				inactive_trashed: gfForms(where: {status: INACTIVE_TRASHED}) {
 					nodes {
-						formId
+						databaseId
 						isActive
 						isTrash
 					}
@@ -326,7 +326,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 			query {
 				gfForms( where: { sort: { key: "id", direction: DESC }, status:INACTIVE_TRASHED } ) {
 					nodes {
-						formId
+						databaseId
 					}
 				}
 			}
@@ -335,7 +335,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$response = $this->graphql( compact( 'query' ) );
 
 		$this->assertArrayNotHasKey( 'errors', $response );
-		$this->assertGreaterThan( $response['data']['gfForms']['nodes'][1]['formId'], $response['data']['gfForms']['nodes'][0]['formId'] );
+		$this->assertGreaterThan( $response['data']['gfForms']['nodes'][1]['databaseId'], $response['data']['gfForms']['nodes'][0]['databaseId'] );
 	}
 
 	/**

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -54,6 +54,7 @@ return array(
     'WPGraphQL\\GF\\Extensions\\WPGatsby\\GravityFormsMonitor' => $baseDir . '/src/Extensions/WPGatsby/GravityFormsMonitor.php',
     'WPGraphQL\\GF\\Extensions\\WPGatsby\\Settings' => $baseDir . '/src/Extensions/WPGatsby/Settings.php',
     'WPGraphQL\\GF\\Extensions\\WPGatsby\\WPGatsby' => $baseDir . '/src/Extensions/WPGatsby/WPGatsby.php',
+    'WPGraphQL\\GF\\Extensions\\WPJamstackDeployments\\WPJamstackDeployments' => $baseDir . '/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php',
     'WPGraphQL\\GF\\GF' => $baseDir . '/src/GF.php',
     'WPGraphQL\\GF\\Interfaces\\Enum' => $baseDir . '/src/Interfaces/Enum.php',
     'WPGraphQL\\GF\\Interfaces\\Field' => $baseDir . '/src/Interfaces/Field.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -69,6 +69,7 @@ class ComposerStaticInit0e8f6c0730ce438688b3484326e9667b
         'WPGraphQL\\GF\\Extensions\\WPGatsby\\GravityFormsMonitor' => __DIR__ . '/../..' . '/src/Extensions/WPGatsby/GravityFormsMonitor.php',
         'WPGraphQL\\GF\\Extensions\\WPGatsby\\Settings' => __DIR__ . '/../..' . '/src/Extensions/WPGatsby/Settings.php',
         'WPGraphQL\\GF\\Extensions\\WPGatsby\\WPGatsby' => __DIR__ . '/../..' . '/src/Extensions/WPGatsby/WPGatsby.php',
+        'WPGraphQL\\GF\\Extensions\\WPJamstackDeployments\\WPJamstackDeployments' => __DIR__ . '/../..' . '/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php',
         'WPGraphQL\\GF\\GF' => __DIR__ . '/../..' . '/src/GF.php',
         'WPGraphQL\\GF\\Interfaces\\Enum' => __DIR__ . '/../..' . '/src/Interfaces/Enum.php',
         'WPGraphQL\\GF\\Interfaces\\Field' => __DIR__ . '/../..' . '/src/Interfaces/Field.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'ca391017aa8723ed8d437adffbe1f0c8afd60d40',
+        'reference' => 'a9cb036b82b4b632fe527676bc5eeced24e4918a',
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'dev' => true,
     ),
@@ -241,7 +241,7 @@
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'ca391017aa8723ed8d437adffbe1f0c8afd60d40',
+            'reference' => 'a9cb036b82b4b632fe527676bc5eeced24e4918a',
             'dev_requirement' => false,
         ),
         'hautelook/phpass' => array(


### PR DESCRIPTION
## Description
Adds support for [Jamstack Deployments](https://github.com/crgeary/wp-jamstack-deployments).
Closes #214 

## Types of changes
- feat: Add support for WP Jamstack Deployments.
- chore: Change WPGatsby Trigger from deprecated `gform_after_duplicate_form` to `gform_post_form_duplicated`.
- tests: use `databaseId` instead of deprecated `formId` when testing `FormQueriesTest`

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
