### PR TITLE
fix: ensure Action Monitor settings are populated

### DIFF
--- a/src/Extensions/WPGatsby/Settings.php
+++ b/src/Extensions/WPGatsby/Settings.php
@@ -36,6 +36,20 @@ class Settings {
 	public static string $section_name = 'wpgatsby_settings';
 
 	/**
+	 * The default GF Action monitor keys.
+	 *
+	 * @var string[]
+	 */
+	public static array $default_action_keys = [
+		'create_form',
+		'update_form',
+		'delete_form',
+		'create_entry',
+		'update_entry',
+		'create_draft_entry',
+	];
+
+	/**
 	 * Gets an instance of the WPGraphQL settings api.
 	 */
 	public static function get_settings_api() : WPGraphQL_Settings_API {
@@ -66,14 +80,7 @@ class Settings {
 					'update_entry'       => __( 'Entry Updates', 'wp-graphql-gravity-forms' ),
 					'create_draft_entry' => __( 'Draft Entry Creation', 'wp-graphql-gravity-forms' ),
 				],
-				'default' => [
-					'create_form'        => 'create_form',
-					'update_form'        => 'update_form',
-					'delete_form'        => 'delete_form',
-					'create_entry'       => 'create_entry',
-					'update_entry'       => 'update_entry',
-					'create_draft_entry' => 'create_draft_entry',
-				],
+				'default' => array_combine( self::$default_action_keys, self::$default_action_keys ),
 			]
 		);
 
@@ -84,22 +91,17 @@ class Settings {
 	 * Gets an array of Gravity Forms actions that should be monitored.
 	 */
 	public static function get_enabled_actions() : array {
-		$options = get_option( self::$section_name );
+		/** @var array $options */
+		$options = get_option( self::$section_name, [] );
 
+		// By default monitor everything.
 		if ( ! isset( $options[ self::$option_name ] ) ) {
-			$options[ self::$option_name ] = [
-				'create_form'        => 'create_form',
-				'update_form'        => 'update_form',
-				'delete_form'        => 'delete_form',
-				'create_entry'       => 'create_entry',
-				'update_entry'       => 'update_entry',
-				'create_draft_entry' => 'create_draft_entry',
-			];
+			$options[ self::$option_name ] = array_combine( self::$default_action_keys, self::$default_action_keys );
 
 			update_option( self::$section_name, $options );
 		}
 
-		$enabled_actions = $options[ self::$option_name ];
+		$enabled_actions = is_array( $options[ self::$option_name ] ) ? $options[ self::$option_name ] : [];
 
 		/**
 		 * Filter for overriding the list of enabled actions.
@@ -107,7 +109,7 @@ class Settings {
 		 *
 		 * @param array $enabled_actions. An array of enabled actions.
 		 */
-		return apply_filters( 'graphql_gf_gatsby_enabled_actions', array_keys( $enabled_actions ) );
+		return apply_filters( 'graphql_gf_gatsby_enabled_actions', array_values( $enabled_actions ) ?: [] );
 	}
 
 	/**

--- a/src/Extensions/WPGatsby/WPGatsby.php
+++ b/src/Extensions/WPGatsby/WPGatsby.php
@@ -30,8 +30,9 @@ class WPGatsby {
 	 * @return boolean
 	 */
 	public static function is_wp_gatsby_enabled() : bool {
-		return class_exists( 'WPGatsby' );
+		return class_exists( 'WPGatsby' ) && class_exists( 'WPGraphQL_Settings_API' );
 	}
+
 	/**
 	 * Registers the custom Action Monitor.
 	 *

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'e2ef8a03eae4edbbc6f797671672dac07dfccacb',
+        'reference' => '0807593ebef8e62a6cb449cc41c53bd1e461194b',
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'dev' => false,
     ),
@@ -16,7 +16,7 @@
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'e2ef8a03eae4edbbc6f797671672dac07dfccacb',
+            'reference' => '0807593ebef8e62a6cb449cc41c53bd1e461194b',
             'dev_requirement' => false,
         ),
         'yahnis-elsts/plugin-update-checker' => array(


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR cleans up the logic used to populate the `log_gatsby_gf_action` setting, ensuring the correct array values are passed.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #248

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Primarily by the logic used by the setting checks.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Visit `mysite.com/wp-admin/options-general.php?page=gatsbyjs`
2. Uncheck all options shown for `Monitor Gravity Forms Actions`
3. Click save changes.


## Additional Info
![image](https://user-images.githubusercontent.com/29322304/173201904-c6984d1f-cc3e-4f9e-af47-59a0e7334998.png)

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
