### PR TITLE
feat: deprecate `FormField.id` in favor of `databaseId`

### DIFF
--- a/docs/form-field-support.md
+++ b/docs/form-field-support.md
@@ -118,7 +118,7 @@ For an example of the PostCategory field:
  gfEntries{
   formFields {
     nodes {
-      id
+      databaseId
       ... on PostCategoryField { # the Interface
         hasAllCategories
         inputType

--- a/docs/querying-entries.md
+++ b/docs/querying-entries.md
@@ -24,7 +24,7 @@ The `id` input accepts either the Gravity Forms Entry ID ( `idType: DATABASE_ID`
     isDraft
     formFields(first: 300) {
       nodes {
-        id
+        databaseId
         type
         ... on TextField {
           label
@@ -47,7 +47,7 @@ The `id` input accepts either the Gravity Forms Entry ID ( `idType: DATABASE_ID`
     isStarred
     formFields(first: 300) {
       nodes {
-        id
+        databaseId
         type
         ... on TextField {
           label
@@ -74,7 +74,7 @@ Entries that include [Pricing Fields](https://docs.gravityforms.com/category/use
       items {
         connectedFormField {
           ... on ProductSingleField {
-            id
+            databaseId
           }
         }
         currency
@@ -90,7 +90,7 @@ Entries that include [Pricing Fields](https://docs.gravityforms.com/category/use
         options {
           connectedFormField{
             ... on OptionCheckboxField {
-              id
+              databaseId
             }
           }
           fieldLabel

--- a/docs/querying-formfields.md
+++ b/docs/querying-formfields.md
@@ -20,7 +20,7 @@ This method is best if you have a small form with a limited number of field type
     databaseId
     formFields(first: 300) {
       nodes {
-        id
+        databaseId
         type
         cssClass
         ... on TextField {
@@ -65,7 +65,7 @@ Luckily, we can use [GraphQL Interfaces](https://graphql.org/learn/schema/#inter
     databaseId
     formFields(where: {pageNumber: 1}) {
       nodes {
-        id
+        databaseId
         inputType
         type
         ... on GfFieldWithLabelSetting {
@@ -185,10 +185,11 @@ The code comments in the example query below explain how you can get a filtered 
         # Filter form fields by the page number in multi-page forms.
         pageNumber: 2
       }
-      ) {
+    ) {
       nodes {
-        id
+        databaseId
         type
+      }
     }
   }
 }

--- a/docs/querying-forms.md
+++ b/docs/querying-forms.md
@@ -16,7 +16,7 @@ The `id` input accepts either the Gravity Forms form ID (`idType: DATABASE_ID`) 
     dateCreated
     formFields {
       nodes {
-        id
+        databaseId
         type
         ... on TextField {
           label
@@ -71,7 +71,7 @@ The code comments in the example query below shows how you can fetch and filter 
         formFields(first: 300) {
           nodes {
             type
-            id
+            databaseId
             cssClass
             ... on TextField {
               label

--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -60,8 +60,14 @@ class FormField extends AbstractInterface {
 				'resolve'     => static fn ( $source ) : bool => ! empty( $source->displayOnly ),
 			],
 			'id'                         => [
+				'type'              => [ 'non_null' => 'Int' ],
+				'description'       => __( 'Field database ID.', 'wp-graphql-gravity-forms' ),
+				'deprecationReason' => __( 'This field will be changing to return a Global ID in a future release. Future-proof your code and use databaseId instead.', 'wp-graphql-gravity-forms' ),
+			],
+			'databaseId'                 => [
 				'type'        => [ 'non_null' => 'Int' ],
-				'description' => __( 'Field ID.', 'wp-graphql-gravity-forms' ),
+				'description' => __( 'Field database ID.', 'wp-graphql-gravity-forms' ),
+				'resolve'     => static fn ( $source ) : int => absint( $source->id ),
 			],
 			'inputType'                  => [
 				'type'        => FormFieldTypeEnum::$type,

--- a/tests/_support/TestCase/FormFieldTestCase.php
+++ b/tests/_support/TestCase/FormFieldTestCase.php
@@ -250,7 +250,7 @@ class FormFieldTestCase extends GFGraphQLTestCase {
 					formFields {
 						nodes {
 							displayOnly
-							id
+							databaseId
 							inputType
 							layoutGridColumnSpan
 							layoutSpacerGridColumnSpan

--- a/tests/wpunit/CaptchaFieldTest.php
+++ b/tests/wpunit/CaptchaFieldTest.php
@@ -135,7 +135,6 @@ class CaptchaFieldTest extends FormFieldTestCase implements FormFieldTestCaseInt
 		return '
 			... on CaptchaField {
 				displayOnly
-				id
 				inputType
 				layoutGridColumnSpan
 				layoutSpacerGridColumnSpan

--- a/tests/wpunit/EntryQueriesTest.php
+++ b/tests/wpunit/EntryQueriesTest.php
@@ -88,6 +88,7 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 					formFields {
 						nodes {
 							id
+							databaseId
 						}
 					}
 					id
@@ -285,6 +286,7 @@ class EntryQueriesTest extends GFGraphQLTestCase {
 								'nodes',
 								[
 									$this->expectedField( 'id', (int) $form['fields'][0]['id'] ),
+									$this->expectedField( 'databaseId', (int) $form['fields'][0]['id'] ),
 								]
 							),
 						]

--- a/tests/wpunit/ProductCalculationFieldTest.php
+++ b/tests/wpunit/ProductCalculationFieldTest.php
@@ -157,7 +157,6 @@ class ProductCalculationFieldTest extends FormFieldTestCase implements FormField
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/ProductHiddenFieldTest.php
+++ b/tests/wpunit/ProductHiddenFieldTest.php
@@ -144,7 +144,6 @@ class ProductHiddenFieldTest extends FormFieldTestCase implements FormFieldTestC
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/ProductPriceFieldTest.php
+++ b/tests/wpunit/ProductPriceFieldTest.php
@@ -122,7 +122,6 @@ class ProductPriceFieldTest extends FormFieldTestCase implements FormFieldTestCa
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/ProductRadioFieldTest.php
+++ b/tests/wpunit/ProductRadioFieldTest.php
@@ -146,7 +146,6 @@ class ProductRadioFieldTest extends FormFieldTestCase implements FormFieldTestCa
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/ProductSelectFieldTest.php
+++ b/tests/wpunit/ProductSelectFieldTest.php
@@ -148,7 +148,6 @@ class ProductSelectFieldTest extends FormFieldTestCase implements FormFieldTestC
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/ProductSingleFieldTest.php
+++ b/tests/wpunit/ProductSingleFieldTest.php
@@ -145,7 +145,6 @@ class ProductSingleFieldTest extends FormFieldTestCase implements FormFieldTestC
 				description
 				descriptionPlacement
 				displayOnly
-				id
 				inputName
 				inputType
 				label

--- a/tests/wpunit/SubmitFormMutationTest.php
+++ b/tests/wpunit/SubmitFormMutationTest.php
@@ -670,7 +670,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertEquals( 'USD', $actual['data']['submitGfForm']['entry']['orderSummary']['currency'] );
 
 		// Test first Order Item.
-		$this->assertEquals( $fields[0]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['connectedFormField']['id'] );
+		$this->assertEquals( $fields[0]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['connectedFormField']['databaseId'] );
 		$this->assertEquals( 'USD', $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['currency'] );
 		$this->assertStringContainsString( $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['price'], $fields[0]->basePrice );
 		$this->assertEquals( 2, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['quantity'] );
@@ -678,13 +678,13 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertEquals( $expected_subtotal_one, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][0]['subtotal'] );
 
 		// Test second Order Item.
-		$this->assertEquals( $fields[1]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['connectedFormField']['id'] );
+		$this->assertEquals( $fields[1]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['connectedFormField']['databaseId'] );
 		$this->assertEquals( 'USD', $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['currency'] );
 		$this->assertStringContainsString( $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['price'], $fields[1]->basePrice );
 		$this->assertEquals( 2, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['quantity'] );
 		// Test options.
 		$this->assertNotEmpty( $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'] );
-		$this->assertEquals( $fields[3]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'][0]['connectedFormField']['id'] );
+		$this->assertEquals( $fields[3]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'][0]['connectedFormField']['databaseId'] );
 		$this->assertEquals( $fields[3]->label, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'][0]['fieldLabel'] );
 		$this->assertEquals( $fields[3]->choices[0]['value'], $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'][0]['name'] );
 		$this->assertEquals( $fields[3]->label . ': ' . $fields[3]->choices[0]['value'], $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['options'][0]['optionLabel'] );
@@ -699,7 +699,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 		$this->assertEquals( $expected_subtotal_two, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][1]['subtotal'] );
 
 		// Test shipping field.
-		$this->assertEquals( $fields[4]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][2]['connectedFormField']['id'] );
+		$this->assertEquals( $fields[4]->id, $actual['data']['submitGfForm']['entry']['orderSummary']['items'][2]['connectedFormField']['databaseId'] );
 		$this->assertEquals( 'USD', $actual['data']['submitGfForm']['entry']['orderSummary']['items'][2]['currency'] );
 		$this->assertStringContainsString( $actual['data']['submitGfForm']['entry']['orderSummary']['items'][2]['price'], $fields[4]->basePrice );
 		$this->assertTrue( $actual['data']['submitGfForm']['entry']['orderSummary']['items'][2]['isShipping'] );
@@ -793,8 +793,8 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 						orderSummary{
 							currency
 							items{
-								connectedFormField{
-									id
+								connectedFormField {
+									databaseId
 								}
 								currency
 								description
@@ -808,7 +808,7 @@ class SubmitFormMutationTest extends GFGraphQLTestCase {
 								name
 								options{
 									connectedFormField {
-										id
+										databaseId
 									}
 									fieldLabel
 									name


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Deprecates the `FormField.id` GraphQL field in favor of `FormField.databaseId`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

In a future release, we need to change the `id` to be a Relay `ID`, so we can implement #298 and make the connection fully Relay compliant (see #335)

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [ ] The changes in this PR have been noted in CHANGELOG.md 
