### PR TITLE
Fix!: Rename pricing fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ phpunit.xml
 schema.graphql
 sonar-project.properties
 sonar-scanner
+composer.lock
 !tests
 tests/*.suite.yml
 Thumbs.db

--- a/src/Type/WPObject/FormField/FormFields.php
+++ b/src/Type/WPObject/FormField/FormFields.php
@@ -52,7 +52,20 @@ class FormFields implements Registrable {
 		$fields = GF_Fields::get_all();
 
 		foreach ( $fields as $field ) {
-			if ( ! in_array( $field->type, Utils::get_ignored_gf_field_types(), true ) ) {
+			if ( ! in_array(
+				$field->type,
+				array_merge(
+					Utils::get_ignored_gf_field_types(),
+					[
+						// These fields are registered as child types of a field interface, and should always be skipped.
+						'calculation',
+						'hiddenproduct',
+						'singleproduct',
+						'singleshipping',
+					]
+				),
+				true
+			) ) {
 				self::register_gf_field( $field, $type_registry );
 			}
 		}

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -213,6 +213,7 @@ class Utils {
 	 */
 	public static function get_possible_form_field_child_types( string $type ) : ?array {
 		$prefix = self::get_safe_form_field_type_name( $type );
+
 		switch ( $type ) {
 			case 'post_category':
 				$child_types = [
@@ -253,18 +254,18 @@ class Utils {
 			case 'product':
 				$child_types = [
 					'calculation'   => $prefix . 'CalculationField',
-					'hiddenproduct' => $prefix . 'HiddenProductField',
+					'hiddenproduct' => $prefix . 'HiddenField',
 					'price'         => $prefix . 'PriceField',
 					'radio'         => $prefix . 'RadioField',
 					'select'        => $prefix . 'SelectField',
-					'singleproduct' => $prefix . 'SingleProductField',
+					'singleproduct' => $prefix . 'SingleField',
 				];
 				break;
 			case 'shipping':
 				$child_types = [
 					'radio'          => $prefix . 'RadioField',
 					'select'         => $prefix . 'SelectField',
-					'singleshipping' => $prefix . 'SingleShippingField',
+					'singleshipping' => $prefix . 'SingleField',
 				];
 				break;
 			case 'option':

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -308,14 +308,6 @@ class Utils {
 	public static function get_ignored_gf_field_types() : array {
 		$ignored_fields = [];
 
-		// These fields are registered as child types of a field interface, and should always be skipped.
-		$duplicate_fields = [
-			'calculation',
-			'hiddenproduct',
-			'singleproduct',
-			'singleshipping',
-		];
-
 		// These fields are no longer supported by GF.
 		$ignored_fields[] = 'donation';
 		// This field is still in beta.
@@ -341,6 +333,6 @@ class Utils {
 		 */
 		$ignored_fields = apply_filters( 'graphql_gf_ignored_field_types', $ignored_fields );
 
-		return array_merge( $ignored_fields, $duplicate_fields );
+		return $ignored_fields;
 	}
 }


### PR DESCRIPTION
## Description
This PR renames the following fields:
- `ProductHiddenProductField` => `ProductHiddenField`
- `ProductSingleProductField` => `ProductSingleField`.
- `ShippingSingleShippingField` => `ShippingSingleField`. 

It also fixes an issue where the `FormFieldTypeEnum` for `calculation`, `hiddenproduct`, `singleproduct`, and `singleshipping` were missing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- fix: dont hide pricing child types from `FormFieldTypeEnum`.
- fix!: Rename `{$type}Single{$type}Field` and `${type}Hidden{$type}Field` to `${type}SingleField` and `${type}HiddenField`, respectively.

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
