### PR TITLE
feat: Add additional fields to `FormConfirmation` and `SubmissionConfirmation`

### DIFF
--- a/src/Type/WPObject/Form/FormConfirmation.php
+++ b/src/Type/WPObject/Form/FormConfirmation.php
@@ -49,6 +49,11 @@ class FormConfirmation extends AbstractObject {
 				'type'        => 'Boolean',
 				'description' => __( 'Whether the confirmation is active or inactive. The default confirmation is always active.', 'wp-graphql-gravity-forms' ),
 			],
+			'isAutoformatted'  => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether the confirmation message should be formatted so that paragraphs are automatically added for new lines.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => fn( $source ) => empty( $source['disableAutoformat'] ),
+			],
 			'isDefault'        => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is the default confirmation.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/WPObject/SubmissionConfirmation.php
+++ b/src/Type/WPObject/SubmissionConfirmation.php
@@ -10,8 +10,12 @@
 
 namespace WPGraphQL\GF\Type\WPObject;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\Enum\SubmissionConfirmationTypeEnum;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - Submission Confirmation
@@ -27,6 +31,34 @@ class SubmissionConfirmation extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
+	public static function register( TypeRegistry $type_registry = null ) : void {
+		register_graphql_object_type(
+			static::$type,
+			[
+				'connections'     => [
+					'page' => [
+						'toType'   => 'Page',
+						'oneToOne' => true,
+						'resolve'  => static function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+							$page_id = url_to_postid( $source['url'] );
+
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'page' );
+
+							$resolver->set_query_arg( 'p', $page_id );
+
+							return $resolver->one_to_one()->get_connection();
+						},
+					],
+				],
+				'description'     => static::get_description(),
+				'fields'          => static::get_fields(),
+				'eagerlyLoadType' => static::$should_load_eagerly,
+			]
+		);
+	}
+	/**
+	 * {@inheritDoc}
+	 */
 	public static function get_description() : string {
 		return __( 'The Confirmation object returned on submission. Null if the submission was not successful.', 'wp-graphql-gravity-forms' );
 	}
