### PR TITLE
chore: use label to run github workflows with secrets

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,10 +9,14 @@ on:
     branches:
       - develop
       - main
+    types: [labeled]
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Check code
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test ✔')
+
     services:
       mariadb:
         image: mariadb
@@ -24,30 +28,29 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
+          tools: composer:v2, wp-cli
           coverage: none
-          tools: composer, wp-cli
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}N-${{ runner.os }}-composer
 
       - name: Install dependencies
-        run: composer install
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--no-progress"
 
       - name: Setup WordPress
         run: |

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Checkout repo
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -21,22 +27,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
-          extensions: mbstring, intl
-          tools: composer
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer
+          tools: composer:v2
+          coverage: none
 
       - name: Install dependencies
-        run: composer install
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--no-progress"
 
       - name: Run PHP_CodeSniffer
         run: composer run-script check-cs

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -13,10 +13,14 @@ on:
       - "**.php"
       - ".github/workflows/*.yml"
       - "!docs/**"
+    types: [labeled]
 
 jobs:
   continuous_integration:
     runs-on: ubuntu-latest
+    name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test ✔')
+
     strategy:
       matrix:
         php: ["7.4", "8.0"]
@@ -28,31 +32,28 @@ jobs:
           - php: "7.4"
             wordpress: "5.7"
       fail-fast: false
-    name: WordPress ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
+
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
+         with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring
-          tools: composer, wp-cli
-
-      - name: Get Composer Cache Directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-${{ runner.os }}-composer-
+          tools: composer:v2
 
       - name: Install dependencies
-        run: composer install
+        uses: ramsey/composer-install@v2
 
       - name: Build "testing" Docker Image
         env:

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -8,10 +8,14 @@ on:
     branches:
       - develop
       - main
+    types: [labeled]
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Lint WPGraphQL Schema
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test ✔')
+
     services:
       mariadb:
         image: mariadb
@@ -21,9 +25,18 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         # Ensure docker waits for mariadb to start
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
@@ -31,7 +44,7 @@ jobs:
           php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
-          tools: composer, wp-cli
+          tools: composer:v2, wp-cli
 
       - name: Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Use `safe to test ✔` for running GH workflows that require secrets

## Why
`pull_request` doesn't have access to secrets, and `pull_request_target` alone is unsafe.
see: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
