### PR TITLE
ci: ignore `graphql-schema-linter` error about missing `FormFieldConnection.pageInfo` description

### DIFF
--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Lint the Static Schema
         run: |
-          graphql-schema-linter --except=relay-connection-types-spec,relay-page-info-spec --ignore '{"defined-types-are-used":["MenuItemsWhereArgs","PostObjectUnion","TermObjectUnion","TimezoneEnum"], "fields-have-descriptions":["WPGatsbyCompatibility","WPGatsbyPageNode","WPGatsbyPreviewStatus"], "enum-values-have-descriptions":["WPGatsbyRemotePreviewStatusEnum","WPGatsbyWPPreviewedNodeStatus"]}' /tmp/schema.graphql
+          graphql-schema-linter --except=relay-connection-types-spec,relay-page-info-spec --ignore '{"fields-have-descriptions":["WPGatsbyCompatibility","WPGatsbyPageNode","WPGatsbyPreviewStatus", "FormFieldConnection.pageInfo"], "enum-values-have-descriptions":["WPGatsbyRemotePreviewStatusEnum","WPGatsbyWPPreviewedNodeStatus"]}' /tmp/schema.graphql
 
       - name: Display ignored linting errors
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- fix: use local store for `FieldInputRegistry` and `FieldChoiceRegistry` to prevent the registration of duplicate/nonexistent types.
-- chore: update Composer dev deps.
+- fix: Use local store for `FieldInputRegistry` and `FieldChoiceRegistry` to prevent the registration of duplicate/nonexistent types.
+- chore: Update Composer dev deps.
 - test: Ensure no `extensions['debug']` messages are returned when querying FormFields.
+- ci: Ignore `graphql-schema-linter` error for `FormFieldConnection.pageInfo` missing a description. This will be reverted once FormFieldConnection is refactored to be a Relay-compatible.
 
 ## v0.12.0 - Form Field Interfaces and Pricing Fields
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Suppresses the following [error](https://github.com/harness-software/wp-graphql-gravity-forms/actions/runs/4866297468/jobs/8677669607?pr=356):
`The field `FormFieldConnection.pageInfo` is missing a description. fields-have-descriptions`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
The error is is because we're no longer using WPGraphQL's new connection interfaces until we can make `FormField.id` compliant with the spec. Once that changes, we can remove this `ignore` rule.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
