### PR TITLE
dev!: change `AddressField.defaultState` and `defaultProvince` to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`.
 - fix: Ensure latest mutation input data is used to prepare the field values on update mutations.
 - fix: Check for falsy `personalData` when resolving the form model.
+- dev!: change `AddressField.defaultState` and `AddressField.defaultProvince` to respective `AddressField{Province|State}Enum`.
 - dev!: Move `TypeRegistry` classes to `WPGraphQL\GF\Registry` namespace.
 - dev!: Register each GraphQL type on its own `add_action()` call.
 - dev!: Remove nullable `$type_registry` param from `Registrable::register()` interface method.

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -106,6 +106,8 @@ class TypeRegistry {
 		// Enums to register.
 		$classes_to_register = [
 			Enum\AddressFieldCountryEnum::class,
+			Enum\AddressFieldProvinceEnum::class,
+			Enum\AddressFieldStateEnum::class,
 			Enum\AddressFieldTypeEnum::class,
 			Enum\AmPmEnum::class,
 			Enum\CaptchaFieldBadgePositionEnum::class,

--- a/src/Type/Enum/AddressFieldProvinceEnum.php
+++ b/src/Type/Enum/AddressFieldProvinceEnum.php
@@ -3,7 +3,7 @@
  * Enum Type - AddressFieldProvinceEnum
  *
  * @package WPGraphQL\GF\Type\Enum,
- * @since 0.10.0
+ * @since @todo
  */
 
 namespace WPGraphQL\GF\Type\Enum;

--- a/src/Type/Enum/AddressFieldProvinceEnum.php
+++ b/src/Type/Enum/AddressFieldProvinceEnum.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Enum Type - AddressFieldProvinceEnum
+ *
+ * @package WPGraphQL\GF\Type\Enum,
+ * @since 0.10.0
+ */
+
+namespace WPGraphQL\GF\Type\Enum;
+
+use GF_Field_Address;
+use GF_Fields;
+use WPGraphQL\Type\WPEnumType;
+
+/**
+ * Class - AddressFieldProvinceEnum
+ */
+class AddressFieldProvinceEnum extends AbstractEnum {
+	/**
+	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
+	 */
+	public static string $type = 'AddressFieldProvinceEnum';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_description() : string {
+		return __( 'Canadian Provinces supported by Gravity Forms Address Field.', 'wp-graphql-gravity-forms' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_values() : array {
+		/**
+		 * A gravity forms address field.
+		 *
+		 * @var GF_Field_Address $field
+		 */
+		$field     = GF_Fields::get( 'address' );
+		$provinces = $field->get_canadian_provinces();
+
+		$values = [];
+
+		foreach ( $provinces as $province ) {
+			$values[ WPEnumType::get_safe_name( $province ) ] = [
+				'value'       => $province,
+				// translators: Province.
+				'description' => sprintf( __( '%s .', 'wp-graphql-gravity-forms' ), $province ),
+			];
+		}
+
+		return $values;
+	}
+}

--- a/src/Type/Enum/AddressFieldStateEnum.php
+++ b/src/Type/Enum/AddressFieldStateEnum.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Enum Type - AddressFieldStateEnum
+ *
+ * @package WPGraphQL\GF\Type\Enum,
+ * @since 0.10.0
+ */
+
+namespace WPGraphQL\GF\Type\Enum;
+
+use GF_Field_Address;
+use GF_Fields;
+use WPGraphQL\Type\WPEnumType;
+
+/**
+ * Class - AddressFieldStateEnum
+ */
+class AddressFieldStateEnum extends AbstractEnum {
+	/**
+	 * Type registered in WPGraphQL.
+	 *
+	 * @var string
+	 */
+	public static string $type = 'AddressFieldStateEnum';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_description() : string {
+		return __( 'US States supported by Gravity Forms Address Field.', 'wp-graphql-gravity-forms' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_values() : array {
+		/**
+		 * A gravity forms address field.
+		 *
+		 * @var GF_Field_Address $field
+		 */
+		$field  = GF_Fields::get( 'address' );
+		$states = $field->get_us_states();
+
+		$values = [];
+
+		foreach ( $states as $state ) {
+			$values[ WPEnumType::get_safe_name( $state ) ] = [
+				'value'       => $state,
+				// translators: State.
+				'description' => sprintf( __( '%s .', 'wp-graphql-gravity-forms' ), $state ),
+			];
+		}
+
+		return $values;
+	}
+}

--- a/src/Type/Enum/AddressFieldStateEnum.php
+++ b/src/Type/Enum/AddressFieldStateEnum.php
@@ -3,7 +3,7 @@
  * Enum Type - AddressFieldStateEnum
  *
  * @package WPGraphQL\GF\Type\Enum,
- * @since 0.10.0
+ * @since @todo
  */
 
 namespace WPGraphQL\GF\Type\Enum;

--- a/src/Type/WPInterface/FieldSetting/FieldWithAddress.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAddress.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 use GF_Field;
 use WPGraphQL\GF\Registry\FieldInputRegistry;
 use WPGraphQL\GF\Type\Enum\AddressFieldCountryEnum;
+use WPGraphQL\GF\Type\Enum\AddressFieldProvinceEnum;
 use WPGraphQL\GF\Type\Enum\AddressFieldTypeEnum;
 
 /**
@@ -54,11 +55,11 @@ class FieldWithAddress extends AbstractFieldSetting {
 				'description' => __( 'Contains the country that will be selected by default. Only applicable when "addressType" is set to "INTERATIONAL".', 'wp-graphql-gravity-forms' ),
 			],
 			'defaultProvince' => [
-				'type'        => 'String',
+				'type'        => AddressFieldProvinceEnum::$type,
 				'description' => __( 'Contains the province that will be selected by default. Only applicable when "addressType" is set to "CANADA".', 'wp-graphql-gravity-forms' ),
 			],
 			'defaultState'    => [
-				'type'        => 'String',
+				'type'        => AddressFieldProvinceEnum::$type,
 				'description' => __( 'Contains the state that will be selected by default. Only applicable when "addressType" is set to "US".', 'wp-graphql-gravity-forms' ),
 			],
 		];

--- a/tests/_support/Helper/GFHelpers/ExpectedFormFields.php
+++ b/tests/_support/Helper/GFHelpers/ExpectedFormFields.php
@@ -24,8 +24,8 @@ trait ExpectedFormFields {
 		$properties[] = $this->expectedField( 'addressType', ! empty( $field->addressType ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldTypeEnum::$type, $field->addressType ) : static::IS_NULL );
 
 		$properties[] = $this->expectedField( 'defaultCountry', ! empty( $field->defaultCountry ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldCountryEnum::$type, $field->defaultCountry ) : static::IS_NULL );
-		$properties[] = $this->expectedField( 'defaultProvince', ! empty( $field->defaultProvince ) ? $field->defaultProvince : static::IS_NULL );
-		$properties[] = $this->expectedField( 'defaultState', ! empty( $field->defaultState ) ? $field->defaultState : static::IS_NULL );
+		$properties[] = $this->expectedField( 'defaultProvince', ! empty( $field->defaultProvince ) ? GFHelpers::get_enum_for_value( Enum\AddressFieldProvinceEnum::$type, $field->defaultProvince ) : static::IS_NULL );
+		$properties[] = $this->expectedField( 'defaultState', ! empty( $field->defaultState ) ? GFHelpers::get_enum_for_value( Enum\AddressFielStateeEnum::$type, $field->defaultState ) : static::IS_NULL );
 
 		$input_keys = [
 			'autocompleteAttribute' => 'autocompleteAttribute',

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -103,6 +103,8 @@ return array(
     'WPGraphQL\\GF\\Type\\AbstractType' => $baseDir . '/src/Type/AbstractType.php',
     'WPGraphQL\\GF\\Type\\Enum\\AbstractEnum' => $baseDir . '/src/Type/Enum/AbstractEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\AddressFieldCountryEnum' => $baseDir . '/src/Type/Enum/AddressFieldCountryEnum.php',
+    'WPGraphQL\\GF\\Type\\Enum\\AddressFieldProvinceEnum' => $baseDir . '/src/Type/Enum/AddressFieldProvinceEnum.php',
+    'WPGraphQL\\GF\\Type\\Enum\\AddressFieldStateEnum' => $baseDir . '/src/Type/Enum/AddressFieldStateEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\AddressFieldTypeEnum' => $baseDir . '/src/Type/Enum/AddressFieldTypeEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\AmPmEnum' => $baseDir . '/src/Type/Enum/AmPmEnum.php',
     'WPGraphQL\\GF\\Type\\Enum\\CaptchaFieldBadgePositionEnum' => $baseDir . '/src/Type/Enum/CaptchaFieldBadgePositionEnum.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -122,6 +122,8 @@ class ComposerStaticInitf35655797d6bdd77951f2274b8dc4a3f
         'WPGraphQL\\GF\\Type\\AbstractType' => __DIR__ . '/../..' . '/src/Type/AbstractType.php',
         'WPGraphQL\\GF\\Type\\Enum\\AbstractEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AbstractEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\AddressFieldCountryEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AddressFieldCountryEnum.php',
+        'WPGraphQL\\GF\\Type\\Enum\\AddressFieldProvinceEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AddressFieldProvinceEnum.php',
+        'WPGraphQL\\GF\\Type\\Enum\\AddressFieldStateEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AddressFieldStateEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\AddressFieldTypeEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AddressFieldTypeEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\AmPmEnum' => __DIR__ . '/../..' . '/src/Type/Enum/AmPmEnum.php',
         'WPGraphQL\\GF\\Type\\Enum\\CaptchaFieldBadgePositionEnum' => __DIR__ . '/../..' . '/src/Type/Enum/CaptchaFieldBadgePositionEnum.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => '578a967cd46dc783e3f9375202ee7b43f67cccf7',
+        'reference' => 'ff6cc6a1a2c67ec2b622c2da3a7077f6198f2e67',
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'dev' => false,
     ),
@@ -16,7 +16,7 @@
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => '578a967cd46dc783e3f9375202ee7b43f67cccf7',
+            'reference' => 'ff6cc6a1a2c67ec2b622c2da3a7077f6198f2e67',
             'dev_requirement' => false,
         ),
         'yahnis-elsts/plugin-update-checker' => array(


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Adds the `AddressFieldProvinceEnum` and `AddressFieldStateEnum` to the schema, and changes `AddressField.defaultProvince` and `AddressField.defaultState` to use those enums

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #320

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
- dev!: change `AddressField.defaultState` and `AddressField.defaultProvince` to respective `AddressField{Province|State}Enum`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
These enums use the full `UPPERCASE_NAME`, so if you want to reuse them in a frontend dropdown, you can just map the generate enum types to `Title Case Name`.

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
