### PR TITLE
Fix/quiz field settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - feat: Refactor `GfFormField` field settings, choices, and inputs to use GraphQL interfaces.
 - feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`.
 - fix: ensure latest mutation input data is used to prepare the field values on update mutations.
+- fix!: Change GraphQL field FormQuizConfirmation.isAutoformatted from type String to type Boolean.
+- fix!: Change GraphQL field FormQuizConfirmation.message from type Int to type String.
+- fix: Fix resolver for GfForm.quiz returning empty data.
 - dev!: Move `TypeRegistry` classes to `WPGraphQL\GF\Registry` namespace.
 - dev!: Register each GraphQL type on its own `add_action()` call.
 - dev!: Remove nullable `$type_registry` param from `Registrable::register()` interface method.
@@ -19,6 +22,7 @@
 - dev: Deprecate the `graphql_gf_form_field_setting_properties` filter in favor of `graphql_gf_form_field_setting_fields`.
 - dev: Deprecate the `graphql_gf_form_field_value_properties` filter in favor of `graphql_gf_form_field_value_fields`.
 - chore: Refactor `FormsConnectionResolver` to use new `AbstractConnectionResolver` methods.
+- test: Add basic WPUnit tests for GFForm.quiz fields.
 
 ## v0.11.4
 

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
@@ -139,8 +139,9 @@ class FormQuiz extends AbstractObject implements Field {
 				'type'        => static::$type,
 				'description' => __( 'Quiz-specific settings that will affect ALL Quiz fields in the form. Requires Gravity Forms Quiz addon.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function( $source, array $args, AppContext $context ) : ?array {
+					// FYI: If a user doesn't explicitly save the quiz settings on the backend, this will be null.
 					$context->gfForm = $source;
-					return ! empty( $source->form['quizSettings'] ) ? $source->form['quizSettings'] : null;
+					return ! empty( $source->quiz ) ? $source->quiz : null;
 				},
 			]
 		);

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizConfirmation.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizConfirmation.php
@@ -36,11 +36,11 @@ class FormQuizConfirmation extends AbstractObject {
 	public static function get_fields() : array {
 		return [
 			'isAutoformatted' => [
-				'type'        => 'String',
+				'type'        => 'Boolean',
 				'description' => __( 'Whether autoformatting is enabled for the confirmation message.', 'wp-graphql-gravity-forms' ),
 			],
 			'message'         => [
-				'type'        => 'Int',
+				'type'        => 'String',
 				'description' => __( 'The message to display.', 'wp-graphql-gravity-forms' ),
 			],
 		];

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -1301,6 +1301,42 @@ class Wpunit extends \Codeception\Module {
 				'enableAnimation'            => false,
 				'enableHoneypot'             => false,
 				'firstPageCssClass'          => 'first-page-css-class',
+				'gravityformsquiz'           => [
+					'shuffleFields' => false,
+					'instantFeedback' => true,
+					'grading' => 'passfail',
+					'grades'  => [
+						[
+							'text' => 'A',
+							'value' => 90,
+						],
+						[
+							'text' => 'B',
+							'value' => 80,
+						],
+						[
+							'text' => 'C',
+							'value' => 70,
+						],
+						[
+							'text' => 'D',
+							'value' => 60,
+						],
+						[
+							'text' => 'F',
+							'value' => 0,
+						],
+					],
+					'passPercent' => 50,
+					'passfailDisplayConfirmation' => true,
+					'passConfirmationMessage' => 'You passed!',
+					'failConfirmationMessage' => 'You failed.',
+					'failConfirmationDisableAutoformat' => false,
+					'letterDisplayConfirmation' => true,
+					'letterConfirmationMessage' => 'Your grade is {quiz_grade}.',
+					'letterConfirmationDisableAutoformat' => false,
+					'general' => null
+				],
 				'is_active'                  => true,
 				'is_trash'                   => false,
 				'labelPlacement'             => 'top_label',

--- a/tests/wpunit/FormQueriesTest.php
+++ b/tests/wpunit/FormQueriesTest.php
@@ -8,6 +8,7 @@
 use GraphQLRelay\Relay;
 use Tests\WPGraphQL\GF\TestCase\GFGraphQLTestCase;
 use WPGraphQL\GF\Type\Enum;
+use WPGraphQL\GF\Extensions\GFQuiz\Type\Enum as QuizEnum;
 use Helper\GFHelpers\GFHelpers;
 use WPGraphQL\GF\Data\Loader\FormsLoader;
 
@@ -231,8 +232,7 @@ class FormQueriesTest extends GFGraphQLTestCase {
 						titleTemplate
 						status
 						shouldUseCurrentUserAsAuthor
-					}'
-					/*
+					}
 					quiz {
 						failConfirmation {
 							isAutoformatted
@@ -258,8 +258,6 @@ class FormQueriesTest extends GFGraphQLTestCase {
 						}
 						passPercent
 					}
-					*/
-					. '
 					requiredIndicator
 					saveAndContinue {
 						buttonText
@@ -510,6 +508,46 @@ class FormQueriesTest extends GFGraphQLTestCase {
 						]
 					),
 					// @todo Quiz fields
+					$this->expectedObject(
+						'quiz',
+						[
+							$this->expectedObject(
+								'failConfirmation', [
+									$this->expectedField( 'isAutoformatted', empty( $form['gravityformsquiz']['failConfirmationDisableAutoformat'] ) ),
+									$this->expectedField( 'message', $form['gravityformsquiz']['failConfirmationMessage'] ),
+								]
+							),
+							$this->expectedNode(
+								'grades',
+								[
+									$this->expectedField( 'text', $form['gravityformsquiz']['grades'][0]['text'] ),
+									$this->expectedField( 'value', $form['gravityformsquiz']['grades'][0]['value'] ),
+								],
+								0
+							),
+							$this->expectedField( 'gradingType', GFHelpers::get_enum_for_value( QuizEnum\QuizFieldGradingTypeEnum::$type, $form['gravityformsquiz']['grading'] ) ),
+							$this->expectedField( 'hasInstantFeedback', ! empty( $form['gravityformsquiz']['instantFeedback'] ) ),
+							$this->expectedField( 'hasLetterConfirmationMessage', ! empty( $form['gravityformsquiz']['letterDisplayConfirmation'] ) ),
+							$this->expectedField( 'hasPassFailConfirmationMessage', ! empty( $form['gravityformsquiz']['passfailDisplayConfirmation'] ) ),
+							$this->expectedField( 'isShuffleFieldsEnabled', ! empty( $form['gravityformsquiz']['shuffleFields'] ) ),
+							$this->expectedObject(
+								'letterConfirmation',
+								[
+									$this->expectedField( 'isAutoformatted', empty( $form['gravityformsquiz']['letterConfirmationDisableAutoformat'] ) ),
+									$this->expectedField( 'message', $form['gravityformsquiz']['letterConfirmationMessage'] ),
+								]
+							),
+							$this->expectedField( 'maxScore', static::IS_NULL ),
+							$this->expectedObject(
+								'passConfirmation',
+								[
+									$this->expectedField( 'isAutoformatted', empty( $form['gravityformsquiz']['passConfirmationDisableAutoformat'] ) ),
+									$this->expectedField( 'message', $form['gravityformsquiz']['passConfirmationMessage'] ),
+								]
+							),
+							$this->expectedField( 'passPercent', $form['gravityformsquiz']['passPercent'] ),
+						]
+					),
 					$this->expectedField( 'requiredIndicator', GFHelpers::get_enum_for_value( Enum\FormFieldRequiredIndicatorEnum::$type, $form['requiredIndicator'] ) ),
 					$this->expectedObject(
 						'saveAndContinue',


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Fixes issues with the resolved data from `GfForm.quiz`, and the GraphQL Types for `FormQuizConfirmation` fields.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
FormQuizConfirmation is unusable with the current type defs, so even if its technically a breaking change, this is being treated as a regression with little impact.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
- fix!: Change GraphQL field `FormQuizConfirmation.isAutoformatted` from type `String` to type `Boolean`.
- fix!: Change GraphQL field `FormQuizConfirmation.message` from type `Int` to type `String`.
- fix: Fix resolver for `GfForm.quiz` returning empty data.
- test: Add basic WPUnit tests for `GFForm.quiz` fields.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR ollows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
