### PR TITLE
fix: correctly resolve `rangeMin` and `rangeMax` values

### DIFF
--- a/src/Type/WPObject/FormField/FieldProperty/FieldProperties.php
+++ b/src/Type/WPObject/FormField/FieldProperty/FieldProperties.php
@@ -1098,7 +1098,15 @@ class FieldProperties {
 			'rangeMax' => [
 				'type'        => 'Float',
 				'description' => __( 'Maximum allowed value for a number field. Values higher than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => fn( $source ) => ! empty( $source->rangeMax ) ? (float) $source->rangeMax : null,
+				'resolve'     => function( $source ) : ?float {
+					if ( ! isset( $source->rangeMax ) ) {
+						return null;
+					}
+
+					$numeric_max = isset( $source->numberFormat ) && 'decimal_comma' === $source->numberFormat ? GFCommon::clean_number( $source->rangeMax, 'decimal_comma' ) : $source->rangeMax;
+
+					return is_numeric( $numeric_max ) ? (float) $numeric_max : null;
+				},
 			],
 		];
 	}
@@ -1111,7 +1119,15 @@ class FieldProperties {
 			'rangeMin' => [
 				'type'        => 'Float',
 				'description' => __( 'Minimum allowed value for a number field. Values lower than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => fn( $source ) => ! empty( $source->rangeMin ) ? (float) $source->rangeMin : null,
+				'resolve'     => function( $source ) : ?float {
+					if ( ! isset( $source->rangeMin ) ) {
+						return null;
+					}
+
+					$numeric_min = isset( $source->numberFormat ) && 'decimal_comma' === $source->numberFormat ? GFCommon::clean_number( $source->rangeMin, 'decimal_comma' ) : $source->rangeMin;
+
+					return is_numeric( $numeric_min ) ? (float) $numeric_min : null;
+				},
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Correctly resolves the `NumberField.rangeMin` and `rangeMax` values.

h/t @natac13 

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Previously, a min/max of 0 would return null, and numbers formatted as a `decimal_comma` would error.

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
