### PR TITLE
docs: use full syntax for listValues example

### DIFF
--- a/docs/submitting-forms.md
+++ b/docs/submitting-forms.md
@@ -90,7 +90,10 @@ The `fieldValues` input takes an array of objects containing the `id` of the fie
         {
           # Multi-column List field value
           id: 6
-          listValues: { rowValues: ["a", "b", "c"] }
+          listValues: [
+            { rowValues: ["a", "b", "c"] }
+            { rowValues: ["d", "e", "f"] }
+          ]
         }
         {
           # Name field value


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Changes the `listValues` input example to use a long-form array syntax, instead of the existing shorthand value.

h/t @tomdofuture

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Our documentation is to show how best to use our schema, not now to write GraphQL queries, and list fields, more often than not are going to take multiple `rowValues` anyway.

Closes #326 


## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
See the changeset.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
