### PR TITLE
fix: Properly store provided IP when submitting an entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat: Deprecate `FormsConnectionOrderbyInput.field` in favor of `FormsConnectionOrderbyInput.column`.
 - fix: Ensure latest mutation input data is used to prepare the field values on update mutations.
 - fix: Check for falsy `personalData` when resolving the form model.
+- fix: Properly store provided IP when submitting an entry.
 - dev!: Audit and fix generated type names.
 - dev!: change `AddressField.defaultState` and `AddressField.defaultProvince` to respective `AddressField{Province|State}Enum`.
 - dev!: Move `TypeRegistry` classes to `WPGraphQL\GF\Registry` namespace.

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -191,7 +191,7 @@ class SubmitForm extends AbstractMutation {
 		}
 		// Update IP created.
 		if ( isset( $input['entryMeta']['ip'] ) ) {
-			$data['ip'] = GFUtils::get_ip( $input['entryMeta']['sourceUrl'] );
+			$data['ip'] = GFUtils::get_ip( $input['entryMeta']['ip'] );
 		}
 
 		// Update source url.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Fixes so IP is saved properly and no longer overwritten by the source URL.

## Why
Fixes #344

## How
This was likely caused by a typo; `$input['entryMeta']['sourceUrl']` was being used instead of `$input['entryMeta']['ip']` when saving the IP for an entry.

## Testing Instructions
See #344. IP should now be stored properly.

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
