### PR TITLE
feat!: Check dep versions and update minimum required WPGraphQL version to v1.9.0.

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards based custom ruleset for your plugin">
 	<description>Generally-applicable sniffs for WordPress plugins.</description>
+
 	<!-- What to scan -->
 	<file>.</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
+	<exclude-pattern>/phpstan/</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
+
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
@@ -19,7 +22,6 @@
 	<arg name="parallel" value="8"/>
 
 	<!-- Tests for PHP version compatibility -->
-		<!-- Tests for PHP version compatibility -->
 	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP">
 		<include-pattern>*\.php$</include-pattern>
@@ -41,7 +43,7 @@
 	<rule ref="WordPress-Extra" />
 
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.4.1"/>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - feat!: Update minimum required WPGraphQL version to v1.9.0.
+- feat: Check if plugin dependences meet the minimum version requirements.
 - feat: Add `connectedChoice` and `connectedInput` to `CheckboxFieldValue` type.
 - feat: Add `orderSummary` to `GfEntry` interface.
 - feat: Add support for `Option`, `Product`, `Quantity`, `Shipping`, and `Total` Gravity Forms fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- feat!: Update minimum required WPGraphQL version to v1.9.0.
 - feat: Add `connectedChoice` and `connectedInput` to `CheckboxFieldValue` type.
 - feat: Add `orderSummary` to `GfEntry` interface.
 - feat: Add support for `Option`, `Product`, `Quantity`, `Shipping`, and `Total` Gravity Forms fields.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Our hope for this open source project is that it will enable more teams to lever
 
 * PHP 7.4+ || 8.0
 * WordPress 5.4.1+
