### PR TITLE
fix: confirmation/notification `isActive` should default to true

### DIFF
--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -56,12 +56,12 @@ class Form extends Model {
 					if ( empty( $this->data['confirmations'] ) ) {
 						return null;
 					}
-
 					// Set necessary fields before returning.
 					return array_map(
 						function( $confirmation ) {
-							// Default fields don't have the `isActive` array key.
-							$confirmation['isActive'] = ! empty( $confirmation['isDefault'] ) ? true : ! empty( $confirmation['isActive'] );
+							// By default confirmations don't have the `isActive` array key.
+							$confirmation['isActive']  = isset( $confirmation['isActive'] ) ? (bool) $confirmation['isActive'] : true;
+							$confirmation['isDefault'] = ! empty( $confirmation['isDefault'] );
 
 							// Set empty pageIds to null.
 							$confirmation['pageId'] = $confirmation['pageId'] ?: null;

--- a/src/Type/WPObject/Form/FormNotification.php
+++ b/src/Type/WPObject/Form/FormNotification.php
@@ -64,11 +64,12 @@ class FormNotification extends AbstractObject {
 			'isActive'              => [
 				'type'        => 'Boolean',
 				'description' => __( 'Is the notification active or inactive. The default is true (active).', 'wp-graphql-gravity-forms' ),
+				'resolve'     => fn( $source ) => isset( $source['isActive'] ) ? (bool) $source['isActive'] : true,
 			],
 			'isAutoformatted'       => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether the email message should be formatted so that paragraphs are automatically added for new lines.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => fn( $source) => empty( $source['disableAutoformat'] ),
+				'resolve'     => fn( $source ) => empty( $source['disableAutoformat'] ),
 			],
 			'message'               => [
 				'type'        => 'String',


### PR DESCRIPTION
## Description
Confirmation and notification `isActive` is not stored by default, so we need to set the default to true.

Fixes #253 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
- fix: Ensure `isActive` on Form confirmations and notifications defaults to `true`.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
