### PR TITLE
dev: remove call to deprecated `resolve_post_object()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - dev: Refactor database ID resolution when the GraphQL `ID` type is indeterminate. Note: The following input args now work with both database and global IDs: `GfEntriesConnectionWhereArgs.formIds`, `GfFormsConnectionwhereArgs.formIds`.
 - docs: Add missing documentation regarding using `productValues` input when submitting forms.
+- dev: Remove usage of deprecated `WPGraphQL\Data\DataSource::resolve_post_object()` method.
 
 ## v0.12.1 - Bug fix
 

--- a/src/Type/WPObject/Entry/SubmittedEntry.php
+++ b/src/Type/WPObject/Entry/SubmittedEntry.php
@@ -11,7 +11,6 @@
 namespace WPGraphQL\GF\Type\WPObject\Entry;
 
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\DataSource;
 use WPGraphQL\GF\Data\Factory;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
@@ -87,7 +86,7 @@ class SubmittedEntry extends AbstractObject implements TypeWithInterfaces, Field
 			'post'           => [
 				'type'        => 'Post',
 				'description' => __( 'For forms with Post fields, this is the post object that was created.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source, array $args, AppContext $context ) => ! empty( $source->postDatabaseId ) ? DataSource::resolve_post_object( $source->postDatabaseId, $context ) : null,
+				'resolve'     => static fn ( $source, array $args, AppContext $context ) => ! empty( $source->postDatabaseId ) ? $context->get_loader( 'post' )->load( $source->postDatabaseId ) : null,
 			],
 			'postDatabaseId' => [
 				'type'        => 'Int',


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR replaces the usage of `WPGraphQL\Data\DataSource::resolve_post_object()` with `$context->get_loader('post')`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
`resolve_post_object()` was deprecated in 0.8.4, but only had notices exposed in https://github.com/wp-graphql/wp-graphql/pull/2776

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
