### PR TITLE
fix: properly store IP when submitting an entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Properly store provided IP when submitting an entry. Thanks @marcusforsberg !
+
 ## v0.11.10 - Gravity Forms v2.6.8+ Compatibility
 
 This _minor_ release adds compatibility for Gravity Forms v2.6.8+ by refactoring the internal logic used for uploading files to use native Gravity Forms methods whenever possible.

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -191,7 +191,7 @@ class SubmitForm extends AbstractMutation {
 		}
 		// Update IP created.
 		if ( isset( $input['entryMeta']['ip'] ) ) {
-			$data['ip'] = GFUtils::get_ip( $input['entryMeta']['sourceUrl'] );
+			$data['ip'] = GFUtils::get_ip( $input['entryMeta']['ip'] );
 		}
 
 		// Update source url.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Reimplements #345 on `v0.11.x`
Fixes so IP is saved properly and no longer overwritten by the source URL.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #344 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
I couldn't rebase #345 onto `main` for some reason, even though `SubmitMutation.php` had no merge conflicts. The code here is identical and full props go to @marcusforsberg
 
## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
