### PR TITLE
docs: Add usage example for file uploads

### DIFF
--- a/docs/submitting-forms.md
+++ b/docs/submitting-forms.md
@@ -188,7 +188,10 @@ mutation submit( $token: String ) {
 ## Submitting File Uploads
 To enable WPGraphQL support for submitting files (via the `fileUploadValues` or `postImageValues` inputs ), you must first install and activate the [WPGraphQL Upload](https://github.com/dre1080/wp-graphql-upload) extension, which will add the `Upload` scalar type to the GraphQL schema.
 
-Once enabled, you can then use the `Upload` type to submit forms that accept file uploads as so:
+**Note**: The GraphQL Spec - and many GraphQL clients - does not natively implement support the [`graphql-multipart-request-spec`](https://github.com/jaydenseric/graphql-multipart-request-spec), and may require an additional dependency such as [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client).
+
+### Example Mutation
+
 ```graphql
 mutation submit( $exampleUploads: [ Upload ], $exampleImageUpload: Upload ){ 
   submitGfForm(
@@ -228,5 +231,3 @@ mutation submit( $exampleUploads: [ Upload ], $exampleImageUpload: Upload ){
   }
 }
 ```
-
-**Note**: The GraphQL Spec - and many GraphQL clients - does not natively implement support the [`graphql-multipart-request-spec`](https://github.com/jaydenseric/graphql-multipart-request-spec), and may require an additional dependency such as [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client).

--- a/docs/submitting-forms.md
+++ b/docs/submitting-forms.md
@@ -157,28 +157,30 @@ As of v0.11.0, WPGraphQL for Gravity Forms supports server-side captcha validati
 To validate a reCAPTCHA field, you need to [fetch the captcha response token](https://developers.google.com/recaptcha/docs/verify), and pass that to the field's `value` input argument:
 
 ```graphql
-submitGfForm( $token: String )
-  input: {
-    formId: 50
-    fieldValues: [
-      # other form fields would go here.
-      {
-        # Captcha Field
-        id: 1
-        value: $token # The google reCAPTCHA response token.
+mutation submit( $token: String ) {
+  submitGfForm(
+    input: {
+      formId: 50
+      fieldValues: [
+        # other form fields would go here.
+        {
+          # Captcha Field
+          id: 1
+          value: $token # The google reCAPTCHA response token.
+        }
       }
     }
-  }
-) {
-  errors {
-    id
-    message
-  }
-  confirmation {
-    message
-  }
-  entry {
-    databaseId
+  ) {
+    errors {
+      id
+      message
+    }
+    confirmation {
+      message
+    }
+    entry {
+      databaseId
+    }
   }
 }
 ```
@@ -188,39 +190,41 @@ To enable WPGraphQL support for submitting files (via the `fileUploadValues` or 
 
 Once enabled, you can then use the `Upload` type to submit forms that accept file uploads as so:
 ```graphql
-submitGfForm( $exampleUploads: [ Upload ], $exampleImageUpload: Upload )
-  input: {
-    formId: 50
-    fieldValues: [
-      # other form fields would go here.
-      {
-        # FileUpload field
-        id: 1
-        fileUploadValues: $exampleUploads # An array of Upload objects. 
-      }
-      {
-        # PostImage field
-        id: 2
-        postImageValues {
-          altText: "Some alt text"
-          caption: "Some caption"
-          image: $exampleImageUpload # The Upload object
-          description: "Some description"
-          title: "Some title"
+mutation submit( $exampleUploads: [ Upload ], $exampleImageUpload: Upload ){ 
+  submitGfForm(
+    input: {
+      formId: 50
+      fieldValues: [
+        # other form fields would go here.
+        {
+          # FileUpload field
+          id: 1
+          fileUploadValues: $exampleUploads # An array of Upload objects. 
+        }
+        {
+          # PostImage field
+          id: 2
+          postImageValues {
+            altText: "Some alt text"
+            caption: "Some caption"
+            image: $exampleImageUpload # The Upload object
+            description: "Some description"
+            title: "Some title"
+          }
         }
       }
     }
-  }
-) {
-  errors {
-    id
-    message
-  }
-  confirmation {
-    message
-  }
-  entry {
-    databaseId
+  ) {
+    errors {
+      id
+      message
+    }
+    confirmation {
+      message
+    }
+    entry {
+      databaseId
+    }
   }
 }
 ```


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Adds some explanation, and usage examples of the `Upload` type.

## Why
Knowledge is power.

