### PR TITLE
docs: replace formId with id in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - dev: Add the following filters: `graphql_gf_form_field_setting_choice_fields`, `graphql_gf_form_field_setting_input_fields`, `graphql_gf_registered_form_field_setting_classes`, `graphql_gf_registered_form_field_setting_choice_classes`, `graphql_gf_registered_form_field_setting_input_classes`.
 - dev: Deprecate the `graphql_gf_form_field_setting_properties` filter in favor of `graphql_gf_form_field_setting_fields`.
 - dev: Deprecate the `graphql_gf_form_field_value_properties` filter in favor of `graphql_gf_form_field_value_fields`.
+- docs: replace `formId` with `id` in `submitGfForm` examples. Props: @mosesintech
 - chore: Refactor `FormsConnectionResolver` to use new `AbstractConnectionResolver` methods.
 - chore: Add `automattic/vipcs` Code Standard ruleset.
 - ci: Update GitHub Action versions used in workflows to latest.

--- a/docs/submitting-forms.md
+++ b/docs/submitting-forms.md
@@ -35,7 +35,7 @@ The `fieldValues` input takes an array of objects containing the `id` of the fie
 {
   submitGfForm(
     input: {
-      formId: 50
+      id: 50
       entryMeta {
         createdById: 1 # The user ID.
         ip: ""         # IP address
@@ -163,7 +163,7 @@ To validate a reCAPTCHA field, you need to [fetch the captcha response token](ht
 mutation submit( $token: String ) {
   submitGfForm(
     input: {
-      formId: 50
+      id: 50
       fieldValues: [
         # other form fields would go here.
         {
@@ -199,7 +199,7 @@ To enable WPGraphQL support for submitting files (via the `fileUploadValues` or 
 mutation submit( $exampleUploads: [ Upload ], $exampleImageUpload: Upload ){ 
   submitGfForm(
     input: {
-      formId: 50
+      id: 50
       fieldValues: [
         # other form fields would go here.
         {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR replaces `formId` with `id` in the example submission mutations.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Attempting to submit a mutation using `formId` gives this error:
`There was an error submitting the form: [GraphQL] Field SubmitGfFormInput.id of required type ID! was not provided. [GraphQL] Field "formId" is not defined by type SubmitGfFormInput.`

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
No implementation, just updating the docs to reflect the correct mutation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [ ] This PR is tested to the best of my abilities.
- [ ] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [ ] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] This PR has unit tests to verify the code works as intended.
- [ ] The changes in this PR have been noted in CHANGELOG.md 
