### PR TITLE
feat: add Page connection to FormConfirmation

### DIFF
--- a/src/Type/WPObject/Form/FormConfirmation.php
+++ b/src/Type/WPObject/Form/FormConfirmation.php
@@ -13,11 +13,43 @@ namespace WPGraphQL\GF\Type\WPObject\Form;
 use WPGraphQL\GF\Type\Enum\FormConfirmationTypeEnum;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\WPObject\ConditionalLogic\ConditionalLogic;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - FormConfirmation
  */
 class FormConfirmation extends AbstractObject {
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function register( TypeRegistry $type_registry = null ) : void {
+		register_graphql_object_type(
+			static::$type,
+			[
+				'connections'     => [
+					'page' => [
+						'toType'   => 'Page',
+						'oneToOne' => true,
+						'resolve'  => static function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+							$page_id = $source['pageId'];
+
+							$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, 'page' );
+
+							$resolver->set_query_arg( 'p', $page_id );
+
+							return $resolver->one_to_one()->get_connection();
+						},
+					],
+				],
+				'description'     => static::get_description(),
+				'fields'          => static::get_fields(),
+				'eagerlyLoadType' => static::$should_load_eagerly,
+			]
+		);
+	}
+
 	/**
 	 * Type registered in WPGraphQL.
 	 *


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Adds a connection from `FormConfirmation` to the `Page` object .

## Why
#270 

## Testing Instructions
```graphql
{
  gfForms {
    nodes {
      confirmations{
        page{
          node{
            databaseId # same as pageId below
          }
        }
        pageId
      }
    }
  }
}
```

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
