### PR TITLE
Fix/Quiz form model 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.4.1
 Tested up to: 5.9.2
 Requires PHP: 7.4
 Requires Gravity Forms: 2.5.0
-Requires WPGraphQL: 1.6.4
+Requires WPGraphQL: 1.7.0
 Stable tag: 0.10.5
 Maintained at: https://github.com/harness-software/wp-graphql-gravity-forms
 License: GPL-3

--- a/src/Extensions/GFQuiz/GFQuiz.php
+++ b/src/Extensions/GFQuiz/GFQuiz.php
@@ -35,7 +35,7 @@ class GFQuiz {
 		add_filter( 'graphql_gf_form_field_child_types', [ __CLASS__, 'field_child_types' ], 10, 2 );
 
 		// Add quiz to Form Model.
-		add_filter( 'graphql_gf_form_modeled_data_experimental', [ __CLASS__, 'form_model' ], 10, 2 );
+		add_filter( 'graphql_model_prepare_fields', [ __CLASS__, 'form_model' ], 10, 3 );
 
 		// // Register field_settings.
 		add_filter( 'graphql_gf_form_field_setting_properties', [ __CLASS__, 'field_setting_properties' ], 10, 3 );
@@ -100,11 +100,14 @@ class GFQuiz {
 	/**
 	 * Adds quiz to model
 	 *
-	 * @param array $fields .
-	 * @param array $data .
+	 * @param array  $fields .
+	 * @param string $model_name .
+	 * @param array  $data .
 	 */
-	public static function form_model( array $fields, array $data ) : array {
-		$fields['quiz'] = fn() : ?array => ! empty( $data['gravityformsquiz'] ) ? $data['gravityformsquiz'] : null;
+	public static function form_model( $fields, string $model_name, $data ) : array {
+		if ( 'FormObject' === $model_name ) {
+			$fields['quiz'] = fn() : ?array => ! empty( $data['gravityformsquiz'] ) ? $data['gravityformsquiz'] : null;
+		}
 
 		return $fields;
 	}

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
@@ -108,7 +108,7 @@ class FormQuiz extends AbstractObject implements Field {
 				'type'        => 'Float',
 				'description' => __( 'The maximum score for this form.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) : ?float {
-					return ( gf_quiz() )->get_max_score( $context->gfForm ) ?: null;
+					return ( gf_quiz() )->get_max_score( $context->gfForm->form ) ?: null;
 				},
 			],
 			'passPercent'                    => [
@@ -140,7 +140,7 @@ class FormQuiz extends AbstractObject implements Field {
 				'description' => __( 'Quiz-specific settings that will affect ALL Quiz fields in the form. Requires Gravity Forms Quiz addon.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function( $source, array $args, AppContext $context ) : ?array {
 					$context->gfForm = $source;
-					return ! empty( $source['quizSettings'] ) ? $source['quizSettings'] : null;
+					return ! empty( $source->form['quizSettings'] ) ? $source->form['quizSettings'] : null;
 				},
 			]
 		);

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -221,8 +221,10 @@ class Form extends Model {
 			 * Internal Filter for modifying the model.
 			 *
 			 * To be replaced by https://github.com/wp-graphql/wp-graphql/issues/2198
+			 *
+			 * @deprecated @todo use "graphql_model_prepare_fields"
 			 */
-			$this->fields = apply_filters( 'graphql_gf_form_modeled_data_experimental', $this->fields, $this->data, );
+			$this->fields = apply_filters_deprecated( 'graphql_gf_form_modeled_data_experimental', [ $this->fields, $this->data ], '@todo', 'graphql_model_prepare_fields' );
 		}
 	}
 }

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -13,8 +13,8 @@
  * Requires at least: 5.4.1
  * Tested up to: 5.9.0
  * Requires PHP: 7.4+
- * WPGraphQL requires at least: 1.6.4+
- * GravityForms requires at least: 2.5.0+
+ * WPGraphQL requires at least: 1.7.0
+ * GravityForms requires at least: 2.5.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *


### PR DESCRIPTION
## Description
- Deprecate `graphql_gf_form_modeled_data_experimental` in favor of [`graphql_model_prepare_fields`](https://github.com/wp-graphql/wp-graphql/pull/2236). This bumps the minimum WPGraphQL version to v1.7.0
- Fixes an issue where QuizField resolvers were using the Form model, instead of the unmodeled source data.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
