### PR TITLE
ci: (temp) revert 8.1 integration tests for WP<6.2

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           tools: composer:v2, wp-cli
           coverage: none

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.1', '8.0', '7.4' ]
+        php: [ '8.0', '7.4' ]
         wordpress: [ '6.2', '6.1', '6.0', '5.9' ]
         include:
           - php: '8.1'

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
           tools: composer:v2, wp-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 - dev: Refactor database ID resolution when the GraphQL `ID` type is indeterminate. Note: The following input args now work with both database and global IDs: `GfEntriesConnectionWhereArgs.formIds`, `GfFormsConnectionwhereArgs.formIds`.
-- ci: Test against PHP 8.1
 - docs: Add missing documentation regarding using `productValues` input when submitting forms.
 
 ## v0.12.1 - Bug fix

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our hope for this open source project is that it will enable more teams to lever
 
 ## System Requirements
 
-* PHP 7.4+ || 8.0 || 8.1
+* PHP 7.4+ || 8.0
 * WordPress 5.4.1+
 * WPGraphQL 1.9.0+
 * Gravity Forms 2.5+ (Recommend: v2.6+)

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -193,6 +193,8 @@ post_setup() {
 	echo "Installed plugins"
 	wp plugin list
 
+	wp config set WP_DEBUG true --raw --type=constant
+	wp config set WP_DEBUG_LOG true --raw --type=constant
 	wp config set GRAPHQL_DEBUG true --raw --type=constant
 
 	wp option update gf_env_hide_setup_wizard true

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
 	echo "  composer build-app"
 	echo "  composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer build-app"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer run-app"
+	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 composer build-app"
+	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 bin/run-docker.sh build -a"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 bin/run-docker.sh run -a"
+	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 bin/run-docker.sh build -a"
+	echo "  WP_VERSION=6.2 PHP_VERSION=8.0 bin/run-docker.sh run -a"
 	exit 1
 }
 
@@ -30,7 +30,7 @@ fi
 
 TAG=${TAG-latest}
 WP_VERSION=${WP_VERSION-6.2}
-PHP_VERSION=${PHP_VERSION-8.1}
+PHP_VERSION=${PHP_VERSION-8.0}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
 

