### PR TITLE
Fix: Ensure DataLoaders return null

### DIFF
--- a/src/Data/Loader/DraftEntriesLoader.php
+++ b/src/Data/Loader/DraftEntriesLoader.php
@@ -11,10 +11,10 @@
 namespace WPGraphQL\GF\Data\Loader;
 
 use Exception;
+use GFFormsModel;
 use GraphQL\Deferred;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
 use WPGraphQL\GF\Model\DraftEntry;
-use WPGraphQL\GF\Utils\GFUtils;
 
 /**
  * Class - DraftEntriesLoader
@@ -54,10 +54,9 @@ class DraftEntriesLoader extends AbstractDataLoader {
 			return $keys;
 		}
 
-		// GF doesn't cache form queries so we're going to use the fetched array.
 		$loaded_entries = [];
 		foreach ( $keys as $key ) {
-			$loaded_entries[ $key ] = GFUtils::get_draft_entry( $key );
+			$loaded_entries[ $key ] = GFFormsModel::get_draft_submission_values( $key ) ?: null;
 		}
 
 		return $loaded_entries;

--- a/src/Data/Loader/EntriesLoader.php
+++ b/src/Data/Loader/EntriesLoader.php
@@ -10,7 +10,7 @@
 
 namespace WPGraphQL\GF\Data\Loader;
 
-use GF_Query;
+use GFAPI;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
 use WPGraphQL\GF\Model\SubmittedEntry;
 
@@ -52,14 +52,13 @@ class EntriesLoader extends AbstractDataLoader {
 			return $keys;
 		}
 
-		$gf_query        = new GF_Query();
-		$entries_from_db = $gf_query->get_entries( $keys );
-		// GF doesn't cache form queries so we're going to use the fetched array.
+		// Associate the requested keys with their loaded entry.
 		$loaded_entries = [];
-		foreach ( $entries_from_db as $entry ) {
-			$loaded_entries [ $entry['id'] ] = $entry;
+		foreach ( $keys as $key ) {
+			$entry                  = GFAPI::get_entry( $key );
+			$loaded_entries[ $key ] = ! is_wp_error( $entry ) ? $entry : null;
 		}
 
-		return array_combine( $keys, $loaded_entries );
+		return $loaded_entries;
 	}
 }

--- a/src/Data/Loader/FormsLoader.php
+++ b/src/Data/Loader/FormsLoader.php
@@ -10,9 +10,9 @@
 
 namespace WPGraphQL\GF\Data\Loader;
 
+use GFAPI;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
 use WPGraphQL\GF\Model\Form;
-use WPGraphQL\GF\Utils\GFUtils;
 
 /**
  * Class - FormsLoader
@@ -52,15 +52,11 @@ class FormsLoader extends AbstractDataLoader {
 			return $keys;
 		}
 
-		$forms_from_db = GFUtils::get_forms( $keys, false );
-
 		$loaded_forms = [];
-		// GF doesn't cache form queries so we're going to use the fetched array.
-		foreach ( $forms_from_db as $form ) {
-			$loaded_forms [ $form['id'] ] = $form;
+		foreach ( $keys as $key ) {
+			$loaded_forms[ $key ] = GFAPI::get_form( $key ) ?: null;
 		}
 
-		// Order the forms by the provided keys.
-		return array_replace( array_flip( $keys ), $loaded_forms );
+		return $loaded_forms;
 	}
 }

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -4,6 +4,7 @@
  * suite already bootstraps the autoloader and creates
  * fatal errors when the autoloader is loaded twice
  */
+define( 'GRAPHQL_DEBUG', true );
 
 // Use reCAPTCHA test keys: https://developers.google.com/recaptcha/docs/faq
 define( 'GF_RECAPTCHA_PUBLIC_KEY', '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI' );

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -64,32 +64,39 @@ class FormQueriesTest extends GFGraphQLTestCase {
 
 		$query = $this->get_form_query();
 
-		$actual = $this->graphql(
-			[
-				'query'     => $query,
-				'variables' => [
-					'id'     => $form_id,
-					'idType' => 'DATABASE_ID',
-				],
-			]
-		);
+		// Test with bad ID.
+		$variables = [
+			'id' => 99999999,
+			'idType' => 'DATABASE_ID'
+		];
 
-		$expected = $this->expected_field_response( $form, $confirmation_key );
+		$actual = $this->graphql( compact( 'query', 'variables') );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertNull( $actual['data']['gfForm'] );
 
 		// Test with Database ID.
+		$variables['id'] = $form_id;
+		$expected = $this->expected_field_response( $form, $confirmation_key );
+
+		$actual = $this->graphql( compact( 'query', 'variables') );
+
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertQuerySuccessful( $actual, $expected );
 
-		// Test with global ID.
-		$actual = $this->graphql(
-			[
-				'query'     => $query,
-				'variables' => [
-					'id'     => $global_id,
-					'idType' => 'ID',
-				],
-			]
-		);
+				// Test with bad global ID.
+		$variables = [
+			'id'     => 'not-a-real-id',
+			'idType' => 'ID',
+		];
+
+		$actual  = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+
+		// Test with Global Id.
+		$variables['id'] = $global_id;
+		$actual  = $this->graphql( compact( 'query', 'variables' ) );
+
+
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertQuerySuccessful( $actual, $expected );
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes the logic used in the form/entry `DataLoader` classes, to ensure that non-existent objects return `null` instead of throwing an error.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Currently, querying for a non-existent `databaseId`s will throw a PHP or GraphQL error, instead of resolving to `null`.

See: https://wp-graphql.slack.com/archives/C01M7SGUGQL/p1657851805580839 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Instead of fetching all items and matching them to the requested `key`, only the requested objects are fetched. `Utils` methods are _not_  used, as we don't want to throw any errors.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Run the following query:
```graphql
{
  gfForm(id: 999999999999, idType: DATABASE_ID) {
    databaseId
  }
  gfEntry(id: 999999999999, idType: DATABASE_ID) {
    id
  }
}
```
## Additional Info
![image](https://user-images.githubusercontent.com/29322304/179237808-c9126e3f-38da-47b8-b0a9-b5526471cba6.png)

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
