### PR TITLE
dev: Prime the FormsLoader when querying form connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 - dev: Refactor database ID resolution when the GraphQL `ID` type is indeterminate. Note: The following input args now work with both database and global IDs: `GfEntriesConnectionWhereArgs.formIds`, `GfFormsConnectionwhereArgs.formIds`.
-- docs: Add missing documentation regarding using `productValues` input when submitting forms.
 - dev: Remove usage of deprecated `WPGraphQL\Data\DataSource::resolve_post_object()` method.
+- dev: Prime the GfForm dataloader when querying form connections, to prevent unnecessary database queries.
+- docs: Add missing documentation regarding using `productValues` input when submitting forms.
 
 ## v0.12.1 - Bug fix
 

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -110,6 +110,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 
 		$query = [];
 
+		$loader = $this->getLoader();
+
 		foreach ( $forms as $form ) {
 			/**
 			 * "wp_graphql_gf_form_object" filter
@@ -120,7 +122,12 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			 *
 			 * @param array $form Form meta array.
 			 */
-			$query[ $form['id'] ] = apply_filters( 'graphql_gf_form_object', $form );
+			$modified_form = apply_filters( 'graphql_gf_form_object', $form );
+
+			// Cache the form in the dataloader.
+			$loader->prime( $modified_form['id'], $modified_form );
+
+			$query[ $modified_form['id'] ] = $modified_form;
 		}
 
 		return $query;


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR primes the `FormsLoader` when using the `FormsConnectionResolver`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Since GF only allows you to query for the entire form, theres no difference between Connection Resolver query and the actual model population. By priming the dataloader cache, we can prevent the unnecessary extra database queries.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
