### PR TITLE
fix: remove use of deprecated `graphql_gf_form_field_value_properties`

### DIFF
--- a/src/Extensions/GFChainedSelects/GFChainedSelects.php
+++ b/src/Extensions/GFChainedSelects/GFChainedSelects.php
@@ -43,7 +43,7 @@ class GFChainedSelects implements Hookable {
 		add_filter( 'graphql_gf_field_value_input_class', [ __CLASS__, 'field_value_input' ], 10, 3 );
 
 		// Register field value property.
-		add_filter( 'graphql_gf_form_field_value_properties', [ __CLASS__, 'field_value_properties' ], 10, 2 );
+		add_filter( 'graphql_gf_form_field_value_fields', [ __CLASS__, 'field_value_fields' ], 10, 2 );
 
 		// Register fieldValues input.
 		add_filter( 'graphql_gf_form_field_values_input_fields', [ __CLASS__, 'field_values_input_fields' ] );
@@ -133,17 +133,17 @@ class GFChainedSelects implements Hookable {
 
 
 	/**
-	 * Registers Signature field settings mapper.
+	 * Registers ChainedSelect field value.
 	 *
-	 * @param array    $properties .
+	 * @param array    $fields .
 	 * @param GF_Field $field .
 	 */
-	public static function field_value_properties( array $properties, GF_Field $field ) : array {
+	public static function field_value_fields( array $fields, GF_Field $field ) : array {
 		if ( 'chainedselect' === $field->get_input_type() ) {
-			$properties += ValueProperty::chained_select_values();
+			$fields = array_merge( $fields, ValueProperty::chained_select_values() );
 		}
 
-		return $properties;
+		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
This PR replaces the use of `graphql_gf_form_field_value_properties` by `GFChainedSelects` with `graphql_gf_form_field_value_fields`, and renames the hooked method and parameters to reflect this.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
GFChainedSelects was still using the deprecated `graphql_gf_form_field_value_properties` hook. 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
1. Run tests with WP debug enabled.
2. Confirm no PHP notices are printed to debug.log

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
