### PR TITLE
fix: use local store for `FieldInputRegistry` and `FieldChoiceRegistry` to prevent duplicate/nonexistent type registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- fix: use local store for `FieldInputRegistry` and `FieldChoiceRegistry` to prevent the registration of duplicate/nonexistent types.
 - chore: update Composer dev deps.
+- test: Ensure no `extensions['debug']` messages are returned when querying FormFields.
 
 ## v0.12.0 - Form Field Interfaces and Pricing Fields
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR stores the types registered by `FieldInputRegistry` and `FieldChoiceRegistry` in a local cache variable, to 
to prevent the registration of duplicate/nonexistent `FormFieldChoice` and `FormFieldInputProperty` types.

Additionally a test has been added to ensure GraphQL debug messages are caught before release.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Previously there was a bug where child types (e.g. `OptionCheckboxField` would try to register their input property types with a nonexistent parent interface. By checking a local store we both save the extra check to the TypeRegistry and ensure that only actual types are used for parent interfaces.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
The classes now have a `$registered_types` static variable which is used for storage and checking.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
The test assert is not applied to mutations (yet), since we intentionally output a debug message for Upload support.
## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
