### PR TITLE
FormsConnectionResolver fixes

### DIFF
--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -148,8 +148,6 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 
 		$nodes = [];
 
-		$ids = $this->ids;
-
 		if ( ! empty( $this->get_offset() ) ) {
 			// Determine if the offset is in the array.
 			$key = array_search( (string) $this->get_offset(), $ids, true );
@@ -160,12 +158,12 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			}
 		}
 
-		$ids = array_slice( $ids, 0, $this->query_amount, true );
-
-				// Flip the direction on `last` query.
+		// Flip the direction on `last` query.
 		if ( ! empty( $this->args['last'] ) ) {
 			$ids = array_reverse( $ids, true );
 		}
+
+		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
 		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -98,7 +98,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	public function get_query() : array {
-		$form_ids    = $this->get_ids();
+		$form_ids    = $this->query_args['form_ids'];
 		$active      = $this->query_args['status']['active'];
 		$sort_column = $this->query_args['sort']['key'];
 		$sort_dir    = $this->query_args['sort']['direction'];
@@ -130,40 +130,34 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids() : array {
-		$form_ids    = $this->query_args['form_ids'];
-		$active      = $this->query_args['status']['active'];
-		$trash       = $this->query_args['status']['trash'];
-		$sort_column = $this->query_args['sort']['key'];
-		$sort_dir    = $this->query_args['sort']['direction'];
-
-		return ! empty( $form_ids ) ? $form_ids : GFFormsModel::get_form_ids( $active, $trash, $sort_column, $sort_dir );
+		return ! empty( $this->query ) ? array_keys( $this->query ) : [];
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function get_nodes() : array {
-		$ids = $this->get_ids();
-		$ids = $ids ?: [];
+		if ( empty( $this->ids ) ) {
+			return [];
+		}
 
 		$nodes = [];
+		$ids   = $this->ids;
 
 		if ( ! empty( $this->get_offset() ) ) {
 			// Determine if the offset is in the array.
-			$key = array_search( (string) $this->get_offset(), $ids, true );
+			$key = array_search( $this->get_offset(), $ids, true );
 			// If the offset is in the array.
-			if ( false !== $key ) {
-				$key = absint( $key );
-				$ids = array_slice( $ids, $key + 1, null, true );
-			}
-		}
-
-		// Flip the direction on `last` query.
-		if ( ! empty( $this->args['last'] ) ) {
-			$ids = array_reverse( $ids, true );
+			$key ++;
+			$ids = array_slice( $ids, $key, null, true );
 		}
 
 		$ids = array_slice( $ids, 0, $this->query_amount, true );
+
+		// Reverse the array if were going backwards.
+		if ( ! empty( $this->args['last'] ) ) {
+			$ids = array_reverse( $ids, true );
+		}
 
 		foreach ( $ids as $id ) {
 			$model = $this->get_node_by_id( $id );

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -42,7 +42,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function is_valid_offset( $offset ) {
-		return (bool) GFAPI::get_form( $offset );
+		return GFAPI::form_id_exists( $offset );
 	}
 
 	/**
@@ -130,7 +130,22 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_ids() : array {
-		return ! empty( $this->query ) ? array_keys( $this->query ) : [];
+		if ( empty( $this->query ) ) {
+			return [];
+		}
+
+		$ids = array_keys( $this->query );
+
+		// Slice here to mimic WP queries that only query the subset.
+		if ( ! empty( $this->get_offset() ) ) {
+			// Determine if the offset is in the array.
+			$key = array_search( $this->get_offset(), $ids, true );
+			// If the offset is in the array.
+			$key ++;
+			$ids = array_slice( $ids, $key, null, true );
+		}
+
+		return $ids;
 	}
 
 	/**
@@ -142,16 +157,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		$nodes = [];
-		$ids   = $this->ids;
 
-		if ( ! empty( $this->get_offset() ) ) {
-			// Determine if the offset is in the array.
-			$key = array_search( $this->get_offset(), $ids, true );
-			// If the offset is in the array.
-			$key ++;
-			$ids = array_slice( $ids, $key, null, true );
-		}
-
+		$ids = $this->ids;
 		$ids = array_slice( $ids, 0, $this->query_amount, true );
 
 		// Reverse the array if were going backwards.

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -187,23 +187,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #2 does not return correct amount.' );
 		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #2 - node 0 is not same' );
 		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #2 - node 1 is not same.' );
-		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #1 does not have next page.' );
-		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #1 does not have previous page.' );
-
-		$variables = [
-			'first'  => 2,
-			'after'  => $response['data']['gfForms']['pageInfo']['endCursor'],
-			'last'   => null,
-			'before' => null,
-		];
-
-		$response = $this->graphql( compact( 'query', 'variables' ) );
-
-		$this->assertArrayNotHasKey( 'errors', $response, 'First/after #2 array has errors.' );
-		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #2 does not return correct amount.' );
-		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #2 - node 0 is not same' );
-		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #2 - node 1 is not same.' );
-		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #2 has next page.' );
+		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #2 does not have next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #2 does not have previous page.' );
 
 		// Check last argument.

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -174,6 +174,8 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #1 does not return correct amount.' );
 		$this->assertSame( $form_ids[2], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #1 - node 0 is not same.' );
 		$this->assertSame( $form_ids[3], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #1- node 1 is not same.' );
+		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #1 does not have next page.' );
+		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #1 does not have previous page.' );
 
 		$variables = [
 			'first'  => 2,
@@ -187,7 +189,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'First/after #2 does not return correct amount.' );
 		$this->assertSame( $form_ids[4], $response['data']['gfForms']['nodes'][0]['databaseId'], 'First/after #2 - node 0 is not same' );
 		$this->assertSame( $form_ids[5], $response['data']['gfForms']['nodes'][1]['databaseId'], 'First/after #2 - node 1 is not same.' );
-		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #2 does not have next page.' );
+		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'First/after #2 has next page.' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'First/after #2 does not have previous page.' );
 
 		// Check last argument.
@@ -228,14 +230,14 @@ class FormQueriesTest extends GFGraphQLTestCase {
 			'first'  => null,
 			'after'  => null,
 			'last'   => 2,
-			'before' => $response['data']['gfForms']['pageInfo']['endCursor'],
+			'before' => $response['data']['gfForms']['pageInfo']['startCursor'],
 		];
 		$response  = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayNotHasKey( 'errors', $response, 'Last/before #2 array has errors.' );
 		$this->assertCount( 2, $response['data']['gfForms']['nodes'], 'last/before does not return correct amount.' );
-		$this->assertSame( $form_ids[0], $response['data']['gfForms']['nodes'][0]['entryId'], 'last/before #2 - node 0 is not same' );
-		$this->assertSame( $form_ids[1], $response['data']['gfForms']['nodes'][1]['entryId'], 'last/before #2 - node 1 is not same' );
+		$this->assertSame( $form_ids[0], $response['data']['gfForms']['nodes'][0]['databaseId'], 'last/before #2 - node 0 is not same' );
+		$this->assertSame( $form_ids[1], $response['data']['gfForms']['nodes'][1]['databaseId'], 'last/before #2 - node 1 is not same' );
 		$this->assertTrue( $response['data']['gfForms']['pageInfo']['hasNextPage'], 'Last/before #2 does not have next page.' );
 		$this->assertFalse( $response['data']['gfForms']['pageInfo']['hasPreviousPage'], 'Last/before #2 has previous page.' );
 
@@ -308,7 +310,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 		// Test where.sort argument.
 		$query = '
 			query {
-				gfForms( where: { sort: { key: "id", direction: DESC }, status:INACTIVE_TRASHED } ) {
+				gfForms( where: { orderby: { field: "id", order: DESC }, status:INACTIVE_TRASHED } ) {
 					nodes {
 						databaseId
 					}


### PR DESCRIPTION
## Description
This PR fixes the underlying logic used by FormsConnectionResolver, reducing the number of database queries and fixing `hasNextPage` and `hasPreviousPage` GraphQL values.

Fixes #150.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: correctly return `hasNextPage` or `hasPreviousPage` on GfForm connections.
- dev: don't re-query database when calling `FormsConnectionResolver::get_ids()`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