@@ -36,17 +68,35 @@ class SubmissionConfirmation extends AbstractObject {
 	 */
 	public static function get_fields() : array {
 		return [
-			'message' => [
+			'message'     => [
 				'type'        => 'String',
 				'description' => __( 'Contains the confirmation message HTML to display. Only applicable when type is set to `MESSAGE`.', 'wp-graphql-gravity-forms' ),
 			],
-			'type'    => [
+			'type'        => [
 				'type'        => SubmissionConfirmationTypeEnum::$type,
 				'description' => __( 'Determines the type of confirmation to be used.', 'wp-graphql-gravity-forms' ),
 			],
-			'url'     => [
+			'url'         => [
 				'type'        => 'String',
 				'description' => __( 'The URL the submission should redirect to. Only applicable when type is set to `REDIRECT`.', 'wp-graphql-gravity-forms' ),
+			],
+			'pageId'      => [
+				'type'        => 'Int',
+				'description' => __( 'Contains the Id of the WordPress page that the browser will be redirected to. Only applicable when type is set to `PAGE`.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => function( $source ) {
+					$post_id = url_to_postid( $source['url'] );
+
+					return ! empty( $post_id ) ? $post_id : null;
+				},
+			],
+			'queryString' => [
+				'type'        => 'String',
+				'description' => __( 'Contains the query string to be appended to the redirection url. Only applicable when type is set to `REDIRECT` or `PAGE` .', 'wp-graphql-gravity-forms' ),
+				'resolve'     => function( $source ) {
+					$parts = wp_parse_url( $source['url'] );
+
+					return false !== $parts && ! empty( $parts['query'] ) ? $parts['query'] : null;
+				},
 			],
 		];
 	}

--- a/tests/wpunit/SubmitDraftEntryMutationTest.php
+++ b/tests/wpunit/SubmitDraftEntryMutationTest.php
@@ -6,6 +6,7 @@
  */
 
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
+use GFAPI;
 
 /**
  * Class - SubmitDraftEntryMutationTest
@@ -66,18 +67,98 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 		];
 
 		wp_set_current_user( $this->admin->ID );
-		$response = $this->graphql( compact( 'query', 'variables' ) );
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
-		$this->assertArrayNotHasKey( 'errors', $response );
+		$this->assertArrayNotHasKey( 'errors', $actual );
 
-		$actual_entry = $this->factory->entry->get_object_by_id( $response['data']['submitGfDraftEntry']['entry']['databaseId'] ?? null );
+		$expected = $this->factory->entry->get_object_by_id( $actual['data']['submitGfDraftEntry']['entry']['databaseId'] ?? null );
 
-		$this->assertEquals( $actual_entry['id'], $response['data']['submitGfDraftEntry']['entry']['databaseId'] );
+		$this->assertEquals( $expected['id'], $actual['data']['submitGfDraftEntry']['entry']['databaseId'] );
 
-		$this->assertEquals( 'value1', $response['data']['submitGfDraftEntry']['entry']['formFields']['nodes'][0]['value'] );
-		$this->assertEquals( "MESSAGE", $response['data']['submitGfDraftEntry']['confirmation']['type'] );
-		$this->assertNotEmpty( $response['data']['submitGfDraftEntry']['confirmation']['message'] );
-		$this->factory->entry->delete( $actual_entry['id'] );
+		$this->assertEquals( 'value1', $actual['data']['submitGfDraftEntry']['entry']['formFields']['nodes'][0]['value'] );
+		$this->assertEquals( 'MESSAGE', $actual['data']['submitGfDraftEntry']['confirmation']['type'] );
+		$this->assertNotEmpty( $actual['data']['submitGfDraftEntry']['confirmation']['message'] );
+		$this->factory->entry->delete( $expected['id'] );
+	}
+
+	public function testSubmitWithURLConfirmation() : void {
+		$form = GFAPI::get_form( $this->form_id );
+
+		$confirmation_id = array_keys( $form['confirmations'] )[0];
+
+		$expected_url = 'https://example.com/test';
+
+		$form['confirmations'][ $confirmation_id ]['type']        = 'REDIRECT';
+		$form['confirmations'][ $confirmation_id ]['url']         = $expected_url;
+		$form['confirmations'][ $confirmation_id ]['queryString'] = 'foo=bar';
+
+		GFAPI::update_form( $form, $this->form_id );
+
+		$query = $this->submit_mutation();
+
+		$variables = [
+			'id'     => $this->draft_token,
+			'idType' => 'RESUME_TOKEN',
+		];
+
+		wp_set_current_user( $this->admin->ID );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$expected = $this->factory->entry->get_object_by_id( $actual['data']['submitGfDraftEntry']['entry']['databaseId'] ?? null );
+
+		$this->assertEquals( $expected['id'], $actual['data']['submitGfDraftEntry']['entry']['databaseId'] );
+
+		$this->assertEquals( 'value1', $actual['data']['submitGfDraftEntry']['entry']['formFields']['nodes'][0]['value'] );
+		$this->assertEquals( 'REDIRECT', $actual['data']['submitGfDraftEntry']['confirmation']['type'] );
+		$this->assertStringContainsString( $expected_url, $actual['data']['submitGfDraftEntry']['confirmation']['url'] );
+		$this->factory->entry->delete( $expected['id'] );
+	}
+
+	public function testSubmitWithPageConfirmation() : void {
+		$form    = GFAPI::get_form( $this->form_id );
+		$page_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Testing Submit with Page Confirmation',
+			]
+		);
+
+		$confirmation_id = array_keys( $form['confirmations'] )[0];
+
+		$form['confirmations'][ $confirmation_id ]['type']        = 'page';
+		$form['confirmations'][ $confirmation_id ]['pageId']      = $page_id;
+		$form['confirmations'][ $confirmation_id ]['queryString'] = 'foo=bar';
+
+		GFAPI::update_form( $form, $this->form_id );
+
+		$query = $this->submit_mutation();
+
+		$variables = [
+			'id'     => $this->draft_token,
+			'idType' => 'RESUME_TOKEN',
+		];
+
+		wp_set_current_user( $this->admin->ID );
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$expected = $this->factory->entry->get_object_by_id( $actual['data']['submitGfDraftEntry']['entry']['databaseId'] ?? null );
+
+		$this->assertEquals( $expected['id'], $actual['data']['submitGfDraftEntry']['entry']['databaseId'] );
+
+		$this->assertEquals( 'value1', $actual['data']['submitGfDraftEntry']['entry']['formFields']['nodes'][0]['value'] );
+		$this->assertEquals( 'REDIRECT', $actual['data']['submitGfDraftEntry']['confirmation']['type'] );
+		$this->assertEquals( $page_id, $actual['data']['submitGfDraftEntry']['confirmation']['pageId'] );
+		$this->assertEquals( $page_id, $actual['data']['submitGfDraftEntry']['confirmation']['page']['node']['databaseId'] );
+
+		$this->factory->entry->delete( $expected['id'] );
+		wp_delete_post( $page_id, true );
 	}
 
 	/**
@@ -113,6 +194,13 @@ class SubmitDraftEntryMutationTest extends GFGraphQLTestCase {
 						message
 						type
 						url
+						page {
+							node {
+								databaseId
+							}
+						}
+						pageId
+						queryString
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
- feat: add `isAutoformatted` to the `FormConfirmation` object.
- feat: add `pageId` and `queryString` fields and `Page` connection to `FormSubmission` object.

## Testing Instructions
```graphql
mutation myMutation($input: SubmitGfFormInput!) {
  submitGfForm(input: $input) {
    confirmation {
      page {
        node {
          databaseId
        }
      }
      pageId
      queryString
      type
    }
    entry {
      form {
        confirmations {
          isAutoformatted
        }
      }
    }
  }
}
```

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