--- a/composer.lock
+++ b/composer.lock
@@ -2079,16 +2079,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.6.0",
+            "version": "7.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "733dd89533dd371a0987172727df15f500dab0ef"
+                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/733dd89533dd371a0987172727df15f500dab0ef",
-                "reference": "733dd89533dd371a0987172727df15f500dab0ef",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b964ca597e86b752cd994f27293e9fa6b6a95ed9",
+                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9",
                 "shasum": ""
             },
             "require": {
@@ -2119,6 +2119,9 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -2184,7 +2187,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.6.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.5.1"
             },
             "funding": [
                 {
@@ -2200,7 +2203,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-14T11:23:39+00:00"
+            "time": "2023-04-17T16:30:08+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -3795,16 +3798,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.15",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/762c4dac4da6f8756eebb80e528c3a47855da9bd",
-                "reference": "762c4dac4da6f8756eebb80e528c3a47855da9bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -3853,7 +3856,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-09T15:28:01+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4175,16 +4178,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -4258,7 +4261,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -4274,7 +4277,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/container",
@@ -5111,16 +5114,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
                 "shasum": ""
             },
             "require": {
@@ -5165,7 +5168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
             },
             "funding": [
                 {
@@ -5173,7 +5176,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5777,16 +5780,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.10.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1"
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/594fd6462aad8ecee0b45ca5045acea4776667f1",
-                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
                 "shasum": ""
             },
             "require": {
@@ -5825,7 +5828,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
             },
             "funding": [
                 {
@@ -5837,7 +5840,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T13:16:46+00:00"
+            "time": "2022-04-01T13:37:23+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -8660,16 +8663,16 @@
         },
         {
             "name": "wp-cli/entity-command",
-            "version": "v2.4.3",
+            "version": "v2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/entity-command.git",
-                "reference": "931bf8f28cc804fcebbcd484375e27116658de79"
+                "reference": "694a4a556d2c16860b738787b4c0294a89c4a760"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/931bf8f28cc804fcebbcd484375e27116658de79",
-                "reference": "931bf8f28cc804fcebbcd484375e27116658de79",
+                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/694a4a556d2c16860b738787b4c0294a89c4a760",
+                "reference": "694a4a556d2c16860b738787b4c0294a89c4a760",
                 "shasum": ""
             },
             "require": {
@@ -8865,9 +8868,9 @@
             "homepage": "https://github.com/wp-cli/entity-command",
             "support": {
                 "issues": "https://github.com/wp-cli/entity-command/issues",
-                "source": "https://github.com/wp-cli/entity-command/tree/v2.4.3"
+                "source": "https://github.com/wp-cli/entity-command/tree/v2.4.2"
             },
-            "time": "2023-05-08T19:35:25+00:00"
+            "time": "2023-03-15T17:10:20+00:00"
         },
         {
             "name": "wp-cli/eval-command",
@@ -9792,16 +9795,16 @@
         },
         {
             "name": "wp-cli/search-replace-command",
-            "version": "v2.1.0",
+            "version": "v2.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/search-replace-command.git",
-                "reference": "c23820436dcac45662e7a6833bbdfa542b0f21a0"
+                "reference": "6b195e3f39dd18270710b28343a8038f5927dd2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/c23820436dcac45662e7a6833bbdfa542b0f21a0",
-                "reference": "c23820436dcac45662e7a6833bbdfa542b0f21a0",
+                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/6b195e3f39dd18270710b28343a8038f5927dd2c",
+                "reference": "6b195e3f39dd18270710b28343a8038f5927dd2c",
                 "shasum": ""
             },
             "require": {
@@ -9846,9 +9849,9 @@
             "homepage": "https://github.com/wp-cli/search-replace-command",
             "support": {
                 "issues": "https://github.com/wp-cli/search-replace-command/issues",
-                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.0"
+                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.0.20"
             },
-            "time": "2023-05-11T08:09:28+00:00"
+            "time": "2023-02-17T16:23:58+00:00"
         },
         {
             "name": "wp-cli/server-command",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql-gravity-forms:latest-wp${WP_VERSION-6.2}-php${PHP_VERSION-8.1}
+    image: wp-graphql-gravity-forms:latest-wp${WP_VERSION-6.2}-php${PHP_VERSION-8.0}
     volumes:
       - .:/var/www/html/wp-content/plugins/wp-graphql-gravity-forms
       - ./.log/app:/var/log/apache2

--- a/tests/_data/config.php
+++ b/tests/_data/config.php
@@ -9,3 +9,5 @@ define( 'GRAPHQL_DEBUG', true );
 // Use reCAPTCHA test keys: https://developers.google.com/recaptcha/docs/faq
 define( 'GF_RECAPTCHA_PUBLIC_KEY', '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI' );
 define( 'GF_RECAPTCHA_PRIVATE_KEY', '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe' );
+define( 'WP_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'harness-software/wp-graphql-gravity-forms',
-        'pretty_version' => 'dev-develop',
-        'version' => 'dev-develop',
-        'reference' => '30b03c910513c9be68f3a38e0657b9ab8810c2ad',
+        'pretty_version' => 'dev-main',
+        'version' => 'dev-main',
+        'reference' => '142fac8e02f97a82609a97ce8eb824e5cc7f8557',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'harness-software/wp-graphql-gravity-forms' => array(
-            'pretty_version' => 'dev-develop',
-            'version' => 'dev-develop',
-            'reference' => '30b03c910513c9be68f3a38e0657b9ab8810c2ad',
+            'pretty_version' => 'dev-main',
+            'version' => 'dev-main',
+            'reference' => '142fac8e02f97a82609a97ce8eb824e5cc7f8557',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Reverts #365 and parts of #364 so Codeception only tests PHP 8.1 against WordPrwss 6.2.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
https://github.com/lucatume/wp-browser/issues/614

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