-* WPGraphQL 1.7.0+ (Recommended: v1.9.0+)
+* WPGraphQL 1.9.0+
 * Gravity Forms 2.5+ (Recommend: v2.6+)
 * **Recommended**: [WPGraphQL Upload](https://github.com/dre1080/wp-graphql-upload) - used for [File Upload and Post Image submissions](docs/submitting-forms.md).
 

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -7,4 +7,3 @@ define( 'WPGRAPHQL_GF_AUTOLOAD', true );
 define( 'CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY', 'wp-jamstack-deployments' );
 define( 'WPGRAPHQL_GF_PLUGIN_FILE', 'wp-graphql-gravity-forms.php' );
 define( 'WPGRAPHQL_GF_VERSION', '0.10.0' );
-define( 'WPGRAPHQL_VERSION', '1.9.0' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.4.1
 Tested up to: 6.0.2
 Requires PHP: 7.4
 Requires Gravity Forms: 2.5.0
-Requires WPGraphQL: 1.7.0
+Requires WPGraphQL: 1.9.0
 Stable tag: 0.11.4
 Maintained at: https://github.com/harness-software/wp-graphql-gravity-forms
 License: GPL-3

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -44,7 +44,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		$this->is_legacy = version_compare( WPGRAPHQL_VERSION, '1.9.0', '<' );
+		$this->is_legacy = defined( 'WPGRAPHQL_VERSION' ) && version_compare( WPGRAPHQL_VERSION, '1.9.0', '<' );
 
 		parent::__construct( $source, $args, $context, $info );
 		$this->offset_index = $this->get_query_offset_index();

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -33,19 +33,9 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	public int $offset_index = 0;
 
 	/**
-	 * Whether the version of WPGraphQL is missing the new methods added in v1.9.0.
-	 * Used to support pre 1.9.0 versions of WPGraphQL.
-	 *
-	 * @var boolean
-	 */
-	public bool $is_legacy = false;
-
-	/**
 	 * {@inheritDoc}
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		$this->is_legacy = defined( 'WPGRAPHQL_VERSION' ) && version_compare( WPGRAPHQL_VERSION, '1.9.0', '<' );
-
 		parent::__construct( $source, $args, $context, $info );
 		$this->offset_index = $this->get_query_offset_index();
 	}
@@ -149,89 +139,6 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 
 		return $ids;
 	}
-
-	/**
-	 * Gets the array index for the given offset.
-	 *
-	 * Shim for pre 1.9.0 versions of WPGraphQL.
-	 *
-	 * @param int|string|false $offset The cursor pagination offset.
-	 * @param array            $ids    The array of ids from the query.
-	 *
-	 * @return int|false $index The array index of the offset.
-	 */
-	public function get_array_index_for_offset( $offset, $ids ) {
-		if ( ! $this->is_legacy ) {
-			return parent::get_array_index_for_offset( $offset, $ids );
-		}
-
-		if ( false === $offset ) {
-			return false;
-		}
-
-		// We use array_values() to ensure we're getting a positional index, and not a key.
-		return array_search( $offset, array_values( $ids ), true );
-	}
-
-	/**
-	 * Returns an array slice of IDs, per the Relay Cursor Connection spec.
-	 *
-	 * Shim for WPGraphQL < 1.9.0
-	 *
-	 * @param array $ids The array of IDs from the query to slice, ordered as expected by the GraphQL query.
-	 *
-	 * @return array
-	 */
-	public function apply_cursors_to_ids( array $ids ) {
-		if ( ! $this->is_legacy ) {
-			return parent::apply_cursors_to_ids( $ids );
-		}
-
-		if ( empty( $ids ) ) {
-			return [];
-		}
-
-		// First we slice the array from the front.
-		if ( ! empty( $this->args['after'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['after'] );
-			$index  = $this->get_array_index_for_offset( $offset, $ids );
-
-			if ( false !== $index ) {
-				// We want to start with the first id after the index.
-				$ids = array_slice( $ids, $index + 1, null, true );
-			}
-		}
-
-		// Then we slice the array from the back.
-		if ( ! empty( $this->args['before'] ) ) {
-			$offset = $this->get_offset_for_cursor( $this->args['before'] );
-			$index  = $this->get_array_index_for_offset( $offset, $ids );
-
-			if ( false !== $index ) {
-				// Because array indexes start at 0, we can overfetch without adding 1 to $index.
-				$ids = array_slice( $ids, 0, $index, true );
-			}
-		}
-
-		return $ids;
-	}
-
-	/**
-	 * Returns an array of IDs for the connection.
-	 *
-	 * Shim for WPGraphQL < 1.9.0
-	 *
-	 * @return array
-	 */
-	public function get_ids() {
-		if ( ! $this->is_legacy ) {
-			return parent::get_ids();
-		}
-		$ids = $this->get_ids_from_query();
-
-		return $this->apply_cursors_to_ids( $ids );
-	}
-
 
 	/**
 	 * {@inheritDoc}

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,22 +1,22 @@
 <?php return array(
     'root' => array(
-        'pretty_version' => 'dev-develop',
-        'version' => 'dev-develop',
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => '3d8d5f8c434f03ee5a1810682e88bbce30825286',
+        'reference' => NULL,
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'dev' => false,
     ),
     'versions' => array(
         'harness-software/wp-graphql-gravity-forms' => array(
-            'pretty_version' => 'dev-develop',
-            'version' => 'dev-develop',
+            'pretty_version' => '1.0.0+no-version-set',
+            'version' => '1.0.0.0',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => '3d8d5f8c434f03ee5a1810682e88bbce30825286',
+            'reference' => NULL,
             'dev_requirement' => false,
         ),
         'yahnis-elsts/plugin-update-checker' => array(

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -13,7 +13,7 @@
  * Requires at least: 5.4.1
  * Tested up to: 6.0.2
  * Requires PHP: 7.4
- * WPGraphQL requires at least: 1.7.0
+ * WPGraphQL requires at least: 1.9.0
  * GravityForms requires at least: 2.5.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -71,7 +71,7 @@ if ( ! function_exists( 'graphql_gf_dependencies_not_ready' ) ) {
 	 * Checks if all the the required plugins are installed and activated.
 	 */
 	function gf_graphql_dependencies_not_ready() : array {
-		$wpgraphql_version = '1.7.0';
+		$wpgraphql_version = '1.9.0';
 		$gf_version        = '2.5.0';
 
 		$deps = [];

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -23,95 +23,111 @@
  * @license GPL-3
  */
 
-/**
- * Define plugin constants.
- */
-function gf_graphql_constants() : void {
-	// Plugin version.
-	if ( ! defined( 'WPGRAPHQL_GF_VERSION' ) ) {
-		define( 'WPGRAPHQL_GF_VERSION', '0.11.4' );
-	}
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	// Plugin Folder Path.
-	if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_DIR' ) ) {
-		define( 'WPGRAPHQL_GF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-	}
+if ( ! function_exists( 'gf_graphql_constants' ) ) {
+	/**
+	 * Define plugin constants.
+	 */
+	function gf_graphql_constants() : void {
+		// Plugin version.
+		if ( ! defined( 'WPGRAPHQL_GF_VERSION' ) ) {
+			define( 'WPGRAPHQL_GF_VERSION', '0.11.4' );
+		}
 
-	// Plugin Folder URL.
-	if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_URL' ) ) {
-		define( 'WPGRAPHQL_GF_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-	}
+		// Plugin Folder Path.
+		if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_DIR' ) ) {
+			define( 'WPGRAPHQL_GF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+		}
 
-	// Plugin Root File.
-	if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_FILE' ) ) {
-		define( 'WPGRAPHQL_GF_PLUGIN_FILE', __FILE__ );
-	}
+		// Plugin Folder URL.
+		if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_URL' ) ) {
+			define( 'WPGRAPHQL_GF_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+		}
 
-	// Whether to autoload the files or not.
-	if ( ! defined( 'WPGRAPHQL_GF_AUTOLOAD' ) ) {
-		define( 'WPGRAPHQL_GF_AUTOLOAD', true );
-	}
+		// Plugin Root File.
+		if ( ! defined( 'WPGRAPHQL_GF_PLUGIN_FILE' ) ) {
+			define( 'WPGRAPHQL_GF_PLUGIN_FILE', __FILE__ );
+		}
 
-	// Whether to enable untested form fields the files or not.
-	if ( ! defined( 'WPGRAPHQL_GF_EXPERIMENTAL_FIELDS' ) ) {
-		define( 'WPGRAPHQL_GF_EXPERIMENTAL_FIELDS', false );
+		// Whether to autoload the files or not.
+		if ( ! defined( 'WPGRAPHQL_GF_AUTOLOAD' ) ) {
+			define( 'WPGRAPHQL_GF_AUTOLOAD', true );
+		}
+
+		// Whether to enable untested form fields the files or not.
+		if ( ! defined( 'WPGRAPHQL_GF_EXPERIMENTAL_FIELDS' ) ) {
+			define( 'WPGRAPHQL_GF_EXPERIMENTAL_FIELDS', false );
+		}
 	}
 }
 
-/**
- * Checks if all the the required plugins are installed and activated.
- */
-function gf_graphql_dependencies_not_ready() : array {
-	$deps = [];
+if ( ! function_exists( 'graphql_gf_dependencies_not_ready' ) ) {
 
-	if ( ! class_exists( '\WPGraphQL' ) ) {
-		$deps[] = 'WPGraphQL';
+	/**
+	 * Checks if all the the required plugins are installed and activated.
+	 */
+	function gf_graphql_dependencies_not_ready() : array {
+		$wpgraphql_version = '1.7.0';
+		$gf_version        = '2.5.0';
+
+		$deps = [];
+
+		if ( ! class_exists( 'WPGraphQL' ) || ( defined( 'WPGRAPHQL_VERSION' ) && version_compare( WPGRAPHQL_VERSION, $wpgraphql_version, '<' ) ) ) {
+			$deps['WPGraphQL'] = $wpgraphql_version;
+		}
+
+		if ( ! class_exists( 'GFCommon' ) || ( ! empty( GFCommon::$version ) && version_compare( GFCommon::$version, $gf_version, '<' ) ) ) {
+			$deps['Gravity Forms'] = $gf_version;
+		}
+
+		return $deps;
 	}
-
-	if ( ! class_exists( 'GFAPI' ) ) {
-		$deps[] = 'Gravity Forms';
-	}
-
-	return $deps;
 }
 
-/**
- * Initializes WPGraphQL for GF.
- *
- * @return \WPGraphQL\GF\GF|false
- */
-function gf_graphql_init() {
-	gf_graphql_constants();
+if ( ! function_exists( 'gf_graphql_init' ) ) {
+	/**
+	 * Initializes WPGraphQL for GF.
+	 *
+	 * @return \WPGraphQL\GF\GF|false
+	 */
+	function gf_graphql_init() {
+		gf_graphql_constants();
 
-	$not_ready = gf_graphql_dependencies_not_ready();
+		$not_ready = gf_graphql_dependencies_not_ready();
 
-	if ( empty( $not_ready ) && defined( 'WPGRAPHQL_GF_PLUGIN_DIR' ) ) {
-		require_once WPGRAPHQL_GF_PLUGIN_DIR . 'src/GF.php';
-		return \WPGraphQL\GF\GF::instance();
+		if ( empty( $not_ready ) && defined( 'WPGRAPHQL_GF_PLUGIN_DIR' ) ) {
+			require_once WPGRAPHQL_GF_PLUGIN_DIR . 'src/GF.php';
+			return \WPGraphQL\GF\GF::instance();
+		}
+
+		foreach ( $not_ready as $dep => $version ) {
+			add_action(
+				'admin_notices',
+				function() use ( $dep, $version ) {
+					?>
+					<div class="error notice">
+						<p>
+							<?php
+								printf(
+									/* translators: dependency not ready error message */
+									esc_html__( '%1$s (v%2$s) must be active for WPGraphQL for Gravity Forms to work.', 'wp-graphql-gravity-forms' ),
+									esc_attr( $dep ),
+									esc_attr( $version ),
+								);
+							?>
+						</p>
+					</div>
+					<?php
+				}
+			);
+		}
+
+		return false;
 	}
-
-	foreach ( $not_ready as $dep ) {
-		add_action(
-			'admin_notices',
-			function() use ( $dep ) {
-				?>
-				<div class="error notice">
-					<p>
-						<?php
-							printf(
-								/* translators: dependency not ready error message */
-								esc_html__( '%1$s must be active for WPGraphQL for Gravity Forms to work.', 'wp-graphql-gravity-forms' ),
-								esc_html( $dep )
-							);
-						?>
-					</p>
-				</div>
-				<?php
-			}
-		);
-	}
-
-	return false;
 }
 
 add_action( 'graphql_init', 'gf_graphql_init' );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
This PR checks and reports if an unsupported plugin dep _version_ is found. 
It also drops support for WPGraphQL < `v1.9.0`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Part of #310 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
- feat!: Update minimum required WPGraphQL version to v1.9.0.
- feat: Check if plugin dependences meet the minimum version requirements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR ollows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
