### PR TITLE
dev: refactor indeterminate ID resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- dev: Refactor database ID resolution when the GraphQL `ID` type is indeterminate. Note: The following input args now work with both database and global IDs: `GfEntriesConnectionWhereArgs.formIds`, `GfFormsConnectionwhereArgs.formIds`.
 - docs: Add missing documentation regarding using `productValues` input when submitting forms.
 
 ## v0.12.1 - Bug fix

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -20,6 +20,7 @@ use WPGraphQL\GF\Data\Loader\EntriesLoader;
 use WPGraphQL\GF\Type\Enum\EntryStatusEnum;
 use WPGraphQL\GF\Type\Enum\FieldFiltersModeEnum;
 use WPGraphQL\GF\Type\Enum\FieldFiltersOperatorInputEnum;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - EntriesConnectionResolver
@@ -241,12 +242,11 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 			return 0;
 		}
 
-		// @todo allow for both Global and DB Ids.
-		if ( is_array( $this->args['where']['formIds'] ) ) {
-			return array_map( 'absint', $this->args['where']['formIds'] );
+		if ( is_string( $this->args['where']['formIds'] ) ) {
+			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 
-		return absint( $this->args['where']['formIds'] );
+		return array_map( fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
 
 	/**

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -242,7 +242,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 			return 0;
 		}
 
-		if ( is_string( $this->args['where']['formIds'] ) ) {
+		if ( is_string( $this->args['where']['formIds'] ) || is_integer( $this->args['where']['formIds'] ) ) {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -150,7 +150,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			return [];
 		}
 
-		if ( is_string( $this->args['where']['formIds'] ) ) {
+		if ( is_string( $this->args['where']['formIds'] ) || is_integer( $this->args['where']['formIds'] ) ) {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -18,6 +18,7 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Type\Enum\FormStatusEnum;
 use WPGraphQL\GF\Utils\GFUtils;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - FormsConnectionResolver
@@ -145,11 +146,15 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 * @return array
 	 */
 	private function get_form_ids(): array {
-		if ( empty( $this->args['where']['formIds'] ) || ! is_array( $this->args['where']['formIds'] ) ) {
+		if ( empty( $this->args['where']['formIds'] ) ) {
 			return [];
 		}
 
-		return array_map( 'absint', $this->args['where']['formIds'] );
+		if ( is_string( $this->args['where']['formIds'] ) ) {
+			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
+		}
+
+		return array_map( fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
 
 

--- a/src/Mutation/AbstractMutation.php
+++ b/src/Mutation/AbstractMutation.php
@@ -11,8 +11,6 @@ namespace WPGraphQL\GF\Mutation;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
 use WPGraphQL\GF\Data\Loader\DraftEntriesLoader;
-use WPGraphQL\GF\Data\Loader\EntriesLoader;
-use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Interfaces\Mutation;
 use WPGraphQL\GF\Type\AbstractType;
 
@@ -81,47 +79,4 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 		return sanitize_text_field( $resume_token );
 	}
 
-	/**
-	 * Gets the entry databaseId from an indeterminate GraphQL ID.
-	 *
-	 * @param int|string $id .
-	 * @throws UserError .
-	 */
-	protected static function get_entry_id_from_id( $id ) : int {
-		$id_parts = Relay::fromGlobalId( $id );
-
-		if ( ! empty( $id_parts['id'] ) && ! empty( $id_parts['type'] ) ) {
-			if ( EntriesLoader::$name !== $id_parts['type'] ) {
-				throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms entry.', 'wp-graphql-gravity-forms' ) );
-			}
-
-			$entry_id = $id_parts['id'];
-		} else {
-			$entry_id = $id;
-		}
-
-		return absint( $entry_id );
-	}
-
-	/**
-	 * Gets the entry databaseId from an indeterminate GraphQL ID.
-	 *
-	 * @param int|string $id .
-	 * @throws UserError .
-	 */
-	protected static function get_form_id_from_id( $id ) : int {
-		$id_parts = Relay::fromGlobalId( $id );
-
-		if ( ! empty( $id_parts['id'] ) && ! empty( $id_parts['type'] ) ) {
-			if ( FormsLoader::$name !== $id_parts['type'] ) {
-				throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms form.', 'wp-graphql-gravity-forms' ) );
-			}
-
-			$form_id = $id_parts['id'];
-		} else {
-			$form_id = $id;
-		}
-
-		return absint( $form_id );
-	}
 }

--- a/src/Mutation/DeleteEntry.php
+++ b/src/Mutation/DeleteEntry.php
@@ -18,6 +18,7 @@ use WPGraphQL\AppContext;
 use WPGraphQL\GF\Model\SubmittedEntry as ModelSubmittedEntry;
 use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
 use WPGraphQL\GF\Utils\GFUtils;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - DeleteEntry
@@ -76,7 +77,7 @@ class DeleteEntry extends AbstractMutation {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}
 
-			$entry_id = self::get_entry_id_from_id( $input['id'] );
+			$entry_id = Utils::get_entry_id_from_id( $input['id'] );
 
 			if ( empty( $input['forceDelete'] ) ) {
 				$result          = GFAPI::update_entry_property( $entry_id, 'status', 'trash' );

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -23,6 +23,7 @@ use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPObject\FieldError;
 use WPGraphQL\GF\Type\WPObject\SubmissionConfirmation;
 use WPGraphQL\GF\Utils\GFUtils;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - SubmitForm
@@ -132,7 +133,7 @@ class SubmitForm extends AbstractMutation {
 	public static function mutate_and_get_payload() : callable {
 		return function( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Get the form database_id.
-			$form_id = self::get_form_id_from_id( $input['id'] );
+			$form_id = Utils::get_form_id_from_id( $input['id'] );
 
 			$form = GFUtils::get_form( $form_id );
 

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -22,6 +22,7 @@ use WPGraphQL\GF\Type\Input\UpdateEntryMetaInput;
 use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
 use WPGraphQL\GF\Type\WPObject\FieldError;
 use WPGraphQL\GF\Utils\GFUtils;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - UpdateEntry
@@ -97,7 +98,7 @@ class UpdateEntry extends AbstractMutation {
 			static::check_required_inputs( $input );
 
 			// Get the entry.
-			$entry_id = self::get_entry_id_from_id( $input['id'] );
+			$entry_id = Utils::get_entry_id_from_id( $input['id'] );
 			$entry    = GFUtils::get_entry( $entry_id );
 
 			// Check if user has permissions.

--- a/src/Type/WPObject/Entry/DraftEntry.php
+++ b/src/Type/WPObject/Entry/DraftEntry.php
@@ -19,7 +19,6 @@ use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
 use WPGraphQL\GF\Type\Enum\DraftEntryIdTypeEnum;
 use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - Draft

--- a/src/Type/WPObject/Entry/SubmittedEntry.php
+++ b/src/Type/WPObject/Entry/SubmittedEntry.php
@@ -10,9 +10,6 @@
 
 namespace WPGraphQL\GF\Type\WPObject\Entry;
 
-use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\DataSource;
 use WPGraphQL\GF\Data\Factory;
@@ -22,6 +19,7 @@ use WPGraphQL\GF\Type\Enum\SubmittedEntryIdTypeEnum;
 use WPGraphQL\GF\Type\Enum\EntryStatusEnum;
 use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - Submitted
@@ -129,20 +127,8 @@ class SubmittedEntry extends AbstractObject implements TypeWithInterfaces, Field
 						'description' => __( 'Type of unique identifier to fetch a content node by. Default is Global ID.', 'wp-graphql-gravity-forms' ),
 					],
 				],
-				'resolve'     => static function ( $root, array $args, AppContext $context, ResolveInfo $info ) {
-					$idType = $args['idType'] ?? 'global_id';
-
-					if ( 'global_id' === $idType ) {
-						$id_parts = Relay::fromGlobalId( $args['id'] );
-
-						if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
-							throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
-						}
-
-						$id = sanitize_text_field( $id_parts['id'] );
-					} else {
-						$id = sanitize_text_field( $args['id'] );
-					}
+				'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					$id = Utils::get_entry_id_from_id( $args['id'] );
 
 					return Factory::resolve_entry( (int) $id, $context );
 				},

--- a/src/Type/WPObject/Form/Form.php
+++ b/src/Type/WPObject/Form/Form.php
@@ -11,9 +11,7 @@
 namespace WPGraphQL\GF\Type\WPObject\Form;
 
 use GF_Query;
-use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQLRelay\Relay;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Connection\EntriesConnection;
 use WPGraphQL\GF\Connection\FormFieldsConnection;
@@ -28,6 +26,7 @@ use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPInterface\FormField;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\WPObject\Button;
+use WPGraphQL\GF\Utils\Utils;
 
 /**
  * Class - Form
@@ -296,22 +295,8 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 						'description' => __( 'Type of unique identifier to fetch a content node by. Default is Global ID.', 'wp-graphql-gravity-forms' ),
 					],
 				],
-				'resolve'     => static function ( $root, array $args, AppContext $context ) {
-					$idType = $args['idType'] ?? 'global_id';
-
-					/**
-					 * If global id is used, get the (int) id.
-					 */
-					if ( 'global_id' === $idType ) {
-						$id_parts = Relay::fromGlobalId( $args['id'] );
-
-						if ( ! is_array( $id_parts ) || empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
-							throw new UserError( __( 'A valid global ID must be provided.', 'wp-graphql-gravity-forms' ) );
-						}
-						$id = (int) sanitize_text_field( $id_parts['id'] );
-					} else {
-						$id = (int) sanitize_text_field( $args['id'] );
-					}
+				'resolve'     => static function ( $source, array $args, AppContext $context ) {
+					$id = Utils::get_form_id_from_id( $args['id'] );
 
 					return Factory::resolve_form( $id, $context );
 				},

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -321,9 +321,10 @@ class Utils {
 		];
 	}
 
-	
 	/**
 	 * Gets the entry databaseId from an indeterminate GraphQL ID.
+	 *
+	 * @since @todo
 	 *
 	 * @param int|string $id .
 	 * @throws UserError .
@@ -350,6 +351,8 @@ class Utils {
 
 	/**
 	 * Gets the entry databaseId from an indeterminate GraphQL ID.
+	 *
+	 * @since @todo
 	 *
 	 * @param int|string $id .
 	 * @throws UserError .

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -11,10 +11,14 @@
 namespace WPGraphQL\GF\Utils;
 
 use GF_Fields;
+use GraphQL\Error\UserError;
+use GraphQLRelay\Relay;
 use WPGraphQL\GF\Data\Loader\DraftEntriesLoader;
 use WPGraphQL\GF\Data\Loader\EntriesLoader;
+use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Type\WPObject\Entry\DraftEntry;
 use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
+use WPGraphQL\Type\ObjectType\User;
 
 /**
  * Class - Utils
@@ -315,5 +319,58 @@ class Utils {
 			'sub_labels_setting',
 			'visibility_setting',
 		];
+	}
+
+	
+	/**
+	 * Gets the entry databaseId from an indeterminate GraphQL ID.
+	 *
+	 * @param int|string $id .
+	 * @throws UserError .
+	 */
+	public static function get_entry_id_from_id( $id ) : int {
+		// If we already have the database ID, send it back as an integer.
+		if ( is_numeric( $id ) ) {
+			return absint( $id );
+		}
+
+		$id_parts = Relay::fromGlobalId( $id );
+
+		if ( empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
+			throw new UserError( __( 'The ID passed is not a valid Global ID.', 'wp-graphql-gravity-forms' ) );
+		}
+
+		if ( EntriesLoader::$name !== $id_parts['type'] ) {
+			throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms entry.', 'wp-graphql-gravity-forms' ) );
+		}
+
+
+		return absint( $id_parts['id'] );
+	}
+
+	/**
+	 * Gets the entry databaseId from an indeterminate GraphQL ID.
+	 *
+	 * @param int|string $id .
+	 * @throws UserError .
+	 */
+	public static function get_form_id_from_id( $id ) : int {
+		// If we already have the database ID, send it back as an integer.
+		if ( is_numeric( $id ) ) {
+			return absint( $id );
+		}
+
+		$id_parts = Relay::fromGlobalId( $id );
+
+		if ( empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
+			throw new UserError( __( 'The ID passed is not a valid Global ID.', 'wp-graphql-gravity-forms' ) );
+		}
+
+		if ( FormsLoader::$name !== $id_parts['type'] ) {
+			throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms form.', 'wp-graphql-gravity-forms' ) );
+		}
+
+
+		return absint( $id_parts['id'] );
 	}
 }

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -330,23 +330,7 @@ class Utils {
 	 * @throws UserError .
 	 */
 	public static function get_entry_id_from_id( $id ) : int {
-		// If we already have the database ID, send it back as an integer.
-		if ( is_numeric( $id ) ) {
-			return absint( $id );
-		}
-
-		$id_parts = Relay::fromGlobalId( $id );
-
-		if ( empty( $id_parts['id'] ) || empty( $id_parts['type'] ) ) {
-			throw new UserError( __( 'The ID passed is not a valid Global ID.', 'wp-graphql-gravity-forms' ) );
-		}
-
-		if ( EntriesLoader::$name !== $id_parts['type'] ) {
-			throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms entry.', 'wp-graphql-gravity-forms' ) );
-		}
-
-
-		return absint( $id_parts['id'] );
+		return self::get_database_id_from_id( $id, EntriesLoader::$name );
 	}
 
 	/**
@@ -358,6 +342,20 @@ class Utils {
 	 * @throws UserError .
 	 */
 	public static function get_form_id_from_id( $id ) : int {
+		return self::get_database_id_from_id( $id, FormsLoader::$name );
+	}
+
+	/**
+	 * Gets the databaseId from an indeterminate GraphQL ID, ensuring it's the correct type.
+	 *
+	 * @since @todo
+	 * 
+	 * @param int|string $id The provided ID.
+	 * @param string     $type The expected dataloader type.
+	 *
+	 * @throws UserError If the ID is not a valid Global ID.
+	 */
+	protected static function get_database_id_from_id( $id, $type ) : int {
 		// If we already have the database ID, send it back as an integer.
 		if ( is_numeric( $id ) ) {
 			return absint( $id );
@@ -369,10 +367,9 @@ class Utils {
 			throw new UserError( __( 'The ID passed is not a valid Global ID.', 'wp-graphql-gravity-forms' ) );
 		}
 
-		if ( FormsLoader::$name !== $id_parts['type'] ) {
-			throw new UserError( __( 'The ID passed is not a for a valid Gravity Forms form.', 'wp-graphql-gravity-forms' ) );
+		if ( $type !== $id_parts['type'] ) {
+			throw new UserError( __( 'The ID passed is not a valid Global ID for this type.', 'wp-graphql-gravity-forms' ) );
 		}
-
 
 		return absint( $id_parts['id'] );
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR refactors the `AbstractMutation::get_entry_id_from_id()` and `AbstractMutation::get_form_id_from_id()` into `Utils` methods, and changes the plugin to use those new methods.

As a result, `GfEntriesConnectionWhereArgs.formIds` and `GfFormsConnectionwhereArgs.formIds` now accept either a global or database ID, and other form/entry ID inputs will work more reliably if no `idType` is provided.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #308 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
