### PR TITLE
feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `column`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: Add `orderSummary` to `GfEntry` interface.
 - feat: Add support for `Option`, `Product`, `Quantity`, `Shipping`, and `Total` Gravity Forms fields.
 - feat: Refactor `GfFormField` field settings, choices, and inputs to use GraphQL interfaces.
+- feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`.
 - fix: ensure latest mutation input data is used to prepare the field values on update mutations.
 - dev!: Move `TypeRegistry` classes to `WPGraphQL\GF\Registry` namespace.
 - dev!: Register each GraphQL type on its own `add_action()` call.

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -146,6 +146,7 @@ class TypeRegistry {
 			Enum\FormSubLabelPlacementEnum::class,
 			Enum\FormSubmitButtonLocationEnum::class,
 			Enum\FormSubmitButtonWidthEnum::class,
+			Enum\FormsConnectionOrderByEnum::class,
 			Enum\NumberFieldFormatEnum::class,
 			Enum\PasswordFieldMinStrengthEnum::class,
 			Enum\PhoneFieldFormatEnum::class,

--- a/src/Type/Enum/FormsConnectionOrderByEnum.php
+++ b/src/Type/Enum/FormsConnectionOrderByEnum.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Enum Type - FormsConnectionOrderByEnum
+ *
+ * @package WPGraphQL\GF\Type\Enum,
+ * @since   0.4.0
+ */
+
+namespace WPGraphQL\GF\Type\Enum;
+
+/**
+ * Class - FormsConnectionOrderByEnum
+ */
+class FormsConnectionOrderByEnum extends AbstractEnum {
+	/**
+	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
+	 */
+	public static string $type = 'FormsConnectionOrderByEnum';
+
+	// Individual elements.
+	const DATE_CREATED = 'date_created';
+	const ID           = 'id';
+	const IS_ACTIVE    = 'is_active';
+	const IS_TRASH     = 'is_trash';
+	const TITLE        = 'title';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_description() : string {
+		return __( 'Type of button to be displayed. Default is TEXT.', 'wp-graphql-gravity-forms' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_values() : array {
+		return [
+			'DATE_CREATED' => [
+				'description' => __( 'The date the form was created.', 'wp-graphql-gravity-forms' ),
+				'value'       => self::DATE_CREATED,
+			],
+			'ID'           => [
+				'description' => __( 'The database ID of the form.', 'wp-graphql-gravity-forms' ),
+				'value'       => self::ID,
+			],
+			'IS_ACTIVE'    => [
+				'description' => __( 'The Form\'s active status.', 'wp-graphql-gravity-forms' ),
+				'value'       => self::IS_ACTIVE,
+			],
+			'IS_TRASH'     => [
+				'description' => __( 'The form\'s trash status .', 'wp-graphql-gravity-forms' ),
+				'value'       => self::IS_TRASH,
+			],
+			'TITLE'        => [
+				'description' => __( 'The title of the form.', 'wp-graphql-gravity-forms' ),
+				'value'       => self::TITLE,
+			],
+		];
+	}
+}

--- a/src/Type/Input/FormsConnectionOrderbyInput.php
+++ b/src/Type/Input/FormsConnectionOrderbyInput.php
@@ -9,6 +9,8 @@
 
 namespace WPGraphQL\GF\Type\Input;
 
+use WPGraphQL\GF\Type\Enum\FormsConnectionOrderByEnum;
+
 /**
  * Class - FormsConnectionOrderbyInput
  */
@@ -32,12 +34,16 @@ class FormsConnectionOrderbyInput extends AbstractInput {
 	 */
 	public static function get_fields() : array {
 		return [
-			// @todo switch to enum
-			'field' => [
-				'type'        => 'String',
-				'description' => __( 'The field name used to sort the results.', 'wp-graphql-gravity-forms' ),
+			'field'   => [
+				'type'              => 'String',
+				'description'       => __( 'The field name used to sort the results.', 'wp-graphql-gravity-forms' ),
+				'deprecationReason' => __( 'Use the `orderBy` field instead.', 'wp-graphql-gravity-forms' ),
 			],
-			'order' => [
+			'column' => [
+				'type'        => FormsConnectionOrderByEnum::$type,
+				'description' => __( 'The form column name used to sort the results.', 'wp-graphql-gravity-forms' ),
+			],
+			'order'   => [
 				'type'        => 'OrderEnum',
 				'description' => __( 'The cardinality of the order of the connection.', 'wp-graphql-gravity-forms' ),
 			],

--- a/tests/wpunit/FormConnectionQueriesTest.php
+++ b/tests/wpunit/FormConnectionQueriesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test GraphQL Entry Queries.
+ * Test GraphQL FormConnectionQueriesTest Queries.
  *
  * @package .
  */
@@ -8,9 +8,9 @@
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
 
 /**
- * Class - EntryQueriesTest
+ * Class - FormConnectionQueriesTest
  */
-class FormConnectionPaginationTest extends GFGraphQLTestCase {
+class FormConnectionQueriesTest extends GFGraphQLTestCase {
 	private $fields = [];
 	private $form_ids;
 	private $text_field_helper;
@@ -80,7 +80,7 @@ class FormConnectionPaginationTest extends GFGraphQLTestCase {
 
 		$query = $this->getQuery();
 
-		$wp_query = GFAPI::get_forms( null, null, 'ids', 'DESC' );
+		$wp_query = GFAPI::get_forms( null, null, 'id', 'DESC' );
 
 		codecept_debug( array_column( $wp_query, 'id' ) );
 
@@ -158,7 +158,7 @@ class FormConnectionPaginationTest extends GFGraphQLTestCase {
 
 		$query = $this->getQuery();
 
-		$wp_query = GFAPI::get_forms( null, null, 'ids', 'ASC' );
+		$wp_query = GFAPI::get_forms( null, null, 'id', 'ASC' );
 
 		codecept_debug( array_column( $wp_query, 'id' ) );
 
@@ -340,13 +340,13 @@ class FormConnectionPaginationTest extends GFGraphQLTestCase {
 			'first' => 2,
 			'where' => [
 				'orderby' => [
-					'field' => 'ids',
+					'column' => 'ID',
 					'order' => 'DESC',
 				],
 			],
 		];
 
-		$wp_query = \GFAPI::get_forms( null, null, 'ids', 'DESC' );
+		$wp_query = \GFAPI::get_forms( null, null, 'id', 'DESC' );
 		$expected = array_slice( $wp_query, 0, 2, false );
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -143,6 +143,7 @@ return array(
     'WPGraphQL\\GF\\Type\\Enum\\FormSubLabelPlacementEnum' => $baseDir . '/src/Type/Enum/FormSubLabelPlacementEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\FormSubmitButtonLocationEnum' => $baseDir . '/src/Type/Enum/FormSubmitButtonLocationEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\FormSubmitButtonWidthEnum' => $baseDir . '/src/Type/Enum/FormSubmitButtonWidthEnum.php',
+    'WPGraphQL\\GF\\Type\\Enum\\FormsConnectionOrderByEnum' => $baseDir . '/src/Type/Enum/FormsConnectionOrderByEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\NumberFieldFormatEnum' => $baseDir . '/src/Type/Enum/NumberFieldFormatEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\PasswordFieldMinStrengthEnum' => $baseDir . '/src/Type/Enum/PasswordFieldMinStrengthEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\PhoneFieldFormatEnum' => $baseDir . '/src/Type/Enum/PhoneFieldFormatEnum.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -162,6 +162,7 @@ class ComposerStaticInit1780be6bb95231f5d94c35ac3decce02
         'WPGraphQL\\GF\\Type\\Enum\\FormSubLabelPlacementEnum' => __DIR__ . '/../..' . '/src/Type/Enum/FormSubLabelPlacementEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\FormSubmitButtonLocationEnum' => __DIR__ . '/../..' . '/src/Type/Enum/FormSubmitButtonLocationEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\FormSubmitButtonWidthEnum' => __DIR__ . '/../..' . '/src/Type/Enum/FormSubmitButtonWidthEnum.php',
+        'WPGraphQL\\GF\\Type\\Enum\\FormsConnectionOrderByEnum' => __DIR__ . '/../..' . '/src/Type/Enum/FormsConnectionOrderByEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\NumberFieldFormatEnum' => __DIR__ . '/../..' . '/src/Type/Enum/NumberFieldFormatEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\PasswordFieldMinStrengthEnum' => __DIR__ . '/../..' . '/src/Type/Enum/PasswordFieldMinStrengthEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\PhoneFieldFormatEnum' => __DIR__ . '/../..' . '/src/Type/Enum/PhoneFieldFormatEnum.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => '403400e948c6bd043c5bc383b72e7c009e933e24',
+        'reference' => 'c7f9b6755890b1fabca7a93b98b42d40c731d109',
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'dev' => false,
     ),
@@ -16,7 +16,7 @@
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => '403400e948c6bd043c5bc383b72e7c009e933e24',
+            'reference' => 'c7f9b6755890b1fabca7a93b98b42d40c731d109',
             'dev_requirement' => false,
         ),
         'yahnis-elsts/plugin-update-checker' => array(


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
This PR deprecates the `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`, which accepts a `FormsConnectionOrderByEnum`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #309

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR ollows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
