### PR TITLE
fix: Check for falsey `personalData` when resolving the form model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat: Refactor `GfFormField` field settings, choices, and inputs to use GraphQL interfaces.
 - feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`.
 - fix: Ensure latest mutation input data is used to prepare the field values on update mutations.
+- fix: Check for falsy `personalData` when resolving the form model.
 - dev!: Move `TypeRegistry` classes to `WPGraphQL\GF\Registry` namespace.
 - dev!: Register each GraphQL type on its own `add_action()` call.
 - dev!: Remove nullable `$type_registry` param from `Registrable::register()` interface method.

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -125,7 +125,6 @@ class Form extends Model {
 					return $pagination;
 				},
 				'personalData'                 => function() : ?array {
-
 					if ( empty( $this->data['personalData'] ) || ! is_array( $this->data['personalData'] ) ) {
 						return null;
 					}

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -125,11 +125,12 @@ class Form extends Model {
 					return $pagination;
 				},
 				'personalData'                 => function() : ?array {
-					$personal_data = $this->data['personalData'] ?? null;
 
-					if ( ! is_array( $personal_data ) ) {
-						return $personal_data;
+					if ( empty( $this->data['personalData'] ) || ! is_array( $this->data['personalData'] ) ) {
+						return null;
 					}
+
+					$personal_data = $this->data['personalData'];
 
 					if ( isset( $personal_data['preventIP'] ) ) {
 						$personal_data['shouldSaveIP'] = empty( $personal_data['preventIP'] );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Ensures `personalData` is a non-empty array before attempting to resolve it on the `Form` model.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
The GF form `getter` ensures the value will be set, so `?? null`, doesn't have its intended effect.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
