### PR TITLE
chore: revert PHP 8.1 Compatibility

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           tools: composer:v2, wp-cli
           coverage: none

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -26,13 +26,9 @@ jobs:
         php: ['8.0', '7.4']
         wordpress: ['6.1', '6.0', '5.9', '5.8', '5.7' ]
         include:
-          - php: '8.1'
+          - php: '8.0'
             wordpress: '6.1'
             coverage: 1
-          - php: '8.1'
-            wordpress: '6.0'
-          - php: '8.1'
-            wordpress: '5.9'
       fail-fast: false
 
     steps:

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
           tools: composer:v2, wp-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 - chore: Add `automattic/vipcs` Code Standard ruleset.
 - ci: Update GitHub Action versions used in workflows to latest.
 - ci: Update Node version to 16+.
-- ci: Test against PHP 8.1.
 
 ## v0.11.10 - Gravity Forms v2.6.8+ Compatibility
 

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
 	echo "  composer build-app"
 	echo "  composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer build-app"
-	echo "  WP_VERSION=6.1 PHP_VERSION=8.1 composer run-app"
+	echo "  WP_VERSION=6.1 PHP_VERSION=8.0 composer build-app"
+	echo "  WP_VERSION=6.1 PHP_VERSION=8.0 composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.1 PHP_VERSION=8.1 bin/run-docker.sh build -a"
-	echo "  WP_VERSION=6.1 PHP_VERSION=8.1 bin/run-docker.sh run -a"
+	echo "  WP_VERSION=6.1 PHP_VERSION=8.0 bin/run-docker.sh build -a"
+	echo "  WP_VERSION=6.1 PHP_VERSION=8.0 bin/run-docker.sh run -a"
 	exit 1
 }
 
@@ -30,7 +30,7 @@ fi
 
 TAG=${TAG-latest}
 WP_VERSION=${WP_VERSION-6.1}
-PHP_VERSION=${PHP_VERSION-8.1}
+PHP_VERSION=${PHP_VERSION-8.0}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Reverts PHP 8.1 compatibility.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #339
Reopens #299 

GF is [not yet compatible with PHP 8.1](https://docs.gravityforms.com/gravity-forms-and-php-8-1-compatibility/) causing #339 to fail.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Reverts 8.1 bumps to 8.0

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
