### PR TITLE
chore: implement WPGraphQL Coding Standards ruleset (PHPCS)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,7 +27,7 @@
 	<!-- Enables parallel processing when available for faster results. -->
 	<arg name="parallel" value="20"/>
 	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
-	<arg name="severity" value="1" />
+	<arg name="severity" value="1"/>
 
 	<!-- Ruleset Config: set these to match your project constraints-->
 
@@ -48,6 +48,7 @@
 	<rule ref="WPGraphQL">
 		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
 		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification" />
 	</rule>
 
 	<!-- Individual rule configuration -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
-<ruleset  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPGraphQL_GF" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
-	<description>Coding Standards for WPGraphQL for Gravity Forms</description>
+<ruleset name="WordPress Coding Standards for WPGraphQL for Gravity Forms" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>Sniffs for the WPGraphQL plugin ecosystem.</description>
 
-	<!-- What to scan -->
-	<file>.</file>
+	<!-- What to scan: include any root-level PHP files, and the /src folder -->
+	<file>./src/</file>
+	<file>./wp-graphql-gravity-forms.php</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/phpstan/</exclude-pattern>
@@ -13,29 +14,48 @@
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 
-	<arg value="sp"/>
 	<!-- Show sniff and progress -->
-	<arg name="basepath" value="./"/>
+	<arg value="sp"/>
 	<!-- Strip the file paths down to the relevant bit -->
+	<arg name="basepath" value="./"/>
+	<!-- Enable colors in report -->
 	<arg name="colors"/>
+	<!-- Only lint php files by default -->
 	<arg name="extensions" value="php"/>
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache" value="tests/_output/cache.json" />
 	<!-- Enables parallel processing when available for faster results. -->
-	<arg name="parallel" value="8"/>
+	<arg name="parallel" value="20"/>
+	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
+	<arg name="severity" value="1" />
 
-	<!-- Tests for PHP version compatibility -->
+	<!-- Ruleset Config: set these to match your project constraints-->
+
+	<!--
+		Tests for PHP version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#Recomended-additional-rulesets
+	-->
 	<config name="testVersion" value="7.4-"/>
-	<rule ref="PHPCompatibilityWP">
-		<include-pattern>*\.php$</include-pattern>
-	</rule>
 
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<!--
+		Tests for WordPress version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
 	<config name="minimum_supported_wp_version" value="5.4.1"/>
 
-	<!-- Plugin-specific expected properties-->
+	<!-- Rules: WPGraphQL Coding Standards -->
+	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->
+	<rule ref="WPGraphQL">
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
+		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+	</rule>
+
+	<!-- Individual rule configuration -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
-			<property name="prefixes" type="array" value="WPGraphQL\GF, wp_graphql, gf_graphql, _gf, WPGRAPHQL_GF" />
+			<!-- @todo drop gf_graphql -->
+			<property name="prefixes" type="array" value="WPGraphQL\GF, wp_graphql, gf_graphql, graphql_gf, _gf, WPGRAPHQL_GF" />
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.I18n">
@@ -45,39 +65,4 @@
 		</properties>
 	</rule>
 
-	<!-- Rules: WordPress Coding Standards -->
-	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
-	<rule ref="WordPress-VIP-Go" />
-
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<rule ref="WordPress-Core">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
-		<exclude name="WordPress.Files.FileName" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName" />
-		<!-- Maybe Add later: -->
-		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound" />
-		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-	</rule>
-	<rule ref="WordPress-Docs" />
-	<rule ref="WordPress-Extra" />
-
-
-
-	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
-		<properties>
-			<property name="blank_line_check" value="true"/>
-		</properties>
-	</rule>
-
-	<!-- Enforce short array syntax -->
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
-	<!--Disable DocBlock requirements if inherited -->
-	<rule ref="Squiz.Commenting.FunctionComment">
-		<properties>
-				<property name="skipIfInheritdoc" value="true" />
-		</properties>
-	</rule>
 </ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - dev: Refactor database ID resolution when the GraphQL `ID` type is indeterminate. Note: The following input args now work with both database and global IDs: `GfEntriesConnectionWhereArgs.formIds`, `GfFormsConnectionwhereArgs.formIds`.
 - dev: Remove usage of deprecated `WPGraphQL\Data\DataSource::resolve_post_object()` method.
 - dev: Prime the GfForm dataloader when querying form connections, to prevent unnecessary database queries.
+- chore: Implement `axepress/wp-graphql-cs` PHP_Codesniffer ruleset.
 - docs: Add missing documentation regarding using `productValues` input when submitting forms.
 
 ## v0.12.1 - Bug fix

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,13 @@
 		"lucatume/wp-browser": "^3.0",
 		"wp-graphql/wp-graphql-testcase": "~2.3",
 		"phpunit/phpunit": "^9.0",
-		"php-coveralls/php-coveralls": "^2.5",
 		"phpstan/phpstan": "^1.2",
 		"phpstan/extension-installer": "^1.1",
 		"szepeviktor/phpstan-wordpress": "^1.0",
 		"axepress/wp-graphql-stubs": "^1.11.1",
-		"wp-cli/wp-cli-bundle": "^2.6",
-		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"automattic/vipwpcs": "^2.3"
+		"axepress/wp-graphql-cs": "dev-develop",
+		"wp-cli/wp-cli-bundle": "^2.8.1",
+		"php-coveralls/php-coveralls": "^2.5"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1da1a18c553a86a5e0f544c50421340d",
+    "content-hash": "4bdccf5a99014b96b2567f69e558d9b8",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -157,6 +157,66 @@
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
             "time": "2021-09-29T16:20:23+00:00"
+        },
+        {
+            "name": "axepress/wp-graphql-cs",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AxeWP/WPGraphQL-Coding-Standards.git",
+                "reference": "03f0f3cfa997a0f32311113e146bcba8ea90b1c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AxeWP/WPGraphQL-Coding-Standards/zipball/03f0f3cfa997a0f32311113e146bcba8ea90b1c5",
+                "reference": "03f0f3cfa997a0f32311113e146bcba8ea90b1c5",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/vipwpcs": "^2.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=7.2",
+                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "slevomat/coding-standard": "^8.12",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "AxePress Development",
+                    "email": "support@axepress.dev",
+                    "homepage": "https://axepress.dev"
+                },
+                {
+                    "name": "David Levine",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) for the WPGraphQL ecosystem.",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress",
+                "wpcs",
+                "wpgraphql"
+            ],
+            "support": {
+                "issues": "https://github.com/AxeWP/WPGraphQL-Coding-Standards/issues",
+                "source": "https://github.com/AxeWP/WPGraphQL-Coding-Standards"
+            },
+            "time": "2023-06-05T09:07:08+00:00"
         },
         {
             "name": "axepress/wp-graphql-stubs",
@@ -2079,21 +2139,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.5.1",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9"
+                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b964ca597e86b752cd994f27293e9fa6b6a95ed9",
-                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0",
                 "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -2105,7 +2165,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "^3.0",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
@@ -2119,9 +2180,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -2187,7 +2245,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.5.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
             },
             "funding": [
                 {
@@ -2203,38 +2261,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:30:08+00:00"
+            "time": "2023-05-21T14:04:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
+                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -2271,7 +2328,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2287,7 +2344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T13:50:22+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -3113,16 +3170,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.66.0",
+            "version": "2.67.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "496712849902241f04902033b0441b269effe001"
+                "reference": "c1001b3bc75039b07f38a79db5237c4c529e04c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/496712849902241f04902033b0441b269effe001",
-                "reference": "496712849902241f04902033b0441b269effe001",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/c1001b3bc75039b07f38a79db5237c4c529e04c8",
+                "reference": "c1001b3bc75039b07f38a79db5237c4c529e04c8",
                 "shasum": ""
             },
             "require": {
@@ -3211,20 +3268,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-29T18:53:47+00:00"
+            "time": "2023-05-25T22:09:47+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -3265,9 +3322,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3465,16 +3522,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.2.0",
+            "version": "v6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "b73fe99eadf9fb56363619dac0343b6d19907dce"
+                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/b73fe99eadf9fb56363619dac0343b6d19907dce",
-                "reference": "b73fe99eadf9fb56363619dac0343b6d19907dce",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/0009429e639b748eef1c955200ea0d4e5ad5627d",
+                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d",
                 "shasum": ""
             },
             "require-dev": {
@@ -3482,7 +3539,8 @@
                 "php": "~7.3 || ~8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.9"
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -3503,9 +3561,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.2.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.2.1"
             },
-            "time": "2023-03-31T09:48:52+00:00"
+            "time": "2023-05-18T04:35:23+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -3749,22 +3807,22 @@
         },
         {
             "name": "phpstan/extension-installer",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a"
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f5e02d40f277d28513001976f444d9ff1dc15e9a",
-                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f45734bfb9984c6c56c4486b71230355f066a58a",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.8.0"
+                "phpstan/phpstan": "^1.9.0"
             },
             "require-dev": {
                 "composer/composer": "^2.0",
@@ -3773,12 +3831,7 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "PHPStan\\ExtensionInstaller\\Plugin",
-                "phpstan/extension-installer": {
-                    "ignore": [
-                        "phpstan/phpstan-phpunit"
-                    ]
-                }
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
             },
             "autoload": {
                 "psr-4": {
@@ -3792,22 +3845,67 @@
             "description": "Composer plugin for automatic installation of PHPStan extensions",
             "support": {
                 "issues": "https://github.com/phpstan/extension-installer/issues",
-                "source": "https://github.com/phpstan/extension-installer/tree/1.3.0"
+                "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
             },
-            "time": "2023-04-18T13:08:02+00:00"
+            "time": "2023-05-24T08:59:17+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "1.10.14",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.20.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
+            },
+            "time": "2023-05-02T09:19:37+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "352bdbb960bb523e3d71b834862589f910921c23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/352bdbb960bb523e3d71b834862589f910921c23",
+                "reference": "352bdbb960bb523e3d71b834862589f910921c23",
                 "shasum": ""
             },
             "require": {
@@ -3856,7 +3954,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-19T13:47:27+00:00"
+            "time": "2023-06-05T08:21:46+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4178,16 +4276,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -4261,7 +4359,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -4277,7 +4375,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "psr/container",
@@ -4755,66 +4853,6 @@
             "time": "2023-05-02T15:15:43+00:00"
         },
         {
-            "name": "rmccue/requests",
-            "version": "v1.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/Requests.git",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "php-parallel-lint/php-console-highlighter": "^0.5.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
-                "requests/test-server": "dev-master",
-                "squizlabs/php_codesniffer": "^3.5",
-                "wp-coding-standards/wpcs": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Requests": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info"
-                }
-            ],
-            "description": "A HTTP library written in PHP, for human beings.",
-            "homepage": "http://github.com/WordPress/Requests",
-            "keywords": [
-                "curl",
-                "fsockopen",
-                "http",
-                "idna",
-                "ipv6",
-                "iri",
-                "sockets"
-            ],
-            "support": {
-                "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
-            },
-            "time": "2021-06-04T09:56:25+00:00"
-        },
-        {
             "name": "sebastian/cli-parser",
             "version": "1.0.1",
             "source": {
@@ -5114,16 +5152,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -5168,7 +5206,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -5176,7 +5214,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5780,16 +5818,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/594fd6462aad8ecee0b45ca5045acea4776667f1",
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1",
                 "shasum": ""
             },
             "require": {
@@ -5828,7 +5866,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.0"
             },
             "funding": [
                 {
@@ -5840,7 +5878,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T13:37:23+00:00"
+            "time": "2023-05-11T13:16:46+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -5947,6 +5985,71 @@
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
             "time": "2023-03-31T16:46:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
+                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.15",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.1.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.12.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-15T21:42:25+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -6227,16 +6330,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.23",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c"
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90f21e27d0d88ce38720556dd164d4a1e4c3934c",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c",
+                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
                 "shasum": ""
             },
             "require": {
@@ -6306,7 +6409,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.23"
+                "source": "https://github.com/symfony/console/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -6322,7 +6425,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-24T18:47:29+00:00"
+            "time": "2023-05-26T05:13:16+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -7396,16 +7499,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.23",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b842fc4b61609e0a155a114082bd94e31e98287"
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b842fc4b61609e0a155a114082bd94e31e98287",
-                "reference": "4b842fc4b61609e0a155a114082bd94e31e98287",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
                 "shasum": ""
             },
             "require": {
@@ -7438,7 +7541,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.23"
+                "source": "https://github.com/symfony/process/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -7454,7 +7557,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-18T13:50:24+00:00"
+            "time": "2023-05-17T11:26:05+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -7689,16 +7792,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.22",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "9a401392f01bc385aa42760eff481d213a0cc2ba"
+                "reference": "de237e59c5833422342be67402d487fbf50334ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/9a401392f01bc385aa42760eff481d213a0cc2ba",
-                "reference": "9a401392f01bc385aa42760eff481d213a0cc2ba",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/de237e59c5833422342be67402d487fbf50334ff",
+                "reference": "de237e59c5833422342be67402d487fbf50334ff",
                 "shasum": ""
             },
             "require": {
@@ -7766,7 +7869,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.22"
+                "source": "https://github.com/symfony/translation/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -7782,7 +7885,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T16:07:23+00:00"
+            "time": "2023-05-19T12:34:17+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -8250,16 +8353,16 @@
         },
         {
             "name": "wp-cli/checksum-command",
-            "version": "v2.2.0",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/checksum-command.git",
-                "reference": "1a44dfbd3f962283a93ba547142300c98956d811"
+                "reference": "5da44c978635768fb941ad594a973dbd712450dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/1a44dfbd3f962283a93ba547142300c98956d811",
-                "reference": "1a44dfbd3f962283a93ba547142300c98956d811",
+                "url": "https://api.github.com/repos/wp-cli/checksum-command/zipball/5da44c978635768fb941ad594a973dbd712450dd",
+                "reference": "5da44c978635768fb941ad594a973dbd712450dd",
                 "shasum": ""
             },
             "require": {
@@ -8303,9 +8406,9 @@
             "homepage": "https://github.com/wp-cli/checksum-command",
             "support": {
                 "issues": "https://github.com/wp-cli/checksum-command/issues",
-                "source": "https://github.com/wp-cli/checksum-command/tree/v2.2.0"
+                "source": "https://github.com/wp-cli/checksum-command/tree/v2.2.2"
             },
-            "time": "2023-03-24T20:57:16+00:00"
+            "time": "2023-06-01T00:12:46+00:00"
         },
         {
             "name": "wp-cli/config-command",
@@ -8382,16 +8485,16 @@
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.1.11",
+            "version": "v2.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "e3212a3e18fe4affabc54c76cc6a59f3d8059d24"
+                "reference": "893e18d266a8e4f9145f9ca32aabd44d0c279562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/e3212a3e18fe4affabc54c76cc6a59f3d8059d24",
-                "reference": "e3212a3e18fe4affabc54c76cc6a59f3d8059d24",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/893e18d266a8e4f9145f9ca32aabd44d0c279562",
+                "reference": "893e18d266a8e4f9145f9ca32aabd44d0c279562",
                 "shasum": ""
             },
             "require": {
@@ -8403,7 +8506,7 @@
                 "wp-cli/db-command": "^1.3 || ^2",
                 "wp-cli/entity-command": "^1.3 || ^2",
                 "wp-cli/extension-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^3.1.4"
+                "wp-cli/wp-cli-tests": "^3.2.7"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -8447,22 +8550,22 @@
             "homepage": "https://github.com/wp-cli/core-command",
             "support": {
                 "issues": "https://github.com/wp-cli/core-command/issues",
-                "source": "https://github.com/wp-cli/core-command/tree/v2.1.11"
+                "source": "https://github.com/wp-cli/core-command/tree/v2.1.13"
             },
-            "time": "2023-04-27T09:50:50+00:00"
+            "time": "2023-05-31T07:42:48+00:00"
         },
         {
             "name": "wp-cli/cron-command",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/cron-command.git",
-                "reference": "a72c43d49703aa5f458cb64df9065e1540e0e394"
+                "reference": "c63ac49baf425b13a80875e092feaebd9c75c932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/a72c43d49703aa5f458cb64df9065e1540e0e394",
-                "reference": "a72c43d49703aa5f458cb64df9065e1540e0e394",
+                "url": "https://api.github.com/repos/wp-cli/cron-command/zipball/c63ac49baf425b13a80875e092feaebd9c75c932",
+                "reference": "c63ac49baf425b13a80875e092feaebd9c75c932",
                 "shasum": ""
             },
             "require": {
@@ -8516,9 +8619,9 @@
             "homepage": "https://github.com/wp-cli/cron-command",
             "support": {
                 "issues": "https://github.com/wp-cli/cron-command/issues",
-                "source": "https://github.com/wp-cli/cron-command/tree/v2.2.1"
+                "source": "https://github.com/wp-cli/cron-command/tree/v2.2.2"
             },
-            "time": "2023-02-17T17:03:53+00:00"
+            "time": "2023-05-25T16:11:42+00:00"
         },
         {
             "name": "wp-cli/db-command",
@@ -8663,16 +8766,16 @@
         },
         {
             "name": "wp-cli/entity-command",
-            "version": "v2.4.2",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/entity-command.git",
-                "reference": "694a4a556d2c16860b738787b4c0294a89c4a760"
+                "reference": "4c0b4846baf193d9a3992386b89a381496983eb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/694a4a556d2c16860b738787b4c0294a89c4a760",
-                "reference": "694a4a556d2c16860b738787b4c0294a89c4a760",
+                "url": "https://api.github.com/repos/wp-cli/entity-command/zipball/4c0b4846baf193d9a3992386b89a381496983eb1",
+                "reference": "4c0b4846baf193d9a3992386b89a381496983eb1",
                 "shasum": ""
             },
             "require": {
@@ -8868,9 +8971,9 @@
             "homepage": "https://github.com/wp-cli/entity-command",
             "support": {
                 "issues": "https://github.com/wp-cli/entity-command/issues",
-                "source": "https://github.com/wp-cli/entity-command/tree/v2.4.2"
+                "source": "https://github.com/wp-cli/entity-command/tree/v2.5.1"
             },
-            "time": "2023-03-15T17:10:20+00:00"
+            "time": "2023-05-30T13:42:30+00:00"
         },
         {
             "name": "wp-cli/eval-command",
@@ -9474,22 +9577,22 @@
         },
         {
             "name": "wp-cli/package-command",
-            "version": "v2.2.5",
+            "version": "v2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/package-command.git",
-                "reference": "a1345d246a856fed3bd64fd69e08c44f8b46bbf4"
+                "reference": "88b7728c81105be91f1e1aabbdf3b4037999b5bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/a1345d246a856fed3bd64fd69e08c44f8b46bbf4",
-                "reference": "a1345d246a856fed3bd64fd69e08c44f8b46bbf4",
+                "url": "https://api.github.com/repos/wp-cli/package-command/zipball/88b7728c81105be91f1e1aabbdf3b4037999b5bd",
+                "reference": "88b7728c81105be91f1e1aabbdf3b4037999b5bd",
                 "shasum": ""
             },
             "require": {
                 "composer/composer": "^1.10.23 || ~2.2.17",
                 "ext-json": "*",
-                "wp-cli/wp-cli": "^2.5"
+                "wp-cli/wp-cli": "^2.8"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1 || ^2",
@@ -9533,9 +9636,9 @@
             "homepage": "https://github.com/wp-cli/package-command",
             "support": {
                 "issues": "https://github.com/wp-cli/package-command/issues",
-                "source": "https://github.com/wp-cli/package-command/tree/v2.2.5"
+                "source": "https://github.com/wp-cli/package-command/tree/v2.3.2"
             },
-            "time": "2023-02-17T18:13:51+00:00"
+            "time": "2023-06-02T06:17:19+00:00"
         },
         {
             "name": "wp-cli/php-cli-tools",
@@ -9795,16 +9898,16 @@
         },
         {
             "name": "wp-cli/search-replace-command",
-            "version": "v2.0.20",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/search-replace-command.git",
-                "reference": "6b195e3f39dd18270710b28343a8038f5927dd2c"
+                "reference": "1d5c77fbead033a7707915fa0c51306fb3c64d37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/6b195e3f39dd18270710b28343a8038f5927dd2c",
-                "reference": "6b195e3f39dd18270710b28343a8038f5927dd2c",
+                "url": "https://api.github.com/repos/wp-cli/search-replace-command/zipball/1d5c77fbead033a7707915fa0c51306fb3c64d37",
+                "reference": "1d5c77fbead033a7707915fa0c51306fb3c64d37",
                 "shasum": ""
             },
             "require": {
@@ -9849,9 +9952,9 @@
             "homepage": "https://github.com/wp-cli/search-replace-command",
             "support": {
                 "issues": "https://github.com/wp-cli/search-replace-command/issues",
-                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.0.20"
+                "source": "https://github.com/wp-cli/search-replace-command/tree/v2.1.1"
             },
-            "time": "2023-02-17T16:23:58+00:00"
+            "time": "2023-06-02T20:30:01+00:00"
         },
         {
             "name": "wp-cli/server-command",
@@ -10098,23 +10201,22 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.7.1",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76"
+                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
-                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
+                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "mustache/mustache": "^2.14.1",
                 "php": "^5.6 || ^7.0 || ^8.0",
-                "rmccue/requests": "^1.8",
                 "symfony/finder": ">2.7",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
                 "wp-cli/php-cli-tools": "~0.11.2"
@@ -10138,7 +10240,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8.x-dev"
+                    "dev-main": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -10165,20 +10267,20 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2022-10-17T23:10:42+00:00"
+            "time": "2023-06-05T06:55:55+00:00"
         },
         {
             "name": "wp-cli/wp-cli-bundle",
-            "version": "v2.7.1",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-bundle.git",
-                "reference": "08765f2bbd1308247050fc8efef63df3a0c9616f"
+                "reference": "42e9cb9c16831c31ff720ed9dd1604e0f9871695"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-bundle/zipball/08765f2bbd1308247050fc8efef63df3a0c9616f",
-                "reference": "08765f2bbd1308247050fc8efef63df3a0c9616f",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-bundle/zipball/42e9cb9c16831c31ff720ed9dd1604e0f9871695",
+                "reference": "42e9cb9c16831c31ff720ed9dd1604e0f9871695",
                 "shasum": ""
             },
             "require": {
@@ -10209,7 +10311,7 @@
                 "wp-cli/shell-command": "^2",
                 "wp-cli/super-admin-command": "^2",
                 "wp-cli/widget-command": "^2",
-                "wp-cli/wp-cli": "^2.7.1"
+                "wp-cli/wp-cli": "^2.8.1"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
@@ -10221,7 +10323,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.6.x-dev"
+                    "dev-main": "2.8.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -10239,7 +10341,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli-bundle/issues",
                 "source": "https://github.com/wp-cli/wp-cli-bundle"
             },
-            "time": "2022-10-17T23:55:22+00:00"
+            "time": "2023-06-05T07:33:43+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -10462,7 +10564,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "axepress/wp-graphql-cs": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Connection/AbstractConnection.php
+++ b/src/Connection/AbstractConnection.php
@@ -25,14 +25,14 @@ abstract class AbstractConnection implements Hookable, Registrable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		add_action( 'graphql_register_types', [ static::class, 'register' ] );
 	}
 
 	/**
 	 * Gets custom connection configuration arguments, such as the resolver, edgeFields, connectionArgs, etc.
 	 */
-	public static function get_connection_args() : array {
+	public static function get_connection_args(): array {
 		return [];
 	}
 
@@ -41,7 +41,7 @@ abstract class AbstractConnection implements Hookable, Registrable {
 	 *
 	 * @param array $filter_by .
 	 */
-	public static function get_filtered_connection_args( array $filter_by = null ) : array {
+	public static function get_filtered_connection_args( array $filter_by = null ): array {
 		$connection_args = static::get_connection_args();
 
 		if ( empty( $filter_by ) ) {

--- a/src/Connection/EntriesConnection.php
+++ b/src/Connection/EntriesConnection.php
@@ -30,7 +30,7 @@ class EntriesConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		// RootQuery to Entry.
 		register_graphql_connection(
 			[
@@ -65,7 +65,7 @@ class EntriesConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connection_args() : array {
+	public static function get_connection_args(): array {
 		return [
 			'dateFilters'      => [
 				'type'        => EntriesDateFiltersInput::$type,

--- a/src/Connection/FormFieldsConnection.php
+++ b/src/Connection/FormFieldsConnection.php
@@ -19,21 +19,21 @@ class FormFieldsConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		// @todo register to rootQuery.
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		// @todo register to rootQuery.
 	}
 
 	/**
 	 * Gets custom connection configuration arguments, such as the resolver, edgeFields, connectionArgs, etc.
 	 */
-	public static function get_connection_args() : array {
+	public static function get_connection_args(): array {
 		return [
 			'ids'         => [
 				'type'        => [ 'list_of' => 'ID' ],

--- a/src/Connection/FormsConnection.php
+++ b/src/Connection/FormsConnection.php
@@ -30,7 +30,7 @@ class FormsConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		// RootQuery to Form.
 		register_graphql_connection(
 			[
@@ -48,7 +48,7 @@ class FormsConnection extends AbstractConnection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connection_args() : array {
+	public static function get_connection_args(): array {
 		return [
 			'formIds' => [
 				'type'        => [ 'list_of' => 'ID' ],

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -18,7 +18,7 @@ class CoreSchemaFilters implements Hookable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		// Register Data Loaders.
 		add_filter( 'graphql_data_loaders', [ Factory::class, 'register_loaders' ], 10, 2 );
 
@@ -40,7 +40,7 @@ class CoreSchemaFilters implements Hookable {
 	 *
 	 * @return array
 	 */
-	public static function strip_connection_interface_from_gf_fields( array $interfaces, array $config ) : array {
+	public static function strip_connection_interface_from_gf_fields( array $interfaces, array $config ): array {
 		// Bail early if Connection, 'Edge, or 'OneToOneConnection' arent in the interfaces.
 		if ( ! in_array( 'Connection', $interfaces, true ) && ! in_array( 'Edge', $interfaces, true ) && ! in_array( 'OneToOneConnection', $interfaces, true ) ) {
 			return $interfaces;

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -50,7 +50,7 @@ class CoreSchemaFilters implements Hookable {
 		if ( false !== strpos( $config['name'], 'FormFieldConnection' ) || false !== strpos( $config['name'], 'QuizFieldConnection' ) ) {
 			$interfaces = array_filter(
 				$interfaces,
-				function( $interface ) {
+				function ( $interface ) {
 					return ! in_array( $interface, [ 'Connection', 'Edge', 'OneToOneConnection' ], true );
 				}
 			);

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -50,7 +50,7 @@ class CoreSchemaFilters implements Hookable {
 		if ( false !== strpos( $config['name'], 'FormFieldConnection' ) || false !== strpos( $config['name'], 'QuizFieldConnection' ) ) {
 			$interfaces = array_filter(
 				$interfaces,
-				function ( $interface ) {
+				static function ( $interface ) {
 					return ! in_array( $interface, [ 'Connection', 'Edge', 'OneToOneConnection' ], true );
 				}
 			);

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -77,8 +77,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
 		 */
 		$query_args = apply_filters( 'graphql_gf_entries_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -100,7 +100,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public function should_execute() : bool {
 		$can_view = false;
@@ -246,7 +246,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 
-		return array_map( fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
+		return array_map( static fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
 
 	/**
@@ -325,7 +325,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return mixed Filter value.
 	 *
-	 * @throws UserError Field filters must have one value field.
+	 * @throws \GraphQL\Error\UserError Field filters must have one value field.
 	 */
 	private function get_field_filter_value( array $field_filter, string $operator ) {
 		$value_fields = $this->get_field_filter_value_fields( $field_filter );
@@ -407,7 +407,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get paging arguments for entry ID query.
 	 *
-	 * @throws UserError When using unsupported pagination.
+	 * @throws \GraphQL\Error\UserError When using unsupported pagination.
 	 */
 	private function get_paging() : array {
 		return [

--- a/src/Data/Connection/EntriesConnectionResolver.php
+++ b/src/Data/Connection/EntriesConnectionResolver.php
@@ -10,8 +10,8 @@
 
 namespace WPGraphQL\GF\Data\Connection;
 
-use GF_Query;
 use GFAPI;
+use GF_Query;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
@@ -48,22 +48,21 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		parent::__construct( $source, $args, $context, $info );
+
 		$this->offset_index = $this->get_query_offset_index();
 	}
 
 	/**
 	 * Return the name of the loader to be used with the connection resolver
-	 *
-	 * @return string
 	 */
-	public function get_loader_name() : string {
+	public function get_loader_name(): string {
 		return EntriesLoader::$name;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_query_args() : array {
+	public function get_query_args(): array {
 		$query_args = [
 			'form_ids'        => $this->get_form_ids(),
 			'search_criteria' => $this->get_search_criteria(),
@@ -88,7 +87,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_query() : GF_Query {
+	public function get_query(): GF_Query {
 		$form_ids        = $this->query_args['form_ids'];
 		$search_criteria = $this->query_args['search_criteria'];
 		$sorting         = $this->query_args['sorting'];
@@ -102,7 +101,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public function should_execute() : bool {
+	public function should_execute(): bool {
 		$can_view = false;
 
 		if (
@@ -140,7 +139,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_ids_from_query() : array {
+	public function get_ids_from_query(): array {
 		$ids = $this->query->get_ids() ?: [];
 
 		// If we're going backwards, we need to reverse the array.
@@ -185,7 +184,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_cursor_for_node( $id ) : string {
+	protected function get_cursor_for_node( $id ): string {
 		// The GF_Query offset index is based on the original sort order.
 		$nodes = ! empty( $this->args['last'] ) ? array_reverse( $this->nodes, true ) : $this->nodes;
 
@@ -197,7 +196,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Gets the array index for offsetting GF_Query.
 	 */
-	public function get_query_offset_index() : int {
+	public function get_query_offset_index(): int {
 		$offset_index = 0;
 
 		if ( ! empty( $this->args['first'] ) ) {
@@ -222,7 +221,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @param string $cursor .
 	 */
-	protected function parse_cursor( string $cursor ) : array {
+	protected function parse_cursor( string $cursor ): array {
 		$decoded     = base64_decode( $cursor ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$current_loc = explode( ':', $decoded );
 
@@ -246,7 +245,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 
-		return array_map( static fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
+		return array_map( static fn ( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
 
 	/**
@@ -254,7 +253,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	private function get_search_criteria() : array {
+	private function get_search_criteria(): array {
 		$search_criteria = $this->apply_status_to_search_criteria( [] );
 
 		if ( ! empty( $this->args['where']['dateFilters']['startDate'] ) ) {
@@ -281,7 +280,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * @param array $search_criteria The search criteria for the entry Ids.
 	 * @return array
 	 */
-	private function apply_status_to_search_criteria( array $search_criteria ) : array {
+	private function apply_status_to_search_criteria( array $search_criteria ): array {
 		$status = $this->args['where']['status'] ?? EntryStatusEnum::ACTIVE; // Default to active entries.
 
 		// For all entries, don't add a 'status' value to search criteria.
@@ -300,7 +299,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * @param array $field_filters .
 	 * @return array
 	 */
-	private function format_field_filters( array $field_filters ) : array {
+	private function format_field_filters( array $field_filters ): array {
 		return array_reduce(
 			$field_filters,
 			function ( $field_filters, $field_filter ) {
@@ -354,9 +353,8 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * Returns whether field filter should be limited to a single value.
 	 *
 	 * @param string $operator Operator.
-	 * @return boolean
 	 */
-	private function should_field_filter_be_limited_to_single_value( string $operator ) : bool {
+	private function should_field_filter_be_limited_to_single_value( string $operator ): bool {
 		return in_array( $operator, self::OPERATORS_TO_LIMIT, true );
 	}
 
@@ -366,11 +364,11 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 * @param array $field_filter .
 	 * @return array
 	 */
-	private function get_field_filter_value_fields( array $field_filter ) : array {
+	private function get_field_filter_value_fields( array $field_filter ): array {
 		return array_values(
 			array_filter(
 				[ 'stringValues', 'intValues', 'floatValues', 'boolValues' ],
-				static function ( $value_field ) use ( $field_filter ) : bool {
+				static function ( $value_field ) use ( $field_filter ): bool {
 					return ! empty( $field_filter[ $value_field ] );
 				}
 			)
@@ -382,7 +380,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	private function get_sort() : array {
+	private function get_sort(): array {
 		// Set default sort direction.
 		$sort = [
 			'direction' => 'DESC',
@@ -409,7 +407,7 @@ class EntriesConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @throws \GraphQL\Error\UserError When using unsupported pagination.
 	 */
-	private function get_paging() : array {
+	private function get_paging(): array {
 		return [
 			'offset'    => $this->get_query_offset_index(),
 			'page_size' => $this->get_query_amount() + 1, // overfetch for prev/next.

--- a/src/Data/Connection/FormFieldsConnectionResolver.php
+++ b/src/Data/Connection/FormFieldsConnectionResolver.php
@@ -18,7 +18,6 @@ use WPGraphQL\AppContext;
  * Class - FormFieldsConnectionResolver
  */
 class FormFieldsConnectionResolver {
-
 	/**
 	 * @var array<string, null>
 	 */
@@ -36,7 +35,7 @@ class FormFieldsConnectionResolver {
 	 *
 	 * @param array $data array of form fields.
 	 */
-	public static function prepare_data( array $data ) : array {
+	public static function prepare_data( array $data ): array {
 		foreach ( $data as &$field ) {
 			// Set layoutGridColumnSpan to int.
 			$field->layoutGridColumnSpan = empty( $field->layoutGridColumnSpan ) ? null : (int) $field->layoutGridColumnSpan;
@@ -108,7 +107,7 @@ class FormFieldsConnectionResolver {
 	 *
 	 * @return array
 	 */
-	private static function get_address_input_keys() : array {
+	private static function get_address_input_keys(): array {
 		return [
 			'street',
 			'lineTwo',
@@ -124,7 +123,7 @@ class FormFieldsConnectionResolver {
 	 *
 	 * @return array
 	 */
-	private static function get_name_input_keys() : array {
+	private static function get_name_input_keys(): array {
 		return [
 			'prefix',
 			'first',
@@ -141,7 +140,7 @@ class FormFieldsConnectionResolver {
 		 * @param array $args .
 		 * @return array
 		 */
-	private static function filter_form_fields_by_connection_args( $fields, $args ) : array {
+	private static function filter_form_fields_by_connection_args( $fields, $args ): array {
 		if ( isset( $args['where']['ids'] ) ) {
 			if ( ! is_array( $args['where']['ids'] ) ) {
 				$args['where']['ids'] = [ $args['where']['ids'] ];

--- a/src/Data/Connection/FormFieldsConnectionResolver.php
+++ b/src/Data/Connection/FormFieldsConnectionResolver.php
@@ -73,12 +73,12 @@ class FormFieldsConnectionResolver {
 	/**
 	 * The connection resolve method.
 	 *
-	 * @param mixed       $source  The object the connection is coming from.
-	 * @param array       $args    Array of args to be passed down to the resolve method.
-	 * @param AppContext  $context The AppContext object to be passed down.
-	 * @param ResolveInfo $info    The ResolveInfo object.
+	 * @param mixed                                $source  The object the connection is coming from.
+	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|Deferred
+	 * @return mixed|array|\WPGraphQL\GF\Data\Connection\Deferred
 	 */
 	public static function resolve( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		if ( ! is_array( $source ) || empty( $source ) ) {

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -12,8 +12,6 @@ namespace WPGraphQL\GF\Data\Connection;
 
 use GFAPI;
 use GraphQL\Error\UserError;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Type\Enum\FormStatusEnum;
@@ -62,7 +60,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError When using `formIds` and `status` together.
+	 * @throws \GraphQL\Error\UserError When using `formIds` and `status` together.
 	 */
 	public function get_query_args() : array {
 		/**
@@ -84,8 +82,8 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 		 * @param array       $query_args The args that will be passed to the WP_Query
 		 * @param mixed       $source     The source that's passed down the GraphQL queries
 		 * @param array       $args       The inputArgs on the field
-		 * @param AppContext  $context    The AppContext passed down the GraphQL tree
-		 * @param ResolveInfo $info       The ResolveInfo passed down the GraphQL tree
+		 * @param \WPGraphQL\AppContext $context The AppContext passed down the GraphQL tree
+		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the GraphQL tree
 		 */
 		$query_args = apply_filters( 'graphql_gf_forms_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 
@@ -161,7 +159,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 
-		return array_map( fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
+		return array_map( static fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
 
 
@@ -203,7 +201,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * Get sort argument for forms ID query.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	private function get_sort() : array {
 		$sort = [

--- a/src/Data/Connection/FormsConnectionResolver.php
+++ b/src/Data/Connection/FormsConnectionResolver.php
@@ -25,14 +25,14 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function should_execute() : bool {
+	public function should_execute(): bool {
 		return true;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_loader_name() : string {
+	public function get_loader_name(): string {
 		return FormsLoader::$name;
 	}
 
@@ -62,7 +62,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @throws \GraphQL\Error\UserError When using `formIds` and `status` together.
 	 */
-	public function get_query_args() : array {
+	public function get_query_args(): array {
 		/**
 		 * Throw error if trying to filter `where.formIds` by `where.status`.
 		 */
@@ -95,7 +95,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_query() : array {
+	public function get_query(): array {
 		$form_ids    = $this->query_args['form_ids'];
 		$active      = $this->query_args['status']['active'];
 		$sort_column = $this->query_args['sort']['key'];
@@ -159,16 +159,15 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 			$this->args['where']['formIds'] = [ $this->args['where']['formIds'] ];
 		}
 
-		return array_map( static fn( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
+		return array_map( static fn ( $id ) => Utils::get_form_id_from_id( $id ), $this->args['where']['formIds'] );
 	}
-
 
 	/**
 	 * Gets form status from query.
 	 *
 	 * @return array
 	 */
-	private function get_form_status() : array {
+	private function get_form_status(): array {
 		$status = $this->args['where']['status'] ?? FormStatusEnum::ACTIVE;
 		if ( FormStatusEnum::INACTIVE === $status ) {
 			return [
@@ -203,7 +202,7 @@ class FormsConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	private function get_sort() : array {
+	private function get_sort(): array {
 		$sort = [
 			'key'       => '',
 			'direction' => 'DESC',

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -28,7 +28,7 @@ class EntryObjectMutation {
 	 *
 	 * @throws \Exception .
 	 */
-	public static function get_field_value_input( array $args, array $form, bool $is_draft, array $entry = null ) : FieldValueInput\AbstractFieldValueInput {
+	public static function get_field_value_input( array $args, array $form, bool $is_draft, array $entry = null ): FieldValueInput\AbstractFieldValueInput {
 		$field = GFUtils::get_field_by_id( $form, $args['id'] );
 
 		$input_type = $field->get_input_type();
@@ -113,9 +113,9 @@ class EntryObjectMutation {
 	 *
 	 * @param array $messages The Gravity Forms submission validation messages.
 	 */
-	public static function get_submission_errors( array $messages ) : array {
+	public static function get_submission_errors( array $messages ): array {
 		return array_map(
-			static function ( $id, $message ) : array {
+			static function ( $id, $message ): array {
 				return [
 					'id'      => $id,
 					'message' => $message,
@@ -131,7 +131,7 @@ class EntryObjectMutation {
 	 *
 	 * @param array $payload the submission response.
 	 */
-	public static function get_submission_confirmation( array $payload ) : ?array {
+	public static function get_submission_confirmation( array $payload ): ?array {
 		if ( empty( $payload['confirmation_type'] ) ) {
 			return null;
 		}
@@ -148,7 +148,7 @@ class EntryObjectMutation {
 	 *
 	 * @param array $field_values .
 	 * */
-	public static function rename_field_names_for_submission( array $field_values ) : array {
+	public static function rename_field_names_for_submission( array $field_values ): array {
 		$formatted = [];
 
 		foreach ( $field_values as $key => $value ) {
@@ -168,7 +168,7 @@ class EntryObjectMutation {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function initialize_files( array $form_fields, array $input_field_values, bool $save_as_draft ) : array {
+	public static function initialize_files( array $form_fields, array $input_field_values, bool $save_as_draft ): array {
 		$files = [];
 
 		// Loop through all the fields to see if there are any upload types.

--- a/src/Data/EntryObjectMutation.php
+++ b/src/Data/EntryObjectMutation.php
@@ -9,7 +9,6 @@
 namespace WPGraphQL\GF\Data;
 
 use Exception;
-use GF_Field;
 use GraphQL\Error\UserError;
 use WPGraphQL\GF\Data\FieldValueInput;
 use WPGraphQL\GF\Data\FieldValueInput\AbstractFieldValueInput;
@@ -27,7 +26,7 @@ class EntryObjectMutation {
 	 * @param bool  $is_draft If the mutation is for a draft entry.
 	 * @param array $entry The GF entry object. Used when updating.
 	 *
-	 * @throws Exception .
+	 * @throws \Exception .
 	 */
 	public static function get_field_value_input( array $args, array $form, bool $is_draft, array $entry = null ) : FieldValueInput\AbstractFieldValueInput {
 		$field = GFUtils::get_field_by_id( $form, $args['id'] );
@@ -95,7 +94,7 @@ class EntryObjectMutation {
 		 *
 		 * @param string $field_value_input_class  The FieldValueInput class to use. The referenced class must extend AbstractFieldValueInput.
 		 * @param array    $args The GraphQL input args for the form field.
-		 * @param GF_Field $field The current Gravity Forms field object.
+		 * @param \GF_Field $field The current Gravity Forms field object.
 		 * @param array $form The current Gravity Forms form object.
 		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
 		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
@@ -163,11 +162,11 @@ class EntryObjectMutation {
 	 * Initializes the globals needed for file uploads to work.
 	 * This prevents any notices about missing array keys.
 	 *
-	 * @param GF_Field[] $form_fields .
-	 * @param array      $input_field_values .
-	 * @param bool       $save_as_draft .
+	 * @param \GF_Field[] $form_fields .
+	 * @param array       $input_field_values .
+	 * @param bool        $save_as_draft .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function initialize_files( array $form_fields, array $input_field_values, bool $save_as_draft ) : array {
 		$files = [];
@@ -218,7 +217,7 @@ class EntryObjectMutation {
 					$temp_filename = 'input_' . $field->id . '_' . \GFCommon::random_str( 16 ) . '_' . $file['name'];
 					$target_file   = $target_dir . wp_basename( $temp_filename );
 					$is_success    = copy( $file['tmp_name'], $target_file );
-					if ( file_exists( $target_file ) ) {
+					if ( $is_success && file_exists( $target_file ) ) {
 						\GFFormsModel::set_permissions( $target_file );
 					}
 

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -32,7 +32,7 @@ class Factory {
 	 *
 	 * @return array Data loaders, with new ones added.
 	 */
-	public static function register_loaders( array $loaders, AppContext $context ) : array {
+	public static function register_loaders( array $loaders, AppContext $context ): array {
 		$loaders[ DraftEntriesLoader::$name ] = new DraftEntriesLoader( $context );
 		$loaders[ EntriesLoader::$name ]      = new EntriesLoader( $context );
 		$loaders[ FormsLoader::$name ]        = new FormsLoader( $context );
@@ -75,7 +75,7 @@ class Factory {
 	 *
 	 * @return int Max query amount, possibly bumped.
 	 */
-	public static function set_max_query_amount( int $max_query_amount, $source, array $args, AppContext $context, ResolveInfo $info ) : int {
+	public static function set_max_query_amount( int $max_query_amount, $source, array $args, AppContext $context, ResolveInfo $info ): int {
 		if ( 'formFields' === $info->fieldName ) {
 			return (int) max( $max_query_amount, 600 );
 		}
@@ -89,7 +89,7 @@ class Factory {
 	 * @param int                   $id .
 	 * @param \WPGraphQL\AppContext $context .
 	 */
-	public static function resolve_form( $id, AppContext $context ) : ?Deferred {
+	public static function resolve_form( $id, AppContext $context ): ?Deferred {
 		return $context->get_loader( FormsLoader::$name )->load_deferred( $id );
 	}
 
@@ -115,7 +115,7 @@ class Factory {
 	 * @param string                $id .
 	 * @param \WPGraphQL\AppContext $context .
 	 */
-	public static function resolve_draft_entry( $id, AppContext $context ) : ?Deferred {
+	public static function resolve_draft_entry( $id, AppContext $context ): ?Deferred {
 		return $context->get_loader( DraftEntriesLoader::$name )->load_deferred( $id );
 	}
 
@@ -125,7 +125,7 @@ class Factory {
 	 * @param int                   $id .
 	 * @param \WPGraphQL\AppContext $context .
 	 */
-	public static function resolve_entry( $id, AppContext $context ) : ?Deferred {
+	public static function resolve_entry( $id, AppContext $context ): ?Deferred {
 		return $context->get_loader( EntriesLoader::$name )->load_deferred( $id );
 	}
 

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -27,8 +27,8 @@ class Factory {
 	/**
 	 * Registers loaders to AppContext.
 	 *
-	 * @param array      $loaders Data loaders.
-	 * @param AppContext $context App context.
+	 * @param array                 $loaders Data loaders.
+	 * @param \WPGraphQL\AppContext $context App context.
 	 *
 	 * @return array Data loaders, with new ones added.
 	 */
@@ -67,11 +67,11 @@ class Factory {
 	/**
 	 * Bump max query amount to account for forms with many fields.
 	 *
-	 * @param int         $max_query_amount Max query amount.
-	 * @param mixed       $source     source passed down from the resolve tree.
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query.
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree.
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree.
+	 * @param int                                  $max_query_amount Max query amount.
+	 * @param mixed                                $source     source passed down from the resolve tree.
+	 * @param array                                $args       array of arguments input in the field as part of the GraphQL query.
+	 * @param \WPGraphQL\AppContext                $context Object containing app context that gets passed down the resolve tree.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Info about fields passed down the resolve tree.
 	 *
 	 * @return int Max query amount, possibly bumped.
 	 */
@@ -86,8 +86,8 @@ class Factory {
 	/**
 	 * Resolves the form object for the form ID specified.
 	 *
-	 * @param int        $id .
-	 * @param AppContext $context .
+	 * @param int                   $id .
+	 * @param \WPGraphQL\AppContext $context .
 	 */
 	public static function resolve_form( $id, AppContext $context ) : ?Deferred {
 		return $context->get_loader( FormsLoader::$name )->load_deferred( $id );
@@ -96,12 +96,12 @@ class Factory {
 	/**
 	 * Wrapper for the FormsConnectionResolver::resolve method.
 	 *
-	 * @param mixed       $source  The object the connection is coming from.
-	 * @param array       $args    Array of args to be passed down to the resolve method.
-	 * @param AppContext  $context The AppContext object to be passed down.
-	 * @param ResolveInfo $info    The ResolveInfo object.
+	 * @param mixed                                $source  The object the connection is coming from.
+	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|Deferred
+	 * @return mixed|array|\GraphQL\Deferred
 	 */
 	public static function resolve_forms_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new FormsConnectionResolver( $source, $args, $context, $info );
@@ -112,8 +112,8 @@ class Factory {
 	/**
 	 * Resolves the entry object for the entry ID specified.
 	 *
-	 * @param string     $id .
-	 * @param AppContext $context .
+	 * @param string                $id .
+	 * @param \WPGraphQL\AppContext $context .
 	 */
 	public static function resolve_draft_entry( $id, AppContext $context ) : ?Deferred {
 		return $context->get_loader( DraftEntriesLoader::$name )->load_deferred( $id );
@@ -122,8 +122,8 @@ class Factory {
 	/**
 	 * Resolves the entry object for the entry ID specified.
 	 *
-	 * @param int        $id .
-	 * @param AppContext $context .
+	 * @param int                   $id .
+	 * @param \WPGraphQL\AppContext $context .
 	 */
 	public static function resolve_entry( $id, AppContext $context ) : ?Deferred {
 		return $context->get_loader( EntriesLoader::$name )->load_deferred( $id );
@@ -132,12 +132,12 @@ class Factory {
 	/**
 	 * Wrapper for the EntriesConnectionResolver::resolve method.
 	 *
-	 * @param mixed       $source  The object the connection is coming from.
-	 * @param array       $args    Array of args to be passed down to the resolve method.
-	 * @param AppContext  $context The AppContext object to be passed down.
-	 * @param ResolveInfo $info    The ResolveInfo object.
+	 * @param mixed                                $source  The object the connection is coming from.
+	 * @param array                                $args    Array of args to be passed down to the resolve method.
+	 * @param \WPGraphQL\AppContext                $context The AppContext object to be passed down.
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo object.
 	 *
-	 * @return mixed|array|Deferred
+	 * @return mixed|array|\GraphQL\Deferred
 	 */
 	public static function resolve_entries_connection( $source, array $args, AppContext $context, ResolveInfo $info ) {
 		$resolver = new EntriesConnectionResolver( $source, $args, $context, $info );

--- a/src/Data/FieldValueInput/AbstractFieldValueInput.php
+++ b/src/Data/FieldValueInput/AbstractFieldValueInput.php
@@ -167,12 +167,12 @@ abstract class AbstractFieldValueInput {
 	 *
 	 * E.g. `nameValues`.
 	 */
-	abstract protected function get_field_name() : string;
+	abstract protected function get_field_name(): string;
 
 	/**
 	 * Checks whether the input values submitted to the mutation are using the correct field value input for the Gravity Forms field type.
 	 */
-	protected function is_valid_input_type() : bool {
+	protected function is_valid_input_type(): bool {
 		$is_valid = false;
 
 		$key = $this->field_name;
@@ -210,7 +210,7 @@ abstract class AbstractFieldValueInput {
 	 *
 	 * @param array $errors .
 	 */
-	public function validate_value( array &$errors ) : void {
+	public function validate_value( array &$errors ): void {
 		$this->field->validate( $this->value, $this->form );
 
 		if ( ! empty( $this->field->failed_validation ) ) {
@@ -226,7 +226,7 @@ abstract class AbstractFieldValueInput {
 	 *
 	 * @param array $field_values the existing field values array.
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values[ $this->field->id ] = $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/AbstractFieldValueInput.php
+++ b/src/Data/FieldValueInput/AbstractFieldValueInput.php
@@ -33,7 +33,7 @@ abstract class AbstractFieldValueInput {
 	/**
 	 * The Gravity Forms field object.
 	 *
-	 * @var GF_Field
+	 * @var \GF_Field
 	 */
 	protected GF_Field $field;
 
@@ -78,10 +78,10 @@ abstract class AbstractFieldValueInput {
 	 * @param array      $input_args The GraphQL input args for the form field.
 	 * @param array      $form The current Gravity Forms form object.
 	 * @param bool       $is_draft Whether the mutation is handling a Draft Entry.
-	 * @param GF_Field   $field The current Gravity Forms field object.
+	 * @param \GF_Field  $field The current Gravity Forms field object.
 	 * @param array|null $entry The current Gravity Forms entry object.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public function __construct( array $input_args, array $form, bool $is_draft, GF_Field $field = null, array $entry = null ) {
 		$this->input_args = $input_args;
@@ -94,7 +94,7 @@ abstract class AbstractFieldValueInput {
 		 * Filters the accepted GraphQL input value key for the form field.
 		 *
 		 * @param string $name The GraphQL input value name to use. E.g. `nameValues`.
-		 * @param GF_Field $field The current Gravity Forms field object.
+		 * @param \GF_Field $field The current Gravity Forms field object.
 		 * @param array $form The current Gravity Forms form object.
 		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
 		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
@@ -123,7 +123,7 @@ abstract class AbstractFieldValueInput {
 		 * Filters the GraphQL input args for the field value input.
 		 *
 		 * @param array|string $args field value input args.
-		 * @param GF_Field $field The current Gravity Forms field object.
+		 * @param \GF_Field $field The current Gravity Forms field object.
 		 * @param array $form The current Gravity Forms form object.
 		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
 		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).
@@ -144,7 +144,7 @@ abstract class AbstractFieldValueInput {
 		 *
 		 * @param array|string $prepared_field_value The field value formatted in a way Gravity Forms can understand.
 		 * @param array|string $args field value input args.
-		 * @param GF_Field $field The current Gravity Forms field object.
+		 * @param \GF_Field $field The current Gravity Forms field object.
 		 * @param array $form The current Gravity Forms form object.
 		 * @param array|null $entry The current Gravity Forms entry object. Only available when using update (`gfUpdateEntry`, `gfUpdateDraftEntry`) mutations.
 		 * @param bool $is_draft_mutation Whether the mutation is handling a Draft Entry (`gfUpdateDraftEntry`, or `gfSubmitForm` when `saveAsDraft` is `true`).

--- a/src/Data/FieldValueInput/AddressValuesInput.php
+++ b/src/Data/FieldValueInput/AddressValuesInput.php
@@ -29,7 +29,7 @@ class AddressValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'addressValues';
 	}
 
@@ -52,7 +52,7 @@ class AddressValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values += $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/CaptchaValueInput.php
+++ b/src/Data/FieldValueInput/CaptchaValueInput.php
@@ -47,5 +47,7 @@ class CaptchaValueInput extends AbstractFieldValueInput {
 	 *
 	 * Recaptchas are validated using the $_POST object, not in the submission values.
 	 */
-	public function add_value_to_submission( array &$field_values ): void {}
+	public function add_value_to_submission( array &$field_values ): void {
+		// noop.
+	}
 }

--- a/src/Data/FieldValueInput/CaptchaValueInput.php
+++ b/src/Data/FieldValueInput/CaptchaValueInput.php
@@ -38,7 +38,7 @@ class CaptchaValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'value';
 	}
 
@@ -47,5 +47,5 @@ class CaptchaValueInput extends AbstractFieldValueInput {
 	 *
 	 * Recaptchas are validated using the $_POST object, not in the submission values.
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {}
+	public function add_value_to_submission( array &$field_values ): void {}
 }

--- a/src/Data/FieldValueInput/CheckboxValuesInput.php
+++ b/src/Data/FieldValueInput/CheckboxValuesInput.php
@@ -39,7 +39,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function prepare_value() {
 		$values_to_save = array_reduce(

--- a/src/Data/FieldValueInput/CheckboxValuesInput.php
+++ b/src/Data/FieldValueInput/CheckboxValuesInput.php
@@ -32,7 +32,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'checkboxValues';
 	}
 
@@ -44,7 +44,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	protected function prepare_value() {
 		$values_to_save = array_reduce(
 			$this->field->inputs,
-			static function ( array $values_to_save, array $input ) : array {
+			static function ( array $values_to_save, array $input ): array {
 				// Initialize all inputs to an empty string.
 				$values_to_save[ $input['id'] ] = '';
 
@@ -81,7 +81,7 @@ class CheckboxValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values += $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/ConsentValueInput.php
+++ b/src/Data/FieldValueInput/ConsentValueInput.php
@@ -31,7 +31,7 @@ class ConsentValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'value';
 	}
 
@@ -51,7 +51,7 @@ class ConsentValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values += $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/EmailValuesInput.php
+++ b/src/Data/FieldValueInput/EmailValuesInput.php
@@ -29,7 +29,7 @@ class EmailValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'emailValues';
 	}
 
@@ -54,7 +54,7 @@ class EmailValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		// Normal email fields are stored under their field id.
 		$field_values[ $this->field->id ] = $this->value[0];
 

--- a/src/Data/FieldValueInput/FileUploadValuesInput.php
+++ b/src/Data/FieldValueInput/FileUploadValuesInput.php
@@ -25,7 +25,7 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'fileUploadValues';
 	}
 
@@ -63,7 +63,7 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	 *
 	 * @param array $field_values.
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		if ( empty( $this->entry ) || $this->is_draft || ! empty( $this->field->multipleFields ) ) {
 			return;
 		}
@@ -74,5 +74,4 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 
 		$field_values[ $this->field->id ] = $this->field->get_value_save_entry( $value, $this->form, $input_name, $this->entry['id'] ?? null, $this->entry );
 	}
-
 }

--- a/src/Data/FieldValueInput/FileUploadValuesInput.php
+++ b/src/Data/FieldValueInput/FileUploadValuesInput.php
@@ -8,8 +8,6 @@
 
 namespace WPGraphQL\GF\Data\FieldValueInput;
 
-use GFFormsModel;
-use GF_Field_FileUpload;
 use GraphQL\Error\UserError;
 use WPGraphQL\GF\Utils\Utils;
 
@@ -34,7 +32,7 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError
+	 * @throws \GraphQL\Error\UserError
 	 */
 	protected function prepare_value() {
 		// Draft entries don't upload files.

--- a/src/Data/FieldValueInput/ImageValuesInput.php
+++ b/src/Data/FieldValueInput/ImageValuesInput.php
@@ -8,9 +8,7 @@
 
 namespace WPGraphQL\GF\Data\FieldValueInput;
 
-use GraphQL\Error\UserError;
 use GF_Field;
-use GF_Field_Post_Image;
 /**
  * Class - ImageValuesInput
  */
@@ -39,7 +37,7 @@ class ImageValuesInput extends FileUploadValuesInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError
+	 * @throws \GraphQL\Error\UserError
 	 */
 	protected function prepare_value() {
 		$value      = $this->args;

--- a/src/Data/FieldValueInput/ImageValuesInput.php
+++ b/src/Data/FieldValueInput/ImageValuesInput.php
@@ -23,7 +23,7 @@ class ImageValuesInput extends FileUploadValuesInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'imageValues';
 	}
 
@@ -55,6 +55,7 @@ class ImageValuesInput extends FileUploadValuesInput {
 		 * This is a crude workaround until AspectMock is updated to support PHP 8.
 		 */
 		parent::prepare_value();
+
 		$url        = $this->field->get_single_file_value( $this->form['id'], 'input_' . $this->field->id );
 		$url        = $url ?: $prev_value[0] ?? null;
 		$this->args = $value;
@@ -84,7 +85,7 @@ class ImageValuesInput extends FileUploadValuesInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		if ( ! $this->is_draft && empty( $this->entry ) ) {
 			$field_values += $this->value;
 		} else {

--- a/src/Data/FieldValueInput/ListValuesInput.php
+++ b/src/Data/FieldValueInput/ListValuesInput.php
@@ -38,7 +38,7 @@ class ListValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function prepare_value() {
 		$value = $this->args;

--- a/src/Data/FieldValueInput/ListValuesInput.php
+++ b/src/Data/FieldValueInput/ListValuesInput.php
@@ -31,7 +31,7 @@ class ListValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'listValues';
 	}
 

--- a/src/Data/FieldValueInput/NameValuesInput.php
+++ b/src/Data/FieldValueInput/NameValuesInput.php
@@ -29,7 +29,7 @@ class NameValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'nameValues';
 	}
 
@@ -51,7 +51,7 @@ class NameValuesInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values += $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/ProductValueInput.php
+++ b/src/Data/FieldValueInput/ProductValueInput.php
@@ -32,7 +32,7 @@ class ProductValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'productValues';
 	}
 
@@ -41,7 +41,7 @@ class ProductValueInput extends AbstractFieldValueInput {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected function is_valid_input_type() : bool {
+	protected function is_valid_input_type(): bool {
 		$is_valid = false;
 
 		// Calculation fields need a quantity and price.
@@ -112,7 +112,7 @@ class ProductValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function add_value_to_submission( array &$field_values ) : void {
+	public function add_value_to_submission( array &$field_values ): void {
 		$field_values += $this->value;
 	}
 }

--- a/src/Data/FieldValueInput/ProductValueInput.php
+++ b/src/Data/FieldValueInput/ProductValueInput.php
@@ -39,7 +39,7 @@ class ProductValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function is_valid_input_type() : bool {
 		$is_valid = false;

--- a/src/Data/FieldValueInput/ValueInput.php
+++ b/src/Data/FieldValueInput/ValueInput.php
@@ -23,14 +23,14 @@ class ValueInput extends AbstractFieldValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'value';
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function prepare_value() : string {
+	protected function prepare_value(): string {
 		// Handle choices with price.
 		if ( ! empty( $this->field->enablePrice ) && false === strpos( $this->args, '|' ) ) {
 			$value_key  = ! empty( $this->field->enablePrice ) || ! empty( $this->field->enableChoiceValue ) ? 'value' : 'text';

--- a/src/Data/FieldValueInput/ValuesInput.php
+++ b/src/Data/FieldValueInput/ValuesInput.php
@@ -12,11 +12,10 @@ namespace WPGraphQL\GF\Data\FieldValueInput;
  * Class - ValuesInput
  */
 class ValuesInput extends AbstractFieldValueInput {
-
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'values';
 	}
 }

--- a/src/Data/Loader/DraftEntriesLoader.php
+++ b/src/Data/Loader/DraftEntriesLoader.php
@@ -29,7 +29,7 @@ class DraftEntriesLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_model( $entry, $key ) : DraftEntry {
+	protected function get_model( $entry, $key ): DraftEntry {
 		return new DraftEntry( $entry, $key );
 	}
 

--- a/src/Data/Loader/DraftEntriesLoader.php
+++ b/src/Data/Loader/DraftEntriesLoader.php
@@ -10,7 +10,6 @@
 
 namespace WPGraphQL\GF\Data\Loader;
 
-use Exception;
 use GFFormsModel;
 use GraphQL\Deferred;
 use WPGraphQL\Data\Loader\AbstractDataLoader;
@@ -65,7 +64,7 @@ class DraftEntriesLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws Exception .
+	 * @throws \Exception .
 	 */
 	public function load_deferred( $database_id ) {
 		if ( empty( $database_id ) ) {

--- a/src/Data/Loader/EntriesLoader.php
+++ b/src/Data/Loader/EntriesLoader.php
@@ -28,7 +28,7 @@ class EntriesLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_model( $entry, $key ) : SubmittedEntry {
+	protected function get_model( $entry, $key ): SubmittedEntry {
 		return new SubmittedEntry( $entry );
 	}
 

--- a/src/Data/Loader/FormsLoader.php
+++ b/src/Data/Loader/FormsLoader.php
@@ -28,7 +28,7 @@ class FormsLoader extends AbstractDataLoader {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_model( $entry, $key ) : Form {
+	protected function get_model( $entry, $key ): Form {
 		return new Form( $entry );
 	}
 

--- a/src/Extensions/Extensions.php
+++ b/src/Extensions/Extensions.php
@@ -22,7 +22,7 @@ class Extensions implements Hookable {
 	/**
 	 * Register Gravity Forms Extensions.
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		GFChainedSelects::register_hooks();
 		GFQuiz::register_hooks();
 		GFSignature::register_hooks();

--- a/src/Extensions/GFChainedSelects/Data/FieldValueInput/ChainedSelectValuesInput.php
+++ b/src/Extensions/GFChainedSelects/Data/FieldValueInput/ChainedSelectValuesInput.php
@@ -17,7 +17,7 @@ class ChainedSelectValuesInput extends CheckboxValuesInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function get_field_name() : string {
+	protected function get_field_name(): string {
 		return 'chainedSelectValues';
 	}
 }

--- a/src/Extensions/GFChainedSelects/GFChainedSelects.php
+++ b/src/Extensions/GFChainedSelects/GFChainedSelects.php
@@ -23,7 +23,7 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Hook extension into plugin.
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		if ( ! self::is_gf_chained_selects_enabled() ) {
 			return;
 		}
@@ -55,7 +55,7 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Returns whether Gravity Forms Signature is enabled.
 	 */
-	public static function is_gf_chained_selects_enabled() : bool {
+	public static function is_gf_chained_selects_enabled(): bool {
 		return class_exists( 'GFChainedSelects' );
 	}
 
@@ -64,7 +64,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $registered_classes .
 	 */
-	public static function enums( array $registered_classes ) : array {
+	public static function enums( array $registered_classes ): array {
 		$registered_classes[] = Enum\ChainedSelectFieldAlignmentEnum::class;
 		return $registered_classes;
 	}
@@ -74,7 +74,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $registered_classes .
 	 */
-	public static function inputs( array $registered_classes ) : array {
+	public static function inputs( array $registered_classes ): array {
 		$registered_classes[] = Input\ChainedSelectFieldInput::class;
 		return $registered_classes;
 	}
@@ -84,7 +84,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_settings( array $classes ) : array {
+	public static function form_field_settings( array $classes ): array {
 		$classes['chained_choices_setting']               = WPInterface\FieldSetting\FieldWithChainedChoices::class;
 		$classes['chained_selects_alignment_setting']     = WPInterface\FieldSetting\FieldWithChainedSelectsAlignment::class;
 		$classes['chained_selects_hide_inactive_setting'] = WPInterface\FieldSetting\FieldWithChainedSelectsHideInactive::class;
@@ -97,7 +97,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_setting_choices( array $classes ) : array {
+	public static function form_field_setting_choices( array $classes ): array {
 		$classes['chained_choices_setting'] = WPInterface\FieldChoiceSetting\ChoiceWithChainedChoices::class;
 
 		return $classes;
@@ -108,7 +108,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_setting_inputs( array $classes ) : array {
+	public static function form_field_setting_inputs( array $classes ): array {
 		$classes['chained_choices_setting'] = WPInterface\FieldInputSetting\InputWithChainedChoices::class;
 
 		return $classes;
@@ -121,7 +121,7 @@ class GFChainedSelects implements Hookable {
 	 * @param array     $args .
 	 * @param \GF_Field $field .
 	 */
-	public static function field_value_input( string $input_class, array $args, GF_Field $field ) : string {
+	public static function field_value_input( string $input_class, array $args, GF_Field $field ): string {
 		if ( 'chainedselect' === $field->get_input_type() ) {
 			$input_class = ChainedSelectValuesInput::class;
 		}
@@ -129,14 +129,13 @@ class GFChainedSelects implements Hookable {
 		return $input_class;
 	}
 
-
 	/**
 	 * Registers ChainedSelect field value.
 	 *
 	 * @param array     $fields .
 	 * @param \GF_Field $field .
 	 */
-	public static function field_value_fields( array $fields, GF_Field $field ) : array {
+	public static function field_value_fields( array $fields, GF_Field $field ): array {
 		if ( 'chainedselect' === $field->get_input_type() ) {
 			$fields = array_merge( $fields, ValueProperty::chained_select_values() );
 		}
@@ -149,7 +148,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $fields .
 	 */
-	public static function field_values_input_fields( array $fields ) : array {
+	public static function field_values_input_fields( array $fields ): array {
 		if ( ! isset( $fields['chainedSelectValues'] ) ) {
 			$fields['chainedSelectValues'] = [
 				'type'        => [ 'list_of' => Input\ChainedSelectFieldInput::$type ],
@@ -165,7 +164,7 @@ class GFChainedSelects implements Hookable {
 	 *
 	 * @param array $fields_to_map .
 	 */
-	public static function form_field_name( array $fields_to_map ) : array {
+	public static function form_field_name( array $fields_to_map ): array {
 		$fields_to_map['chainedselect'] = 'ChainedSelect';
 
 		return $fields_to_map;

--- a/src/Extensions/GFChainedSelects/GFChainedSelects.php
+++ b/src/Extensions/GFChainedSelects/GFChainedSelects.php
@@ -29,27 +29,27 @@ class GFChainedSelects implements Hookable {
 		}
 
 		// Register Enums.
-		add_filter( 'graphql_gf_registered_enum_classes', [ __CLASS__, 'enums' ] );
+		add_filter( 'graphql_gf_registered_enum_classes', [ self::class, 'enums' ] );
 
 		// Register Inputs.
-		add_filter( 'graphql_gf_registered_input_classes', [ __CLASS__, 'inputs' ] );
+		add_filter( 'graphql_gf_registered_input_classes', [ self::class, 'inputs' ] );
 
 		// Register Form Field Settings interfaces.
-		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ __CLASS__, 'form_field_settings' ] );
-		add_filter( 'graphql_gf_registered_form_field_setting_choice_classes', [ __CLASS__, 'form_field_setting_choices' ] );
-		add_filter( 'graphql_gf_registered_form_field_setting_input_classes', [ __CLASS__, 'form_field_setting_inputs' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ self::class, 'form_field_settings' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_choice_classes', [ self::class, 'form_field_setting_choices' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_input_classes', [ self::class, 'form_field_setting_inputs' ] );
 
 		// Register FieldValueInput.
-		add_filter( 'graphql_gf_field_value_input_class', [ __CLASS__, 'field_value_input' ], 10, 3 );
+		add_filter( 'graphql_gf_field_value_input_class', [ self::class, 'field_value_input' ], 10, 3 );
 
 		// Register field value property.
-		add_filter( 'graphql_gf_form_field_value_fields', [ __CLASS__, 'field_value_fields' ], 10, 2 );
+		add_filter( 'graphql_gf_form_field_value_fields', [ self::class, 'field_value_fields' ], 10, 2 );
 
 		// Register fieldValues input.
-		add_filter( 'graphql_gf_form_field_values_input_fields', [ __CLASS__, 'field_values_input_fields' ] );
+		add_filter( 'graphql_gf_form_field_values_input_fields', [ self::class, 'field_values_input_fields' ] );
 
 		// Map GF field name.
-		add_filter( 'graphql_gf_form_fields_name_map', [ __CLASS__, 'form_field_name' ] );
+		add_filter( 'graphql_gf_form_fields_name_map', [ self::class, 'form_field_name' ] );
 	}
 
 	/**
@@ -117,9 +117,9 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers the SignatureValuesInput class.
 	 *
-	 * @param string   $input_class .
-	 * @param array    $args .
-	 * @param GF_Field $field .
+	 * @param string    $input_class .
+	 * @param array     $args .
+	 * @param \GF_Field $field .
 	 */
 	public static function field_value_input( string $input_class, array $args, GF_Field $field ) : string {
 		if ( 'chainedselect' === $field->get_input_type() ) {
@@ -133,8 +133,8 @@ class GFChainedSelects implements Hookable {
 	/**
 	 * Registers ChainedSelect field value.
 	 *
-	 * @param array    $fields .
-	 * @param GF_Field $field .
+	 * @param array     $fields .
+	 * @param \GF_Field $field .
 	 */
 	public static function field_value_fields( array $fields, GF_Field $field ) : array {
 		if ( 'chainedselect' === $field->get_input_type() ) {

--- a/src/Extensions/GFChainedSelects/Type/Enum/ChainedSelectFieldAlignmentEnum.php
+++ b/src/Extensions/GFChainedSelects/Type/Enum/ChainedSelectFieldAlignmentEnum.php
@@ -28,14 +28,14 @@ class ChainedSelectFieldAlignmentEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Alignment of the dropdown fields.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'HORIZONTAL' => [
 				'description' => __( 'Horizontal alignment (in a row).', 'wp-graphql-gravity-forms' ),

--- a/src/Extensions/GFChainedSelects/Type/Enum/ChainedSelectFieldAlignmentEnum.php
+++ b/src/Extensions/GFChainedSelects/Type/Enum/ChainedSelectFieldAlignmentEnum.php
@@ -22,8 +22,8 @@ class ChainedSelectFieldAlignmentEnum extends AbstractEnum {
 	public static string $type = 'ChainedSelectFieldAlignmentEnum';
 
 	// Individual elements.
-	const HORIZONTAL = 'horizontal';
-	const VERTICAL   = 'vertical';
+	public const HORIZONTAL = 'horizontal';
+	public const VERTICAL   = 'vertical';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extensions/GFChainedSelects/Type/Input/ChainedSelectFieldInput.php
+++ b/src/Extensions/GFChainedSelects/Type/Input/ChainedSelectFieldInput.php
@@ -25,14 +25,14 @@ class ChainedSelectFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for a single ChainedSelect.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'inputId' => [
 				'type'        => 'Float',

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
@@ -33,7 +33,7 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ __CLASS__, 'add_fields_to_child_type' ], 10, 4 );
+		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ self::class, 'add_fields_to_child_type' ], 10, 4 );
 
 		parent::register_hooks();
 	}
@@ -53,10 +53,10 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array    $fields An array of GraphQL field configs.
-	 * @param string   $choice_name The name of the choice type.
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
+	 * @param array     $fields An array of GraphQL field configs.
+	 * @param string    $choice_name The name of the choice type.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings ) : array {
 		if (

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldChoiceSetting/ChoiceWithChainedChoices.php
@@ -41,7 +41,7 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isSelected' => [
 				'type'        => 'Boolean',
@@ -58,7 +58,7 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 	 * @param \GF_Field $field The Gravity Forms Field object.
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 */
-	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings ) : array {
+	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings ): array {
 		if (
 			! in_array( self::$field_setting, $settings, true )
 		) {
@@ -75,5 +75,4 @@ class ChoiceWithChainedChoices extends AbstractFieldChoiceSetting {
 		];
 		return $fields;
 	}
-
 }

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldInputSetting/InputWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldInputSetting/InputWithChainedChoices.php
@@ -31,7 +31,7 @@ class InputWithChainedChoices extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'name' => [
 				'type'        => 'String',

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
@@ -57,7 +57,7 @@ class FieldWithChainedChoices extends AbstractFieldSetting implements TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		// This setting is identical to `choices_setting` but for some reason exists independently.
 		return FieldWithChoicesSetting::get_fields();
 	}
@@ -65,7 +65,7 @@ class FieldWithChainedChoices extends AbstractFieldSetting implements TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithChoices::$type,
 			FieldWithInputs::$type,
@@ -77,7 +77,7 @@ class FieldWithChainedChoices extends AbstractFieldSetting implements TypeWithIn
 	 *
 	 * @param array $settings the GF Field settings.
 	 */
-	public static function add_setting( array $settings ) : array {
+	public static function add_setting( array $settings ): array {
 		if ( ! in_array( self::$field_setting, $settings, true ) ) {
 			$settings[] = self::$field_setting;
 		}

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedChoices.php
@@ -48,8 +48,8 @@ class FieldWithChainedChoices extends AbstractFieldSetting implements TypeWithIn
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_settings_with_choices', [ __CLASS__, 'add_setting' ], 10 );
-		add_filter( 'graphql_gf_form_field_settings_with_inputs', [ __CLASS__, 'add_setting' ], 10 );
+		add_filter( 'graphql_gf_form_field_settings_with_choices', [ self::class, 'add_setting' ], 10 );
+		add_filter( 'graphql_gf_form_field_settings_with_inputs', [ self::class, 'add_setting' ], 10 );
 
 		parent::register_hooks();
 	}

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedSelectsAlignment.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedSelectsAlignment.php
@@ -32,7 +32,7 @@ class FieldWithChainedSelectsAlignment extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'chainedSelectsAlignment' => [
 				'type'        => ChainedSelectFieldAlignmentEnum::$type,

--- a/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedSelectsHideInactive.php
+++ b/src/Extensions/GFChainedSelects/Type/WPInterface/FieldSetting/FieldWithChainedSelectsHideInactive.php
@@ -31,7 +31,7 @@ class FieldWithChainedSelectsHideInactive extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'shouldHideInactiveChoices' => [
 				'type'        => 'Boolean',

--- a/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
+++ b/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
@@ -18,12 +18,12 @@ class ValueProperty extends FieldValues {
 	/**
 	 * Get `values` property for Chained Select field.
 	 */
-	public static function chained_select_values() : array {
+	public static function chained_select_values(): array {
 		return [
 			'values' => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => __( 'ChainedSelect field value.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source, array $args, AppContext $context ) : ?array {
+				'resolve'     => static function ( $source, array $args, AppContext $context ): ?array {
 					if ( ! self::is_field_and_entry( $source, $context ) ) {
 						return null;
 					}

--- a/src/Extensions/GFQuiz/GFQuiz.php
+++ b/src/Extensions/GFQuiz/GFQuiz.php
@@ -9,8 +9,8 @@
 namespace WPGraphQL\GF\Extensions\GFQuiz;
 
 use WPGraphQL\GF\Extensions\GFQuiz\Type\Enum;
-use WPGraphQL\GF\Extensions\GFQuiz\Type\WPObject;
 use WPGraphQL\GF\Extensions\GFQuiz\Type\WPInterface;
+use WPGraphQL\GF\Extensions\GFQuiz\Type\WPObject;
 use WPGraphQL\GF\Interfaces\Hookable;
 use WPGraphQL\GF\Utils\Utils;
 
@@ -21,7 +21,7 @@ class GFQuiz implements Hookable {
 	/**
 	 * Hook extension into plugin.
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		if ( ! self::is_gf_quiz_enabled() ) {
 			return;
 		}
@@ -46,7 +46,7 @@ class GFQuiz implements Hookable {
 	/**
 	 * Returns whether Gravity Forms Quiz is enabled.
 	 */
-	public static function is_gf_quiz_enabled() : bool {
+	public static function is_gf_quiz_enabled(): bool {
 		return class_exists( 'GFQuiz' );
 	}
 
@@ -55,7 +55,7 @@ class GFQuiz implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function enums( array $classes ) : array {
+	public static function enums( array $classes ): array {
 		$classes[] = Enum\QuizFieldGradingTypeEnum::class;
 		$classes[] = Enum\QuizFieldTypeEnum::class;
 
@@ -67,7 +67,7 @@ class GFQuiz implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_settings( array $classes ) : array {
+	public static function form_field_settings( array $classes ): array {
 		$classes['gquiz-setting-choices']                 = WPInterface\FieldSetting\FieldWithQuizChoices::class;
 		$classes['gquiz-setting-question']                = WPInterface\FieldSetting\FieldWithQuizQuestion::class;
 		$classes['gquiz-setting-randomize-quiz-choices']  = WPInterface\FieldSetting\FieldWithQuizRandomizeQuizChoices::class;
@@ -81,7 +81,7 @@ class GFQuiz implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_setting_choices( array $classes ) : array {
+	public static function form_field_setting_choices( array $classes ): array {
 		$classes['gquiz-setting-choices'] = WPInterface\FieldChoiceSetting\ChoiceWithQuizChoices::class;
 
 		return $classes;
@@ -92,7 +92,7 @@ class GFQuiz implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function objects( array $classes ) : array {
+	public static function objects( array $classes ): array {
 		$classes[] = WPObject\Entry\EntryQuizResults::class;
 		$classes[] = WPObject\Form\FormQuizGrades::class;
 		$classes[] = WPObject\Form\FormQuizConfirmation::class;
@@ -112,7 +112,7 @@ class GFQuiz implements Hookable {
 	 * @param array  $child_types An array of GF_Field::$type => GraphQL type names.
 	 * @param string $field_type The 'parent' GF_Field type.
 	 */
-	public static function field_child_types( array $child_types, string $field_type ) : array {
+	public static function field_child_types( array $child_types, string $field_type ): array {
 		if ( 'quiz' === $field_type ) {
 			$prefix = Utils::get_safe_form_field_type_name( $field_type );
 
@@ -133,7 +133,7 @@ class GFQuiz implements Hookable {
 	 * @param string $model_name .
 	 * @param array  $data .
 	 */
-	public static function form_model( $fields, string $model_name, $data ) : array {
+	public static function form_model( $fields, string $model_name, $data ): array {
 		if ( 'FormObject' === $model_name ) {
 			$fields['quiz'] = static fn (): ?array => empty( $data['gravityformsquiz'] ) ? null : $data['gravityformsquiz'];
 		}

--- a/src/Extensions/GFQuiz/GFQuiz.php
+++ b/src/Extensions/GFQuiz/GFQuiz.php
@@ -27,20 +27,20 @@ class GFQuiz implements Hookable {
 		}
 
 		// Register Enums.
-		add_filter( 'graphql_gf_registered_enum_classes', [ __CLASS__, 'enums' ] );
+		add_filter( 'graphql_gf_registered_enum_classes', [ self::class, 'enums' ] );
 
 		// Register Form Field Settings interfaces.
-		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ __CLASS__, 'form_field_settings' ] );
-		add_filter( 'graphql_gf_registered_form_field_setting_choice_classes', [ __CLASS__, 'form_field_setting_choices' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ self::class, 'form_field_settings' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_choice_classes', [ self::class, 'form_field_setting_choices' ] );
 
 		// Register Objects.
-		add_filter( 'graphql_gf_registered_object_classes', [ __CLASS__, 'objects' ] );
+		add_filter( 'graphql_gf_registered_object_classes', [ self::class, 'objects' ] );
 
 		// Register Child Field types.
-		add_filter( 'graphql_gf_form_field_child_types', [ __CLASS__, 'field_child_types' ], 10, 2 );
+		add_filter( 'graphql_gf_form_field_child_types', [ self::class, 'field_child_types' ], 10, 2 );
 
 		// Add quiz to Form Model.
-		add_filter( 'graphql_model_prepare_fields', [ __CLASS__, 'form_model' ], 10, 3 );
+		add_filter( 'graphql_model_prepare_fields', [ self::class, 'form_model' ], 10, 3 );
 	}
 
 	/**

--- a/src/Extensions/GFQuiz/Type/Enum/QuizFieldGradingTypeEnum.php
+++ b/src/Extensions/GFQuiz/Type/Enum/QuizFieldGradingTypeEnum.php
@@ -29,14 +29,14 @@ class QuizFieldGradingTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of grading system used by Gravity Forms Quiz. Default is `NONE`.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'NONE'     => [
 				'description' => __( 'No grading.', 'wp-graphql-gravity-forms' ),

--- a/src/Extensions/GFQuiz/Type/Enum/QuizFieldGradingTypeEnum.php
+++ b/src/Extensions/GFQuiz/Type/Enum/QuizFieldGradingTypeEnum.php
@@ -22,9 +22,9 @@ class QuizFieldGradingTypeEnum extends AbstractEnum {
 	public static string $type = 'QuizFieldGradingTypeEnum';
 
 	// Individual elements.
-	const NONE     = 'none';
-	const PASSFAIL = 'passfail';
-	const LETTER   = 'letter';
+	public const NONE     = 'none';
+	public const PASSFAIL = 'passfail';
+	public const LETTER   = 'letter';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extensions/GFQuiz/Type/Enum/QuizFieldTypeEnum.php
+++ b/src/Extensions/GFQuiz/Type/Enum/QuizFieldTypeEnum.php
@@ -22,9 +22,9 @@ class QuizFieldTypeEnum extends AbstractEnum {
 	public static string $type = 'QuizFieldTypeEnum';
 
 	// Individual elements.
-	const CHECKBOX = 'checkbox';
-	const RADIO    = 'radio';
-	const SELECT   = 'select';
+	public const CHECKBOX = 'checkbox';
+	public const RADIO    = 'radio';
+	public const SELECT   = 'select';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extensions/GFQuiz/Type/Enum/QuizFieldTypeEnum.php
+++ b/src/Extensions/GFQuiz/Type/Enum/QuizFieldTypeEnum.php
@@ -29,14 +29,14 @@ class QuizFieldTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Gravity Forms field type used to display the current Quiz Field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'CHECKBOX' => [
 				'description' => __( 'Gravity Forms `CheckboxField`.', 'wp-graphql-gravity-forms' ),

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldChoiceSetting/ChoiceWithQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldChoiceSetting/ChoiceWithQuizChoices.php
@@ -32,12 +32,12 @@ class ChoiceWithQuizChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isCorrect'     => [
 				'type'        => 'Boolean',
 				'description' => __( 'Indicates the choice item is the correct answer.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source['gquizIsCorrect'] ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source['gquizIsCorrect'] ),
 			],
 			'weight'        => [
 				'type'        => 'Float',

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
@@ -32,7 +32,7 @@ class FieldWithQuizChoices extends AbstractFieldSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_settings_with_choices', [ __CLASS__, 'add_setting' ], 10 );
+		add_filter( 'graphql_gf_form_field_settings_with_choices', [ self::class, 'add_setting' ], 10 );
 
 		parent::register_hooks();
 	}

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizChoices.php
@@ -36,15 +36,16 @@ class FieldWithQuizChoices extends AbstractFieldSetting {
 
 		parent::register_hooks();
 	}
+
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasWeightedScore' => [
 				'type'        => 'Boolean',
 				'description' => __( 'If this setting is disabled then the response will be awarded a score of 1 if correct and 0 if incorrect.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source->gquizWeightedScoreEnabled ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source->gquizWeightedScoreEnabled ),
 			],
 		];
 	}
@@ -54,7 +55,7 @@ class FieldWithQuizChoices extends AbstractFieldSetting {
 	 *
 	 * @param array $settings the GF Field settings.
 	 */
-	public static function add_setting( array $settings ) : array {
+	public static function add_setting( array $settings ): array {
 		if ( ! in_array( self::$field_setting, $settings, true ) ) {
 			$settings[] = self::$field_setting;
 		}

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizQuestion.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizQuestion.php
@@ -29,5 +29,4 @@ class FieldWithQuizQuestion extends FieldWithLabel {
 	 * @var string
 	 */
 	public static string $field_setting = 'gquiz-setting-question';
-
 }

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizRandomizeQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizRandomizeQuizChoices.php
@@ -31,12 +31,12 @@ class FieldWithQuizRandomizeQuizChoices extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'shouldRandomizeQuizChoices' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to randomize the order in which the answers are displayed to the user.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source->gquizEnableRandomizeQuizChoices ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source->gquizEnableRandomizeQuizChoices ),
 			],
 		];
 	}

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizShowAnswerExplanation.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldSetting/FieldWithQuizShowAnswerExplanation.php
@@ -31,17 +31,17 @@ class FieldWithQuizShowAnswerExplanation extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'answerExplanation'           => [
 				'type'        => 'String',
 				'description' => __( 'The explanation for the correct answer and/or incorrect answers.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : ?string => ! empty( $source->gquizAnswerExplanation ) ? $source->gquizAnswerExplanation : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source->gquizAnswerExplanation ) ? $source->gquizAnswerExplanation : null,
 			],
 			'shouldShowAnswerExplanation' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to show an answer explanation.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source->gquizShowAnswerExplanation ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source->gquizShowAnswerExplanation ),
 			],
 		];
 	}

--- a/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
@@ -33,48 +33,49 @@ class EntryQuizResults extends AbstractObject implements Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The quiz results for the entry. Requires Gravity Forms Quiz to be enabled.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'score'          => [
 				'type'        => 'Int',
 				'description' => __( 'The raw quiz score.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $root ) : ?int {
+				'resolve'     => static function ( $root ): ?int {
 					return $root['gquiz_score'] ?? null;
 				},
 			],
 			'percent'        => [
 				'type'        => 'Int',
 				'description' => __( 'The quiz score as a percent.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $root ) : ?int {
+				'resolve'     => static function ( $root ): ?int {
 					return $root['gquiz_percent'] ?? null;
 				},
 			],
 			'grade'          => [
 				'type'        => 'String',
 				'description' => __( 'The quiz score as a letter grade.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $root ) : ?string {
+				'resolve'     => static function ( $root ): ?string {
 					return $root['gquiz_grade'] ?? null;
 				},
 			],
 			'isPassingScore' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether the quiz score meets the assigned passing threshold.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $root ) : ?bool {
+				'resolve'     => static function ( $root ): ?bool {
 					return $root['gquiz_is_pass'] ?? null;
 				},
 			],
@@ -84,7 +85,7 @@ class EntryQuizResults extends AbstractObject implements Field {
 	/**
 	 * Register quizResults.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			SubmittedEntry::$type,
 			self::$field_name,

--- a/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Entry/EntryQuizResults.php
@@ -11,7 +11,6 @@ namespace WPGraphQL\GF\Extensions\GFQuiz\Type\WPObject\Entry;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - EntryQuizResults

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
@@ -37,27 +37,28 @@ class FormQuiz extends AbstractObject implements Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Quiz-specific settings that will affect ALL Quiz fields in the form.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'failConfirmation'               => [
 				'type'        => FormQuizConfirmation::$type,
 				'description' => __( 'The message to display if the quiz grade is below the Pass Percentage. Only used if grading is set to `PASSFAIL`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?array {
+				'resolve'     => static function ( $source ): ?array {
 					// Return null if the grading type is not PASSFAIL.
 					if ( isset( $source['grading'] ) && 'passfail' !== $source['grading'] ) {
 						return null;
@@ -92,7 +93,7 @@ class FormQuiz extends AbstractObject implements Field {
 			'hasLetterConfirmationMessage'   => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to display a confirmation message upon submission of the quiz form. Only used if `grading` is set to `LETTER`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?bool {
+				'resolve'     => static function ( $source ): ?bool {
 					// Return null if the grading type is not LETTER.
 					if ( isset( $source['grading'] ) && 'letter' !== $source['grading'] ) {
 						return null;
@@ -104,7 +105,7 @@ class FormQuiz extends AbstractObject implements Field {
 			'hasPassFailConfirmationMessage' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to display a confirmation message upon submission of the quiz form. Only used if grading is set to `PASSFAIL`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?bool {
+				'resolve'     => static function ( $source ): ?bool {
 					// Return null if the grading type is not PASSFAIL.
 					if ( isset( $source['grading'] ) && 'passfail' !== $source['grading'] ) {
 						return null;
@@ -121,7 +122,7 @@ class FormQuiz extends AbstractObject implements Field {
 			'letterConfirmation'             => [
 				'type'        => FormQuizConfirmation::$type,
 				'description' => __( 'The confirmation message to display if `grading` is set to `LETTER`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?array {
+				'resolve'     => static function ( $source ): ?array {
 					// Return null if the grading type is not LETTER.
 					if ( isset( $source['grading'] ) && 'letter' !== $source['grading'] ) {
 						return null;
@@ -136,14 +137,14 @@ class FormQuiz extends AbstractObject implements Field {
 			'maxScore'                       => [
 				'type'        => 'Float',
 				'description' => __( 'The maximum score for this form.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source, array $args, AppContext $context ) : ?float {
+				'resolve'     => static function ( $source, array $args, AppContext $context ): ?float {
 					return ( gf_quiz() )->get_max_score( $context->gfForm->form ) ?: null;
 				},
 			],
 			'passPercent'                    => [
 				'type'        => 'Int',
 				'description' => __( "The percentage score the user must equal or exceed to be considered to have 'passed.' Only used if `grading` is set to `PASSFAIL`.", 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?int {
+				'resolve'     => static function ( $source ): ?int {
 					// Return null if the grading type is not PASSFAIL.
 					if ( isset( $source['grading'] ) && 'passfail' !== $source['grading'] ) {
 						return null;
@@ -154,7 +155,7 @@ class FormQuiz extends AbstractObject implements Field {
 			'passConfirmation'               => [
 				'type'        => FormQuizConfirmation::$type,
 				'description' => __( 'The message to display if the quiz grade is above or equal to the Pass Percentage. Only used if grading is set to `PASSFAIL`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?array {
+				'resolve'     => static function ( $source ): ?array {
 					// Return null if the grading type is not PASSFAIL.
 					if ( isset( $source['grading'] ) && 'passfail' !== $source['grading'] ) {
 						return null;
@@ -171,14 +172,14 @@ class FormQuiz extends AbstractObject implements Field {
 	/**
 	 * Register quiz.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			Form::$type,
 			self::$field_name,
 			[
 				'type'        => static::$type,
 				'description' => __( 'Quiz-specific settings that will affect ALL Quiz fields in the form. Requires Gravity Forms Quiz addon.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source, array $args, AppContext $context ) : ?array {
+				'resolve'     => static function ( $source, array $args, AppContext $context ): ?array {
 					// FYI: If a user doesn't explicitly save the quiz settings on the backend, this will be null.
 					$context->gfForm = $source;
 					return empty( $source->quiz ) ? null : $source->quiz;

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
@@ -15,7 +15,6 @@ use WPGraphQL\GF\Extensions\GFQuiz\Type\Enum\QuizFieldGradingTypeEnum;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\WPObject\Form\Form;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - FormConfirmation

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizConfirmation.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizConfirmation.php
@@ -26,14 +26,14 @@ class FormQuizConfirmation extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Quiz Confirmation message data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isAutoformatted' => [
 				'type'        => 'Boolean',

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizGrades.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuizGrades.php
@@ -26,14 +26,14 @@ class FormQuizGrades extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The letter grades to be assigned based on the percentage score achieved. Only used if `grading` is set to `LETTER`.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'text'  => [
 				'type'        => 'String',

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -131,7 +131,7 @@ class QuizResults extends AbstractObject implements Field {
 	 */
 	protected static function get_quiz_results_data( array $form, array $results_config ): array {
 		if ( ! class_exists( 'GFResults' ) ) {
-			require_once GFCommon::get_base_path() . '/includes/addon/class-gf-results.php';
+			require_once GFCommon::get_base_path() . '/includes/addon/class-gf-results.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 		}
 
 		if ( isset( $results_config['callbacks']['filters'] ) ) {

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -17,7 +17,6 @@ use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\WPObject\Form\Form;
-use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - QuizResults

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -45,22 +45,23 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The quiz results for all entries.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'averagePercentage' => [
 				'type'        => 'Float',
@@ -100,7 +101,7 @@ class QuizResults extends AbstractObject implements Field {
 	/**
 	 * Register quizResults.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		$from_type = sprintf( '%1$sTo%2$sConnection', Form::$type, Entry::$type );
 
 		register_graphql_field(
@@ -128,7 +129,7 @@ class QuizResults extends AbstractObject implements Field {
 	 * @param array $form .
 	 * @param array $results_config the GFQuiz config array.
 	 */
-	protected static function get_quiz_results_data( array $form, array $results_config ) : array {
+	protected static function get_quiz_results_data( array $form, array $results_config ): array {
 		if ( ! class_exists( 'GFResults' ) ) {
 			require_once GFCommon::get_base_path() . '/includes/addon/class-gf-results.php';
 		}
@@ -150,7 +151,7 @@ class QuizResults extends AbstractObject implements Field {
 	 * @param array $data The Quiz Results data.
 	 * @param array $form .
 	 */
-	protected static function prepare_results_data( array $data, array $form ) : array {
+	protected static function prepare_results_data( array $data, array $form ): array {
 		if ( empty( $data['entry_count'] ) ) {
 			return [];
 		}
@@ -186,7 +187,7 @@ class QuizResults extends AbstractObject implements Field {
 	 *
 	 * @param array $score_frequencies the score frequences array. E.g. `[ $score => $count ]`.
 	 */
-	private static function map_score_frequencies( array $score_frequencies ) : array {
+	private static function map_score_frequencies( array $score_frequencies ): array {
 		return array_map(
 			static fn ( $score, $count) => [
 				'score' => $score,
@@ -202,7 +203,7 @@ class QuizResults extends AbstractObject implements Field {
 	 *
 	 * @param array $grade_frequencies the score frequences array. E.g. `[ $grade => $count ]`.
 	 */
-	private static function map_grade_frequencies( array $grade_frequencies ) : array {
+	private static function map_grade_frequencies( array $grade_frequencies ): array {
 		return array_map(
 			static fn ( $grade, $count) => [
 				'grade' => $grade,
@@ -220,15 +221,15 @@ class QuizResults extends AbstractObject implements Field {
 	 * @param array   $form .
 	 * @param integer $entry_count . The number of submitted entries.
 	 */
-	private static function map_field_data( array $field_data, array $form, int $entry_count ) : array {
+	private static function map_field_data( array $field_data, array $form, int $entry_count ): array {
 		return array_map(
-			static function ( $id, $data ) use ( $entry_count, $form ) : array {
+			static function ( $id, $data ) use ( $entry_count, $form ): array {
 				$field = GFAPI::get_field( $form, $id );
 				// Move the totals out of $data, since we  dont need them in the choice array.
 				$totals = $data['totals'];
 				unset( $data['totals'] );
 				$choice_counts = array_map(
-					static function ( $count, $value ) use ( $field ) : array {
+					static function ( $count, $value ) use ( $field ): array {
 						return [
 							'count' => $count,
 							'value' => $value,

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsChoiceCount.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsChoiceCount.php
@@ -24,14 +24,14 @@ class QuizResultsChoiceCount extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The response counts for individual quiz fields.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'count' => [
 				'type'        => 'Int',

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsFieldCount.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsFieldCount.php
@@ -36,7 +36,7 @@ class QuizResultsFieldCount extends AbstractObject implements TypeWithConnection
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connections() : array {
+	public static function get_connections(): array {
 		return [
 			'formField' => [
 				'toType'   => 'QuizField',
@@ -51,14 +51,14 @@ class QuizResultsFieldCount extends AbstractObject implements TypeWithConnection
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The quiz results summary for an individual quiz field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'choiceCounts'   => [
 				'type'        => [ 'list_of' => QuizResultsChoiceCount::$type ],

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsGradeCount.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsGradeCount.php
@@ -24,14 +24,14 @@ class QuizResultsGradeCount extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A quiz Grade and its count.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'count' => [
 				'type'        => 'Int',

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsScoreCount.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResultsScoreCount.php
@@ -24,14 +24,14 @@ class QuizResultsScoreCount extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A quiz score and its count.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'count' => [
 				'type'        => 'Int',

--- a/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
+++ b/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
@@ -8,8 +8,8 @@
 
 namespace WPGraphQL\GF\Extensions\GFSignature\Data\FieldValueInput;
 
-use GraphQL\Error\UserError;
 use GFCommon;
+use GraphQL\Error\UserError;
 use WPGraphQL\GF\Data\FieldValueInput\ValueInput;
 
 /**
@@ -26,7 +26,7 @@ class SignatureValuesInput extends ValueInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function prepare_value() : string {
+	protected function prepare_value(): string {
 		$value = $this->args;
 
 		$this->ensure_signatures_folder_exists();
@@ -51,7 +51,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected function ensure_signatures_folder_exists() : void {
+	protected function ensure_signatures_folder_exists(): void {
 		$folder = \GFSignature::get_signatures_folder();
 		$exists = wp_mkdir_p( $folder );
 
@@ -72,7 +72,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected function save_signature( string $signature ) : string {
+	protected function save_signature( string $signature ): string {
 		if ( '' === $signature ) {
 			return '';
 		}
@@ -101,7 +101,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @param string $prev_filename The file name of the image to delete.
 	 */
-	protected function delete_previous_signature_image( string $prev_filename = null ) : void {
+	protected function delete_previous_signature_image( string $prev_filename = null ): void {
 		if ( ! $prev_filename ) {
 			return;
 		}
@@ -119,7 +119,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @param string $signature_decoded Decoded png signature image data.
 	 */
-	protected function does_image_exceed_max_upload_size( string $signature_decoded ) : bool {
+	protected function does_image_exceed_max_upload_size( string $signature_decoded ): bool {
 		return strlen( $signature_decoded ) > wp_max_upload_size();
 	}
 
@@ -130,7 +130,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected function get_decoded_image_data( string $signature ) : string {
+	protected function get_decoded_image_data( string $signature ): string {
 		$error_message = __( 'An invalid signature image was provided. Image must be a base-64 encoded png.', 'wp-graphql-gravity-forms' );
 
 		$string_parts = explode( ';', $signature );

--- a/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
+++ b/src/Extensions/GFSignature/Data/FieldValueInput/SignatureValuesInput.php
@@ -49,7 +49,7 @@ class SignatureValuesInput extends ValueInput {
 	/**
 	 * Ensures the folder for storing signatures exists.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function ensure_signatures_folder_exists() : void {
 		$folder = \GFSignature::get_signatures_folder();
@@ -70,7 +70,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @return string $filename The filename of the saved signature image file.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function save_signature( string $signature ) : string {
 		if ( '' === $signature ) {
@@ -128,7 +128,7 @@ class SignatureValuesInput extends ValueInput {
 	 *
 	 * @param string $signature Base-64 encoded png signature image data.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected function get_decoded_image_data( string $signature ) : string {
 		$error_message = __( 'An invalid signature image was provided. Image must be a base-64 encoded png.', 'wp-graphql-gravity-forms' );

--- a/src/Extensions/GFSignature/GFSignature.php
+++ b/src/Extensions/GFSignature/GFSignature.php
@@ -27,12 +27,12 @@ class GFSignature implements Hookable {
 		}
 
 		// Register Enums.
-		add_filter( 'graphql_gf_registered_enum_classes', [ __CLASS__, 'enums' ] );
+		add_filter( 'graphql_gf_registered_enum_classes', [ self::class, 'enums' ] );
 		// Register Form Field Settings interfaces.
-		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ __CLASS__, 'form_field_settings' ] );
+		add_filter( 'graphql_gf_registered_form_field_setting_classes', [ self::class, 'form_field_settings' ] );
 
 		// Register FieldValueInput.
-		add_filter( 'graphql_gf_field_value_input_class', [ __CLASS__, 'field_value_input' ], 10, 3 );
+		add_filter( 'graphql_gf_field_value_input_class', [ self::class, 'field_value_input' ], 10, 3 );
 	}
 
 	/**
@@ -73,9 +73,9 @@ class GFSignature implements Hookable {
 	/**
 	 * Registers the SignatureValuesInput class.
 	 *
-	 * @param string   $input_class .
-	 * @param array    $args .
-	 * @param GF_Field $field .
+	 * @param string    $input_class .
+	 * @param array     $args .
+	 * @param \GF_Field $field .
 	 */
 	public static function field_value_input( string $input_class, array $args, GF_Field $field ) : string {
 		if ( 'signature' === $field->get_input_type() ) {

--- a/src/Extensions/GFSignature/GFSignature.php
+++ b/src/Extensions/GFSignature/GFSignature.php
@@ -11,8 +11,8 @@ namespace WPGraphQL\GF\Extensions\GFSignature;
 use GF_Field;
 use WPGraphQL\GF\Extensions\GFSignature\Data\FieldValueInput\SignatureValuesInput;
 use WPGraphQL\GF\Extensions\GFSignature\Type\Enum;
-use WPGraphQL\GF\Interfaces\Hookable;
 use WPGraphQL\GF\Extensions\GFSignature\Type\WPInterface;
+use WPGraphQL\GF\Interfaces\Hookable;
 
 /**
  * Class - GFSignature
@@ -21,7 +21,7 @@ class GFSignature implements Hookable {
 	/**
 	 * Hook extension into plugin.
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		if ( ! self::is_gf_signature_enabled() ) {
 			return;
 		}
@@ -38,7 +38,7 @@ class GFSignature implements Hookable {
 	/**
 	 * Returns whether Gravity Forms Signature is enabled.
 	 */
-	public static function is_gf_signature_enabled() : bool {
+	public static function is_gf_signature_enabled(): bool {
 		return class_exists( 'GFSignature' );
 	}
 
@@ -47,7 +47,7 @@ class GFSignature implements Hookable {
 	 *
 	 * @param array $registered_classes .
 	 */
-	public static function enums( array $registered_classes ) : array {
+	public static function enums( array $registered_classes ): array {
 		$registered_classes[] = Enum\SignatureFieldBorderStyleEnum::class;
 		$registered_classes[] = Enum\SignatureFieldBorderWidthEnum::class;
 		return $registered_classes;
@@ -58,7 +58,7 @@ class GFSignature implements Hookable {
 	 *
 	 * @param array $classes .
 	 */
-	public static function form_field_settings( array $classes ) : array {
+	public static function form_field_settings( array $classes ): array {
 		$classes['background_color_setting'] = WPInterface\FieldSetting\FieldWithBackgroundColor::class;
 		$classes['border_color_setting']     = WPInterface\FieldSetting\FieldWithBorderColor::class;
 		$classes['border_style_setting']     = WPInterface\FieldSetting\FieldWithBorderStyle::class;
@@ -77,12 +77,11 @@ class GFSignature implements Hookable {
 	 * @param array     $args .
 	 * @param \GF_Field $field .
 	 */
-	public static function field_value_input( string $input_class, array $args, GF_Field $field ) : string {
+	public static function field_value_input( string $input_class, array $args, GF_Field $field ): string {
 		if ( 'signature' === $field->get_input_type() ) {
 			$input_class = SignatureValuesInput::class;
 		}
 
 		return $input_class;
 	}
-
 }

--- a/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderStyleEnum.php
+++ b/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderStyleEnum.php
@@ -22,14 +22,14 @@ class SignatureFieldBorderStyleEnum extends AbstractEnum {
 	public static string $type = 'SignatureFieldBorderStyleEnum';
 
 	// Individual elements.
-	const DASHED = 'dashed';
-	const DOTTED = 'dotted';
-	const DOUBLE = 'double';
-	const GROOVE = 'groove';
-	const INSET  = 'inset';
-	const OUTSET = 'outset';
-	const RIDGE  = 'ridge';
-	const SOLID  = 'solid';
+	public const DASHED = 'dashed';
+	public const DOTTED = 'dotted';
+	public const DOUBLE = 'double';
+	public const GROOVE = 'groove';
+	public const INSET  = 'inset';
+	public const OUTSET = 'outset';
+	public const RIDGE  = 'ridge';
+	public const SOLID  = 'solid';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderStyleEnum.php
+++ b/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderStyleEnum.php
@@ -34,14 +34,14 @@ class SignatureFieldBorderStyleEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Border style to be used around the signature area.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'DOTTED' => [
 				'description' => __( 'A "dotted" border style.', 'wp-graphql-gravity-forms' ),

--- a/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderWidthEnum.php
+++ b/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderWidthEnum.php
@@ -30,14 +30,14 @@ class SignatureFieldBorderWidthEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Width of the border around the signature area.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'NONE'   => [
 				'description' => __( 'No border width.', 'wp-graphql-gravity-forms' ),

--- a/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderWidthEnum.php
+++ b/src/Extensions/GFSignature/Type/Enum/SignatureFieldBorderWidthEnum.php
@@ -22,10 +22,10 @@ class SignatureFieldBorderWidthEnum extends AbstractEnum {
 	public static string $type = 'SignatureFieldBorderWidthEnum';
 
 	// Individual elements.
-	const NONE   = '0';
-	const SMALL  = '1';
-	const MEDIUM = '2';
-	const LARGE  = '3';
+	public const NONE   = '0';
+	public const SMALL  = '1';
+	public const MEDIUM = '2';
+	public const LARGE  = '3';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBackgroundColor.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBackgroundColor.php
@@ -31,7 +31,7 @@ class FieldWithBackgroundColor extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'backgroundColor' => [
 				'type'        => 'String',

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderColor.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderColor.php
@@ -31,7 +31,7 @@ class FieldWithBorderColor extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'borderColor' => [
 				'type'        => 'String',

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderStyle.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderStyle.php
@@ -32,7 +32,7 @@ class FieldWithBorderStyle extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'borderStyle' => [
 				'type'        => SignatureFieldBorderStyleEnum::$type,

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderWidth.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBorderWidth.php
@@ -32,7 +32,7 @@ class FieldWithBorderWidth extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'borderWidth' => [
 				'type'        => SignatureFieldBorderWidthEnum::$type,

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBoxWidth.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithBoxWidth.php
@@ -31,7 +31,7 @@ class FieldWithBoxWidth extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'boxWidth' => [
 				'type'        => 'Int',

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithPenColor.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithPenColor.php
@@ -31,7 +31,7 @@ class FieldWithPenColor extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'penColor' => [
 				'type'        => 'String',

--- a/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithPenSize.php
+++ b/src/Extensions/GFSignature/Type/WPInterface/FieldSetting/FieldWithPenSize.php
@@ -31,7 +31,7 @@ class FieldWithPenSize extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'penSize' => [
 				'type'        => 'Int',

--- a/src/Extensions/WPGatsby/GravityFormsMonitor.php
+++ b/src/Extensions/WPGatsby/GravityFormsMonitor.php
@@ -31,7 +31,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	/**
 	 * The class constructor.
 	 *
-	 * @param ActionMonitor $action_monitor .
+	 * @param \WPGatsby\ActionMonitor\ActionMonitor $action_monitor .
 	 */
 	public function __construct( ActionMonitor $action_monitor ) {
 		self::$enabled_actions = Settings::get_enabled_actions();

--- a/src/Extensions/WPGatsby/GravityFormsMonitor.php
+++ b/src/Extensions/WPGatsby/GravityFormsMonitor.php
@@ -44,7 +44,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * @todo Trigger on delete entry, once filter is added.
 	 */
-	public function init() : void {
+	public function init(): void {
 		// Create form.
 		add_action( 'gform_post_form_duplicated', [ $this, 'after_duplicate_form' ], 10, 2 );
 		// Create or update form.
@@ -72,7 +72,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param string $action_name the name of the action defined in the settings.
 	 * @param array  $args the action config.
 	 */
-	public function log( string $action_name, array $args ) : void {
+	public function log( string $action_name, array $args ): void {
 		if ( ! in_array( $action_name, self::$enabled_actions, true ) ) {
 			return;
 		}
@@ -85,7 +85,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * @param integer $form_id .
 	 */
-	public function after_create_form( int $form_id ) : void {
+	public function after_create_form( int $form_id ): void {
 		$args = [
 			'action_type'         => 'CREATE',
 			'title'               => sprintf( 'Form #%d', $form_id ),
@@ -105,7 +105,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param int $old_id .
 	 * @param int $new_id .
 	 */
-	public function after_duplicate_form( int $old_id, int $new_id ) : void {
+	public function after_duplicate_form( int $old_id, int $new_id ): void {
 		$this->after_create_form( $new_id );
 	}
 
@@ -114,7 +114,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * @param integer $form_id .
 	 */
-	public function after_update_form( int $form_id ) : void {
+	public function after_update_form( int $form_id ): void {
 		$args = [
 			'action_type'         => 'UPDATE',
 			'title'               => sprintf( 'Form #%d', $form_id ),
@@ -134,7 +134,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param mixed $form_meta .
 	 * @param int   $form_id The form ID.
 	 */
-	public function post_update_form_meta( $form_meta, int $form_id ) : void {
+	public function post_update_form_meta( $form_meta, int $form_id ): void {
 		$this->after_update_form( $form_id );
 	}
 
@@ -144,7 +144,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param array $form .
 	 * @param bool  $is_new whether the form was created or updated.
 	 */
-	public function after_save_form( array $form, bool $is_new ) : void {
+	public function after_save_form( array $form, bool $is_new ): void {
 		if ( $is_new ) {
 			$this->after_create_form( $form['id'] );
 		} else {
@@ -157,7 +157,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * @param integer $form_id .
 	 */
-	public function after_delete_form( int $form_id ) : void {
+	public function after_delete_form( int $form_id ): void {
 		$args = [
 			'action_type'         => 'DELETE',
 			'title'               => sprintf( 'Form #%d', $form_id ),
@@ -171,13 +171,12 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 		$this->log( 'delete_form', $args );
 	}
 
-
 	/**
 	 * Triggers a Gatsby `log_action()` after an entry is created.
 	 *
 	 * @param array $entry .
 	 */
-	public function after_create_entry( array $entry ) : void {
+	public function after_create_entry( array $entry ): void {
 		$args = [
 			'action_type'         => 'CREATE',
 			'title'               => sprintf( 'Entry #%s', $entry['id'] ),
@@ -197,7 +196,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param array $form .
 	 * @param int   $entry_id .
 	 */
-	public function after_update_entry( array $form, int $entry_id ) : void {
+	public function after_update_entry( array $form, int $entry_id ): void {
 		$args = [
 			'action_type'         => 'UPDATE',
 			'title'               => sprintf( 'Entry #%d', $entry_id ),
@@ -216,7 +215,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 *
 	 * @param array $entry .
 	 */
-	public function post_update_entry( array $entry ) : void {
+	public function post_update_entry( array $entry ): void {
 		$this->after_update_entry( [], $entry['id'] );
 	}
 
@@ -228,7 +227,7 @@ class GravityFormsMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {
 	 * @param array  $submission .
 	 * @param string $resume_token .
 	 */
-	public function after_save_draft_entry( array $submission, string $resume_token ) : void {
+	public function after_save_draft_entry( array $submission, string $resume_token ): void {
 		$args = [
 			'action_type'         => 'Create',
 			'title'               => sprintf( 'Draft Entry #%s', $resume_token ),

--- a/src/Extensions/WPGatsby/Settings.php
+++ b/src/Extensions/WPGatsby/Settings.php
@@ -17,7 +17,7 @@ class Settings {
 	/**
 	 * An instance of the Settings API.
 	 *
-	 * @var ?WPGraphQL_Settings_API
+	 * @var ?\WPGraphQL_Settings_API
 	 */
 	private static $settings_api;
 

--- a/src/Extensions/WPGatsby/Settings.php
+++ b/src/Extensions/WPGatsby/Settings.php
@@ -52,7 +52,7 @@ class Settings {
 	/**
 	 * Gets an instance of the WPGraphQL settings api.
 	 */
-	public static function get_settings_api() : WPGraphQL_Settings_API {
+	public static function get_settings_api(): WPGraphQL_Settings_API {
 		if ( ! isset( self::$settings_api ) ) {
 			self::$settings_api = new WPGraphQL_Settings_API();
 		}
@@ -63,7 +63,7 @@ class Settings {
 	/**
 	 * Registers settings to enable/disable action monitoring to Settings>GatsbyJS.
 	 */
-	public static function register_settings() : void {
+	public static function register_settings(): void {
 		$settings_api = self::get_settings_api();
 
 		$settings_api->add_field(
@@ -90,7 +90,7 @@ class Settings {
 	/**
 	 * Gets an array of Gravity Forms actions that should be monitored.
 	 */
-	public static function get_enabled_actions() : array {
+	public static function get_enabled_actions(): array {
 		/** @var array $options */
 		$options = get_option( self::$section_name, [] );
 
@@ -117,7 +117,7 @@ class Settings {
 	 *
 	 * @param string $action_name the name of the action triggering.
 	 */
-	public static function is_action_enabled( string $action_name ) : bool {
+	public static function is_action_enabled( string $action_name ): bool {
 		$enabled_actions = self::get_enabled_actions();
 
 		return ! empty( $enabled_actions ) && in_array( $action_name, $enabled_actions, true );

--- a/src/Extensions/WPGatsby/WPGatsby.php
+++ b/src/Extensions/WPGatsby/WPGatsby.php
@@ -23,7 +23,7 @@ class WPGatsby implements Hookable {
 		}
 
 		// Register action monitors.
-		add_filter( 'gatsby_action_monitors', [ __CLASS__, 'register_monitors' ], 10, 2 );
+		add_filter( 'gatsby_action_monitors', [ self::class, 'register_monitors' ], 10, 2 );
 		add_action( 'admin_init', [ Settings::class, 'register_settings' ], 11 );
 	}
 	/**

--- a/src/Extensions/WPGatsby/WPGatsby.php
+++ b/src/Extensions/WPGatsby/WPGatsby.php
@@ -26,10 +26,11 @@ class WPGatsby implements Hookable {
 		add_filter( 'gatsby_action_monitors', [ self::class, 'register_monitors' ], 10, 2 );
 		add_action( 'admin_init', [ Settings::class, 'register_settings' ], 11 );
 	}
+
 	/**
 	 * Returns whether WPGatsby is enabled.
 	 */
-	public static function is_wp_gatsby_enabled() : bool {
+	public static function is_wp_gatsby_enabled(): bool {
 		return class_exists( 'WPGatsby' ) && class_exists( 'WPGraphQL_Settings_API' );
 	}
 
@@ -39,7 +40,7 @@ class WPGatsby implements Hookable {
 	 * @param array                                 $monitors .
 	 * @param \WPGatsby\ActionMonitor\ActionMonitor $action_monitor .
 	 */
-	public static function register_monitors( array $monitors, \WPGatsby\ActionMonitor\ActionMonitor $action_monitor ) : array {
+	public static function register_monitors( array $monitors, \WPGatsby\ActionMonitor\ActionMonitor $action_monitor ): array {
 		$monitors['GravityFormsMonitor'] = new GravityFormsMonitor( $action_monitor );
 
 		return $monitors;

--- a/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
+++ b/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
@@ -38,9 +38,9 @@ class WPJamstackDeployments implements Hookable {
 		}
 
 		// Register settings.
-		add_action( 'admin_init', [ __CLASS__, 'register_settings' ], 11 );
+		add_action( 'admin_init', [ self::class, 'register_settings' ], 11 );
 		// Filters sanitization callback.
-		add_filter( 'sanitize_option_' . self::get_options_key(), [ __CLASS__, 'sanitize' ], 10 );
+		add_filter( 'sanitize_option_' . self::get_options_key(), [ self::class, 'sanitize' ], 10 );
 
 		// Trigger deployments.
 		self::trigger_deployments();
@@ -130,12 +130,12 @@ class WPJamstackDeployments implements Hookable {
 			switch ( $gf_hook ) {
 				case 'create_form':
 					add_action( 'gform_post_form_duplicated', 'jamstack_deployments_fire_webhook' );
-					add_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ], 10, 2 );
+					add_action( 'gform_after_save_form', [ self::class, 'after_save_form' ], 10, 2 );
 					break;
 				case 'update_form':
 					// Only add action if it doenst already exist.
-					if ( ! has_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ] ) ) {
-						add_action( 'gform_after_save_form', [ __CLASS__, 'after_save_form' ], 10, 2 );
+					if ( ! has_action( 'gform_after_save_form', [ self::class, 'after_save_form' ] ) ) {
+						add_action( 'gform_after_save_form', [ self::class, 'after_save_form' ], 10, 2 );
 					}
 					add_action( 'gform_post_update_form_meta', 'jamstack_deployments_fire_webhook' );
 					add_action( 'gform_post_form_activated', 'jamstack_deployments_fire_webhook' );

--- a/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
+++ b/src/Extensions/WPJamstackDeployments/WPJamstackDeployments.php
@@ -28,7 +28,6 @@ class WPJamstackDeployments implements Hookable {
 	 */
 	public static array $options;
 
-
 	/**
 	 * {@inheritDoc}
 	 */
@@ -49,21 +48,21 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * Returns whether WPJamstackDeployments is enabled.
 	 */
-	public static function is_wp_jamstack_deployments_enabled() : bool {
+	public static function is_wp_jamstack_deployments_enabled(): bool {
 		return class_exists( 'Crgeary\JAMstackDeployments\App' );
 	}
 
 	/**
 	 * Returns the Options Key used by WPJamstackDeployments.
 	 */
-	public static function get_options_key() : string {
+	public static function get_options_key(): string {
 		return defined( 'CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY' ) ? CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY : 'wp_jamstack_deployments';
 	}
 
 	/**
 	 * Returns the array of options.
 	 */
-	public static function get_options() : array {
+	public static function get_options(): array {
 		if ( empty( self::$options ) ) {
 			self::$options = \jamstack_deployments_get_options();
 		}
@@ -74,7 +73,7 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * Registers settings to enable/disable deployments.
 	 */
-	public static function register_settings() : void {
+	public static function register_settings(): void {
 		$key = self::get_options_key();
 
 		$option = self::get_options();
@@ -109,7 +108,7 @@ class WPJamstackDeployments implements Hookable {
 	 *
 	 * @param array $input .
 	 */
-	public static function sanitize( array $input ) : array {
+	public static function sanitize( array $input ): array {
 		if ( ! isset( $input[ self::$option_name ] ) || ! is_array( $input[ self::$option_name ] ) ) {
 			$input[ self::$option_name ] = [];
 		}
@@ -120,7 +119,7 @@ class WPJamstackDeployments implements Hookable {
 	/**
 	 * Adds actions to trigger deployments based on the settings.
 	 */
-	public static function trigger_deployments() : void {
+	public static function trigger_deployments(): void {
 		$options = self::get_options();
 		if ( empty( $options[ self::$option_name ] ) ) {
 			return;
@@ -166,7 +165,7 @@ class WPJamstackDeployments implements Hookable {
 	 * @param array   $form .
 	 * @param boolean $is_new .
 	 */
-	public static function after_save_form( array $form, bool $is_new ) : void {
+	public static function after_save_form( array $form, bool $is_new ): void {
 		$options = self::get_options();
 
 		if ( in_array( 'create_form', $options[ self::$option_name ], true ) && $is_new ) {

--- a/src/GF.php
+++ b/src/GF.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		/**
 		 * Class instances.
 		 *
-		 * @var ?GF $instance
+		 * @var ?\WPGraphQL\GF\GF $instance
 		 */
 		private static $instance;
 
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		 * Constructor
 		 */
 		public static function instance() : self {
-			if ( ! isset( self::$instance ) || ! ( is_a( self::$instance, __CLASS__ ) ) ) {
+			if ( ! isset( self::$instance ) || ! ( is_a( self::$instance, self::class ) ) ) {
 				if ( ! function_exists( 'is_plugin_active' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/plugin.php';
 				}
@@ -39,7 +39,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 			/**
 			 * Fire off init action.
 			 *
-			 * @param GF $instance the instance of the plugin class.
+			 * @param \WPGraphQL\GF\GF $instance the instance of the plugin class.
 			 */
 			do_action( 'graphql_gf_init', self::$instance );
 

--- a/src/GF.php
+++ b/src/GF.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		/**
 		 * Constructor
 		 */
-		public static function instance() : self {
+		public static function instance(): self {
 			if ( ! isset( self::$instance ) || ! ( is_a( self::$instance, self::class ) ) ) {
 				if ( ! function_exists( 'is_plugin_active' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		 *
 		 * @since 0.10.0
 		 */
-		private function includes() : void {
+		private function includes(): void {
 			if ( defined( 'WPGRAPHQL_GF_AUTOLOAD' ) && false !== WPGRAPHQL_GF_AUTOLOAD && defined( 'WPGRAPHQL_GF_PLUGIN_DIR' ) ) {
 				require_once WPGRAPHQL_GF_PLUGIN_DIR . 'vendor/autoload.php';
 			}
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		/**
 		 * Sets up the schema.
 		 */
-		private function setup() : void {
+		private function setup(): void {
 			Extensions::register_hooks();
 			CoreSchemaFilters::register_hooks();
 			UpdateChecker::register_hooks();
@@ -87,7 +87,7 @@ if ( ! class_exists( 'WPGraphQL\GF\GF' ) ) :
 		 *
 		 * @since  0.10.0
 		 */
-		public function __wakeup() : void {
+		public function __wakeup(): void {
 			// De-serializing instances of the class is forbidden.
 			_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the GF class is not allowed.', 'wp-graphql-gravity-forms' ), '0.10.0' );
 		}

--- a/src/Interfaces/Enum.php
+++ b/src/Interfaces/Enum.php
@@ -15,5 +15,5 @@ interface Enum {
 	/**
 	 * Gets the Enum type values.
 	 */
-	public static function get_values() : array;
+	public static function get_values(): array;
 }

--- a/src/Interfaces/Field.php
+++ b/src/Interfaces/Field.php
@@ -15,5 +15,5 @@ interface Field {
 	/**
 	 * Register field in GraphQL schema.
 	 */
-	public static function register_field() : void;
+	public static function register_field(): void;
 }

--- a/src/Interfaces/Hookable.php
+++ b/src/Interfaces/Hookable.php
@@ -15,5 +15,5 @@ interface Hookable {
 	/**
 	 * Hooks class into WordPress.
 	 */
-	public static function register_hooks() : void;
+	public static function register_hooks(): void;
 }

--- a/src/Interfaces/Mutation.php
+++ b/src/Interfaces/Mutation.php
@@ -17,21 +17,19 @@ interface Mutation {
 	 *
 	 * @since 0.4.0
 	 */
-	public static function get_input_fields() : array;
+	public static function get_input_fields(): array;
 
 	/**
 	 * Defines the output field configuration.
 	 *
 	 * @since 0.4.0
 	 */
-	public static function get_output_fields() : array;
-
+	public static function get_output_fields(): array;
 
 	/**
 	 * Defines the data modification closure.
 	 *
 	 * @since 0.4.0
 	 */
-	public static function mutate_and_get_payload() : callable;
-
+	public static function mutate_and_get_payload(): callable;
 }

--- a/src/Interfaces/Registrable.php
+++ b/src/Interfaces/Registrable.php
@@ -15,5 +15,5 @@ interface Registrable {
 	/**
 	 * Register connections to the GraphQL Schema.
 	 */
-	public static function register() : void;
+	public static function register(): void;
 }

--- a/src/Interfaces/TypeWithConnections.php
+++ b/src/Interfaces/TypeWithConnections.php
@@ -15,5 +15,5 @@ interface TypeWithConnections {
 	/**
 	 * Gets the the connection config for the GraphQL Type.
 	 */
-	public static function get_connections() : array;
+	public static function get_connections(): array;
 }

--- a/src/Interfaces/TypeWithDescription.php
+++ b/src/Interfaces/TypeWithDescription.php
@@ -15,5 +15,5 @@ interface TypeWithDescription {
 	/**
 	 * Gets the Field type description.
 	 */
-	public static function get_description() : string;
+	public static function get_description(): string;
 }

--- a/src/Interfaces/TypeWithFields.php
+++ b/src/Interfaces/TypeWithFields.php
@@ -15,5 +15,5 @@ interface TypeWithFields {
 	/**
 	 * Gets the properties for the type.
 	 */
-	public static function get_fields() : array;
+	public static function get_fields(): array;
 }

--- a/src/Interfaces/TypeWithInterfaces.php
+++ b/src/Interfaces/TypeWithInterfaces.php
@@ -15,5 +15,5 @@ interface TypeWithInterfaces {
 	/**
 	 * Gets the the connection config for the GraphQL Type.
 	 */
-	public static function get_interfaces() : array;
+	public static function get_interfaces(): array;
 }

--- a/src/Model/DraftEntry.php
+++ b/src/Model/DraftEntry.php
@@ -57,7 +57,7 @@ class DraftEntry extends Model {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function is_private() : bool {
+	protected function is_private(): bool {
 		$can_view = true;
 
 		/**
@@ -78,30 +78,30 @@ class DraftEntry extends Model {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function init() : void {
+	protected function init(): void {
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
 				// Interface fields.
-				'createdByDatabaseId' => fn() : ?int => ! empty( $this->submission['partial_entry']['created_by'] ) ? (int) $this->submission['partial_entry']['created_by'] : null,
-				'createdById'         => fn() : ?string => ! empty( $this->data['created_by'] ) ? Relay::toGlobalId( 'user', $this->data['created_by'] ) : null,
-				'dateCreated'         => fn() : ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
-				'dateCreatedGmt'      => fn() : ?string => ! empty( $this->data['date_created'] ) ? $this->data['date_created'] : null,
-				'dateUpdated'         => fn() : ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? get_date_from_gmt( $this->submission['partial_entry']['date_updated'] ) : null,
-				'dateUpdatedGmt'      => fn() : ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? $this->submission['partial_entry']['date_updated'] : null,
-				'entry'               => fn() : array => $this->submission['partial_entry'],
-				'entryValues'         => fn() : ?array => array_filter( $this->submission['partial_entry'], static fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
-				'formId'              => fn() => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
-				'formDatabaseId'      => fn() : ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
-				'id'                  => fn() : string => Relay::toGlobalId( DraftEntriesLoader::$name, $this->resume_token ),
-				'ip'                  => fn() : ?string => ! empty( $this->submission['partial_entry']['ip'] ) ? $this->submission['partial_entry']['ip'] : null,
-				'isDraft'             => fn() : bool => ! empty( $this->resume_token ),
-				'isSubmitted'         => fn() : bool => ! empty( $this->submission['partial_entry']['id'] ),
-				'sourceUrl'           => fn() : ?string => ! empty( $this->submission['partial_entry']['source_url'] ) ? $this->submission['partial_entry']['source_url'] : null,
-				'userAgent'           => fn() : ?string => ! empty( $this->submission['partial_entry']['user_agent'] ) ? $this->submission['partial_entry']['user_agent'] : null,
+				'createdByDatabaseId' => fn (): ?int => ! empty( $this->submission['partial_entry']['created_by'] ) ? (int) $this->submission['partial_entry']['created_by'] : null,
+				'createdById'         => fn (): ?string => ! empty( $this->data['created_by'] ) ? Relay::toGlobalId( 'user', $this->data['created_by'] ) : null,
+				'dateCreated'         => fn (): ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
+				'dateCreatedGmt'      => fn (): ?string => ! empty( $this->data['date_created'] ) ? $this->data['date_created'] : null,
+				'dateUpdated'         => fn (): ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? get_date_from_gmt( $this->submission['partial_entry']['date_updated'] ) : null,
+				'dateUpdatedGmt'      => fn (): ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? $this->submission['partial_entry']['date_updated'] : null,
+				'entry'               => fn (): array => $this->submission['partial_entry'],
+				'entryValues'         => fn (): ?array => array_filter( $this->submission['partial_entry'], static fn ( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
+				'formId'              => fn () => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
+				'formDatabaseId'      => fn (): ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
+				'id'                  => fn (): string => Relay::toGlobalId( DraftEntriesLoader::$name, $this->resume_token ),
+				'ip'                  => fn (): ?string => ! empty( $this->submission['partial_entry']['ip'] ) ? $this->submission['partial_entry']['ip'] : null,
+				'isDraft'             => fn (): bool => ! empty( $this->resume_token ),
+				'isSubmitted'         => fn (): bool => ! empty( $this->submission['partial_entry']['id'] ),
+				'sourceUrl'           => fn (): ?string => ! empty( $this->submission['partial_entry']['source_url'] ) ? $this->submission['partial_entry']['source_url'] : null,
+				'userAgent'           => fn (): ?string => ! empty( $this->submission['partial_entry']['user_agent'] ) ? $this->submission['partial_entry']['user_agent'] : null,
 
 				// Fields specific to the model.
-				'currency'            => fn() : ?int => ! empty( $this->submission['partial_entry']['currency'] ) ? (int) $this->submission['partial_entry']['currency'] : null,
-				'resumeToken'         => fn() : string => $this->resume_token,
+				'currency'            => fn (): ?int => ! empty( $this->submission['partial_entry']['currency'] ) ? (int) $this->submission['partial_entry']['currency'] : null,
+				'resumeToken'         => fn (): string => $this->resume_token,
 			];
 		}
 	}

--- a/src/Model/DraftEntry.php
+++ b/src/Model/DraftEntry.php
@@ -89,7 +89,7 @@ class DraftEntry extends Model {
 				'dateUpdated'         => fn() : ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? get_date_from_gmt( $this->submission['partial_entry']['date_updated'] ) : null,
 				'dateUpdatedGmt'      => fn() : ?string => ! empty( $this->submission['partial_entry']['date_updated'] ) ? $this->submission['partial_entry']['date_updated'] : null,
 				'entry'               => fn() : array => $this->submission['partial_entry'],
-				'entryValues'         => fn() : ?array => array_filter( $this->submission['partial_entry'], fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
+				'entryValues'         => fn() : ?array => array_filter( $this->submission['partial_entry'], static fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
 				'formId'              => fn() => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
 				'formDatabaseId'      => fn() : ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
 				'id'                  => fn() : string => Relay::toGlobalId( DraftEntriesLoader::$name, $this->resume_token ),

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -52,7 +52,7 @@ class Form extends Model {
 	protected function init() : void {
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
-				'confirmations'                => function() : ?array {
+				'confirmations'                => function () : ?array {
 					if ( empty( $this->data['confirmations'] ) ) {
 						return null;
 					}
@@ -78,7 +78,7 @@ class Form extends Model {
 				'dateCreated'                  => fn() : ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
 				'description'                  => fn() : ?string => $this->data['description'] ?? null,
 				'descriptionPlacement'         => fn() : ?string => $this->data['descriptionPlacement'] ?? null,
-				'entryLimits'                  => function() : array {
+				'entryLimits'                  => function () : array {
 					return [
 						'hasLimit'            => ! empty( $this->data['limitEntries'] ),
 						'limitationPeriod'    => ! empty( $this->data['limitEntriesPeriod'] ) ? $this->data['limitEntriesPeriod'] : null,
@@ -95,7 +95,7 @@ class Form extends Model {
 				'isActive'                     => fn() : bool => $this->data['is_active'] ?? true,
 				'isTrash'                      => fn() : bool => $this->data['is_trash'] ?? false,
 				'labelPlacement'               => fn() : ?string => $this->data['labelPlacement'] ?? null,
-				'login'                        => function() : array {
+				'login'                        => function () : array {
 					return [
 						'isLoginRequired'      => ! empty( $this->data['requireLogin'] ),
 						'loginRequiredMessage' => ! empty( $this->data['requireLoginMessage'] ) ? $this->data['requireLoginMessage'] : null,
@@ -104,7 +104,7 @@ class Form extends Model {
 				'markupVersion'                => fn() : ?string => $this->data['markupVersion'] ?? null,
 				'notifications'                => fn() : ?array => ! empty( $this->data['notifications'] ) ? $this->data['notifications'] : null,
 				'nextFieldId'                  => fn() : ?int => isset( $this->data['nextFieldId'] ) ? (int) $this->data['nextFieldId'] : null,
-				'pagination'                   => function() : ?array {
+				'pagination'                   => function () : ?array {
 					if ( ! isset( $this->data['pagination'] ) ) {
 						return null;
 					}
@@ -126,7 +126,7 @@ class Form extends Model {
 
 					return $pagination;
 				},
-				'personalData'                 => function() : ?array {
+				'personalData'                 => function () : ?array {
 					$personal_data = ! empty( $this->data['personalData'] ) ? $this->data['personalData'] : null;
 
 					if ( ! is_array( $personal_data ) ) {
@@ -168,7 +168,7 @@ class Form extends Model {
 
 					return $personal_data;
 				},
-				'postCreation'                 => function() : array {
+				'postCreation'                 => function () : array {
 					return [
 						'authorDatabaseId'             => isset( $this->data['postAuthor'] ) ? (int) $this->data['postAuthor'] : null,
 						'authorId'                     => isset( $this->data['postAuthor'] ) ? Relay::toGlobalId( 'user', $this->data['postAuthor'] ) : null,
@@ -184,7 +184,7 @@ class Form extends Model {
 				},
 				'requiredIndicator'            => fn() : ?string => $this->data['requiredIndicator'] ?? null,
 				'saveAndContinue'              => fn() : ?array => ! empty( $this->data['save'] ) ? $this->data['save'] : null,
-				'scheduling'                   => function() : array {
+				'scheduling'                   => function () : array {
 					return [
 						'closedMessage'  => ! empty( $this->data['scheduleMessage'] ) ? $this->data['scheduleMessage'] : null,
 						'hasSchedule'    => ! empty( $this->data['scheduleForm'] ),
@@ -206,7 +206,7 @@ class Form extends Model {
 					];
 				},
 				'subLabelPlacement'            => fn() : ?string => ! empty( $this->data['subLabelPlacement'] ) ? $this->data['subLabelPlacement'] : null,
-				'submitButton'                 => function() : ?array {
+				'submitButton'                 => function () : ?array {
 					$button = isset( $this->data['button'] ) ? $this->data['button'] : null;
 					// Coax types.
 					$button['layoutGridColumnSpan'] = ! empty( $button['layoutGridColumnSpan'] ) ? (int) $button['layoutGridColumnSpan'] : null;

--- a/src/Model/Form.php
+++ b/src/Model/Form.php
@@ -32,6 +32,7 @@ class Form extends Model {
 	 */
 	public function __construct( $form ) {
 		$this->data = $form;
+
 		parent::__construct();
 	}
 
@@ -49,10 +50,10 @@ class Form extends Model {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function init() : void {
+	protected function init(): void {
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
-				'confirmations'                => function () : ?array {
+				'confirmations'                => function (): ?array {
 					if ( empty( $this->data['confirmations'] ) ) {
 						return null;
 					}
@@ -71,14 +72,14 @@ class Form extends Model {
 						$this->data['confirmations']
 					);
 				},
-				'cssClass'                     => fn() : ?string => ! empty( $this->data['cssClass'] ) ? $this->data['cssClass'] : null,
-				'customRequiredIndicator'      => fn() : ?string => ! empty( $this->data['customRequiredIndicator'] ) ? $this->data['customRequiredIndicator'] : null,
-				'databaseId'                   => fn() : int => (int) $this->data['id'],
-				'dateCreatedGmt'               => fn() : ?string => $this->data['date_created'] ?? null,
-				'dateCreated'                  => fn() : ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
-				'description'                  => fn() : ?string => $this->data['description'] ?? null,
-				'descriptionPlacement'         => fn() : ?string => $this->data['descriptionPlacement'] ?? null,
-				'entryLimits'                  => function () : array {
+				'cssClass'                     => fn (): ?string => ! empty( $this->data['cssClass'] ) ? $this->data['cssClass'] : null,
+				'customRequiredIndicator'      => fn (): ?string => ! empty( $this->data['customRequiredIndicator'] ) ? $this->data['customRequiredIndicator'] : null,
+				'databaseId'                   => fn (): int => (int) $this->data['id'],
+				'dateCreatedGmt'               => fn (): ?string => $this->data['date_created'] ?? null,
+				'dateCreated'                  => fn (): ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
+				'description'                  => fn (): ?string => $this->data['description'] ?? null,
+				'descriptionPlacement'         => fn (): ?string => $this->data['descriptionPlacement'] ?? null,
+				'entryLimits'                  => function (): array {
 					return [
 						'hasLimit'            => ! empty( $this->data['limitEntries'] ),
 						'limitationPeriod'    => ! empty( $this->data['limitEntriesPeriod'] ) ? $this->data['limitEntriesPeriod'] : null,
@@ -86,25 +87,25 @@ class Form extends Model {
 						'maxEntries'          => isset( $this->data['limitEntriesCount'] ) ? (int) $this->data['limitEntriesCount'] : null,
 					];
 				},
-				'hasConditionalLogicAnimation' => fn() : bool => $this->data['enableAnimation'] ?? false,
-				'hasHoneypot'                  => fn() : bool => $this->data['enableHoneypot'] ?? false,
-				'firstPageCssClass'            => fn() : ?string => $this->data['firstPageCssClass'] ?? null,
-				'form'                         => fn() : array => $this->data,
-				'formFields'                   => fn() : ?array => ! empty( $this->data['fields'] ) ? $this->data['fields'] : null,
-				'id'                           => fn() : string => Relay::toGlobalId( FormsLoader::$name, $this->data['id'] ),
-				'isActive'                     => fn() : bool => $this->data['is_active'] ?? true,
-				'isTrash'                      => fn() : bool => $this->data['is_trash'] ?? false,
-				'labelPlacement'               => fn() : ?string => $this->data['labelPlacement'] ?? null,
-				'login'                        => function () : array {
+				'hasConditionalLogicAnimation' => fn (): bool => $this->data['enableAnimation'] ?? false,
+				'hasHoneypot'                  => fn (): bool => $this->data['enableHoneypot'] ?? false,
+				'firstPageCssClass'            => fn (): ?string => $this->data['firstPageCssClass'] ?? null,
+				'form'                         => fn (): array => $this->data,
+				'formFields'                   => fn (): ?array => ! empty( $this->data['fields'] ) ? $this->data['fields'] : null,
+				'id'                           => fn (): string => Relay::toGlobalId( FormsLoader::$name, $this->data['id'] ),
+				'isActive'                     => fn (): bool => $this->data['is_active'] ?? true,
+				'isTrash'                      => fn (): bool => $this->data['is_trash'] ?? false,
+				'labelPlacement'               => fn (): ?string => $this->data['labelPlacement'] ?? null,
+				'login'                        => function (): array {
 					return [
 						'isLoginRequired'      => ! empty( $this->data['requireLogin'] ),
 						'loginRequiredMessage' => ! empty( $this->data['requireLoginMessage'] ) ? $this->data['requireLoginMessage'] : null,
 					];
 				},
-				'markupVersion'                => fn() : ?string => $this->data['markupVersion'] ?? null,
-				'notifications'                => fn() : ?array => ! empty( $this->data['notifications'] ) ? $this->data['notifications'] : null,
-				'nextFieldId'                  => fn() : ?int => isset( $this->data['nextFieldId'] ) ? (int) $this->data['nextFieldId'] : null,
-				'pagination'                   => function () : ?array {
+				'markupVersion'                => fn (): ?string => $this->data['markupVersion'] ?? null,
+				'notifications'                => fn (): ?array => ! empty( $this->data['notifications'] ) ? $this->data['notifications'] : null,
+				'nextFieldId'                  => fn (): ?int => isset( $this->data['nextFieldId'] ) ? (int) $this->data['nextFieldId'] : null,
+				'pagination'                   => function (): ?array {
 					if ( ! isset( $this->data['pagination'] ) ) {
 						return null;
 					}
@@ -126,7 +127,7 @@ class Form extends Model {
 
 					return $pagination;
 				},
-				'personalData'                 => function () : ?array {
+				'personalData'                 => function (): ?array {
 					$personal_data = ! empty( $this->data['personalData'] ) ? $this->data['personalData'] : null;
 
 					if ( ! is_array( $personal_data ) ) {
@@ -168,7 +169,7 @@ class Form extends Model {
 
 					return $personal_data;
 				},
-				'postCreation'                 => function () : array {
+				'postCreation'                 => function (): array {
 					return [
 						'authorDatabaseId'             => isset( $this->data['postAuthor'] ) ? (int) $this->data['postAuthor'] : null,
 						'authorId'                     => isset( $this->data['postAuthor'] ) ? Relay::toGlobalId( 'user', $this->data['postAuthor'] ) : null,
@@ -182,9 +183,9 @@ class Form extends Model {
 						'shouldUseCurrentUserAsAuthor' => ! empty( $this->data['useCurrentUserAsAuthor'] ),
 					];
 				},
-				'requiredIndicator'            => fn() : ?string => $this->data['requiredIndicator'] ?? null,
-				'saveAndContinue'              => fn() : ?array => ! empty( $this->data['save'] ) ? $this->data['save'] : null,
-				'scheduling'                   => function () : array {
+				'requiredIndicator'            => fn (): ?string => $this->data['requiredIndicator'] ?? null,
+				'saveAndContinue'              => fn (): ?array => ! empty( $this->data['save'] ) ? $this->data['save'] : null,
+				'scheduling'                   => function (): array {
 					return [
 						'closedMessage'  => ! empty( $this->data['scheduleMessage'] ) ? $this->data['scheduleMessage'] : null,
 						'hasSchedule'    => ! empty( $this->data['scheduleForm'] ),
@@ -205,8 +206,8 @@ class Form extends Model {
 						],
 					];
 				},
-				'subLabelPlacement'            => fn() : ?string => ! empty( $this->data['subLabelPlacement'] ) ? $this->data['subLabelPlacement'] : null,
-				'submitButton'                 => function () : ?array {
+				'subLabelPlacement'            => fn (): ?string => ! empty( $this->data['subLabelPlacement'] ) ? $this->data['subLabelPlacement'] : null,
+				'submitButton'                 => function (): ?array {
 					$button = isset( $this->data['button'] ) ? $this->data['button'] : null;
 					// Coax types.
 					$button['layoutGridColumnSpan'] = ! empty( $button['layoutGridColumnSpan'] ) ? (int) $button['layoutGridColumnSpan'] : null;
@@ -214,9 +215,9 @@ class Form extends Model {
 					$button['text']                 = ! empty( $button['text'] ) ? $button['text'] : null;
 					return $button;
 				},
-				'title'                        => fn() : ?string => ! empty( $this->data['title'] ) ? $this->data['title'] : null,
-				'hasValidationSummary'         => fn() : bool => ! empty( $this->data['validationSummary'] ),
-				'version'                      => fn() : ?string => ! empty( $this->data['version'] ) ? $this->data['version'] : null,
+				'title'                        => fn (): ?string => ! empty( $this->data['title'] ) ? $this->data['title'] : null,
+				'hasValidationSummary'         => fn (): bool => ! empty( $this->data['validationSummary'] ),
+				'version'                      => fn (): ?string => ! empty( $this->data['version'] ) ? $this->data['version'] : null,
 			];
 
 			/**

--- a/src/Model/SubmittedEntry.php
+++ b/src/Model/SubmittedEntry.php
@@ -33,13 +33,14 @@ class SubmittedEntry extends Model {
 	 */
 	public function __construct( $entry ) {
 		$this->data = $entry;
+
 		parent::__construct();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function is_private() : bool {
+	protected function is_private(): bool {
 		$can_view = false;
 
 		if (
@@ -67,40 +68,40 @@ class SubmittedEntry extends Model {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function init() : void {
+	protected function init(): void {
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
 				// Interface fields.
-				'createdByDatabaseId' => fn() : ?int => ! empty( $this->data['created_by'] ) ? (int) $this->data['created_by'] : null,
-				'createdById'         => fn() : ?string => ! empty( $this->data['created_by'] ) ? Relay::toGlobalId( 'user', $this->data['created_by'] ) : null,
-				'dateCreated'         => fn() : ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
-				'dateCreatedGmt'      => fn() : ?string => ! empty( $this->data['date_created'] ) ? $this->data['date_created'] : null,
-				'dateUpdated'         => fn() : ?string => ! empty( $this->data['date_updated'] ) ? get_date_from_gmt( $this->data['date_updated'] ) : null,
-				'dateUpdatedGmt'      => fn() : ?string => ! empty( $this->data['date_updated'] ) ? $this->data['date_updated'] : null,
-				'entry'               => fn() : array => $this->data,
-				'entryValues'         => fn() : ?array => array_filter( $this->data, static fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
-				'formDatabaseId'      => fn() : ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
-				'formId'              => fn() => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
-				'id'                  => fn() : string => Relay::toGlobalId( EntriesLoader::$name, (string) $this->data['id'] ),
-				'ip'                  => fn() : ?string => ! empty( $this->data['ip'] ) ? $this->data['ip'] : null,
-				'isDraft'             => fn() : bool => ! empty( $this->data['resume_token'] ),
-				'isSubmitted'         => fn() : bool => ! empty( $this->data['id'] ),
-				'sourceUrl'           => fn() : ?string => ! empty( $this->data['source_url'] ) ? $this->data['source_url'] : null,
-				'userAgent'           => fn() : ?string => ! empty( $this->data['user_agent'] ) ? $this->data['user_agent'] : null,
+				'createdByDatabaseId' => fn (): ?int => ! empty( $this->data['created_by'] ) ? (int) $this->data['created_by'] : null,
+				'createdById'         => fn (): ?string => ! empty( $this->data['created_by'] ) ? Relay::toGlobalId( 'user', $this->data['created_by'] ) : null,
+				'dateCreated'         => fn (): ?string => ! empty( $this->data['date_created'] ) ? get_date_from_gmt( $this->data['date_created'] ) : null,
+				'dateCreatedGmt'      => fn (): ?string => ! empty( $this->data['date_created'] ) ? $this->data['date_created'] : null,
+				'dateUpdated'         => fn (): ?string => ! empty( $this->data['date_updated'] ) ? get_date_from_gmt( $this->data['date_updated'] ) : null,
+				'dateUpdatedGmt'      => fn (): ?string => ! empty( $this->data['date_updated'] ) ? $this->data['date_updated'] : null,
+				'entry'               => fn (): array => $this->data,
+				'entryValues'         => fn (): ?array => array_filter( $this->data, static fn ( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
+				'formDatabaseId'      => fn (): ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
+				'formId'              => fn () => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
+				'id'                  => fn (): string => Relay::toGlobalId( EntriesLoader::$name, (string) $this->data['id'] ),
+				'ip'                  => fn (): ?string => ! empty( $this->data['ip'] ) ? $this->data['ip'] : null,
+				'isDraft'             => fn (): bool => ! empty( $this->data['resume_token'] ),
+				'isSubmitted'         => fn (): bool => ! empty( $this->data['id'] ),
+				'sourceUrl'           => fn (): ?string => ! empty( $this->data['source_url'] ) ? $this->data['source_url'] : null,
+				'userAgent'           => fn (): ?string => ! empty( $this->data['user_agent'] ) ? $this->data['user_agent'] : null,
 
 				// Fields specific to the model.
-				'databaseId'          => fn() : ?int => ! empty( $this->data['id'] ) ? (int) $this->data['id'] : null,
-				'isFulfilled'         => fn() : bool => ! empty( $this->data['is_fulfilled'] ),
-				'isStarred'           => fn() : bool => ! empty( $this->data['is_starred'] ),
-				'isRead'              => fn() : bool => ! empty( $this->data['is_read'] ),
-				'paymentAmount'       => fn() : ?float => isset( $this->data['payment_amount'] ) ? (float) $this->data['payment_amount'] : null,
-				'paymentDate'         => fn() : ?string => ! empty( $this->data['payment_date'] ) ? $this->data['payment_date'] : null,
-				'paymentMethod'       => fn() : ?string => ! empty( $this->data['payment_method'] ) ? $this->data['payment_method'] : null,
-				'paymentStatus'       => fn() : ?string => ! empty( $this->data['payment_status'] ) ? $this->data['payment_status'] : null,
-				'postDatabaseId'      => fn() : ?int => ! empty( $this->data['post_id'] ) ? (int) $this->data['post_id'] : null,
-				'status'              => fn() : ?string => ! empty( $this->data['status'] ) ? $this->data['status'] : null,
-				'transactionId'       => fn() : ?string => ! empty( $this->data['transaction_id'] ) ? $this->data['transaction_id'] : null,
-				'transactionType'     => fn() : ?string => ! empty( $this->data['transaction_type'] ) ? $this->data['transaction_type'] : null,
+				'databaseId'          => fn (): ?int => ! empty( $this->data['id'] ) ? (int) $this->data['id'] : null,
+				'isFulfilled'         => fn (): bool => ! empty( $this->data['is_fulfilled'] ),
+				'isStarred'           => fn (): bool => ! empty( $this->data['is_starred'] ),
+				'isRead'              => fn (): bool => ! empty( $this->data['is_read'] ),
+				'paymentAmount'       => fn (): ?float => isset( $this->data['payment_amount'] ) ? (float) $this->data['payment_amount'] : null,
+				'paymentDate'         => fn (): ?string => ! empty( $this->data['payment_date'] ) ? $this->data['payment_date'] : null,
+				'paymentMethod'       => fn (): ?string => ! empty( $this->data['payment_method'] ) ? $this->data['payment_method'] : null,
+				'paymentStatus'       => fn (): ?string => ! empty( $this->data['payment_status'] ) ? $this->data['payment_status'] : null,
+				'postDatabaseId'      => fn (): ?int => ! empty( $this->data['post_id'] ) ? (int) $this->data['post_id'] : null,
+				'status'              => fn (): ?string => ! empty( $this->data['status'] ) ? $this->data['status'] : null,
+				'transactionId'       => fn (): ?string => ! empty( $this->data['transaction_id'] ) ? $this->data['transaction_id'] : null,
+				'transactionType'     => fn (): ?string => ! empty( $this->data['transaction_type'] ) ? $this->data['transaction_type'] : null,
 			];
 		}
 	}

--- a/src/Model/SubmittedEntry.php
+++ b/src/Model/SubmittedEntry.php
@@ -78,7 +78,7 @@ class SubmittedEntry extends Model {
 				'dateUpdated'         => fn() : ?string => ! empty( $this->data['date_updated'] ) ? get_date_from_gmt( $this->data['date_updated'] ) : null,
 				'dateUpdatedGmt'      => fn() : ?string => ! empty( $this->data['date_updated'] ) ? $this->data['date_updated'] : null,
 				'entry'               => fn() : array => $this->data,
-				'entryValues'         => fn() : ?array => array_filter( $this->data, fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
+				'entryValues'         => fn() : ?array => array_filter( $this->data, static fn( $key ) => is_numeric( $key ), ARRAY_FILTER_USE_KEY ) ?: null,
 				'formDatabaseId'      => fn() : ?int => ! empty( $this->data['form_id'] ) ? (int) $this->data['form_id'] : null,
 				'formId'              => fn() => ! empty( $this->data['form_id'] ) ? Relay::toGlobalId( FormsLoader::$name, $this->data['form_id'] ) : null,
 				'id'                  => fn() : string => Relay::toGlobalId( EntriesLoader::$name, (string) $this->data['id'] ),

--- a/src/Mutation/AbstractMutation.php
+++ b/src/Mutation/AbstractMutation.php
@@ -48,7 +48,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	 * Checks that necessary WPGraphQL are set.
 	 *
 	 * @param array $input .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected static function check_required_inputs( ?array $input ) : void {
 		if ( empty( $input ) || ! is_array( $input ) ) {
@@ -61,7 +61,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	 *
 	 * @param int|string $id .
 	 * @param string     $id_type .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected static function get_resume_token_from_id( $id, string $id_type ) : string {
 		if ( 'resume_token' === $id_type ) {

--- a/src/Mutation/AbstractMutation.php
+++ b/src/Mutation/AbstractMutation.php
@@ -28,7 +28,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		$config = static::get_type_config();
 		register_graphql_mutation( static::$name, $config );
 	}
@@ -36,7 +36,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		return [
 			'inputFields'         => static::get_input_fields(),
 			'outputFields'        => static::get_output_fields(),
@@ -50,7 +50,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	 * @param array $input .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected static function check_required_inputs( ?array $input ) : void {
+	protected static function check_required_inputs( ?array $input ): void {
 		if ( empty( $input ) || ! is_array( $input ) ) {
 			throw new UserError( __( 'Mutation not processed. The input data was missing or invalid.', 'wp-graphql-gravity-forms' ) );
 		}
@@ -63,7 +63,7 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 	 * @param string     $id_type .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected static function get_resume_token_from_id( $id, string $id_type ) : string {
+	protected static function get_resume_token_from_id( $id, string $id_type ): string {
 		if ( 'resume_token' === $id_type ) {
 			$resume_token = $id;
 		} else {
@@ -78,5 +78,4 @@ abstract class AbstractMutation extends AbstractType implements Mutation {
 
 		return sanitize_text_field( $resume_token );
 	}
-
 }

--- a/src/Mutation/DeleteDraftEntry.php
+++ b/src/Mutation/DeleteDraftEntry.php
@@ -73,7 +73,7 @@ class DeleteDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/DeleteDraftEntry.php
+++ b/src/Mutation/DeleteDraftEntry.php
@@ -24,7 +24,6 @@ use WPGraphQL\GF\Utils\GFUtils;
  * Class - DeleteDraftEntry
  */
 class DeleteDraftEntry extends AbstractMutation {
-
 	/**
 	 * Mutation Name
 	 *
@@ -35,7 +34,7 @@ class DeleteDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'     => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -51,7 +50,7 @@ class DeleteDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'deletedId'  => [
 				'type'        => 'ID',
@@ -72,8 +71,8 @@ class DeleteDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/DeleteDraftEntry.php
+++ b/src/Mutation/DeleteDraftEntry.php
@@ -73,7 +73,7 @@ class DeleteDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/DeleteEntry.php
+++ b/src/Mutation/DeleteEntry.php
@@ -72,7 +72,7 @@ class DeleteEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/DeleteEntry.php
+++ b/src/Mutation/DeleteEntry.php
@@ -34,7 +34,7 @@ class DeleteEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'          => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -50,7 +50,7 @@ class DeleteEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'deletedId' => [
 				'type'        => 'ID',
@@ -71,8 +71,8 @@ class DeleteEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/DeleteEntry.php
+++ b/src/Mutation/DeleteEntry.php
@@ -72,7 +72,7 @@ class DeleteEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			if ( ! GFCommon::current_user_can_any( 'gravityforms_delete_entries' ) ) {
 				throw new UserError( __( 'Sorry, you are not allowed to delete entries.', 'wp-graphql-gravity-forms' ) );
 			}

--- a/src/Mutation/SubmitDraftEntry.php
+++ b/src/Mutation/SubmitDraftEntry.php
@@ -80,7 +80,7 @@ class SubmitDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Get the resume token.
 			$id_type      = isset( $input['idType'] ) ? $input['idType'] : 'global_id';
 			$resume_token = self::get_resume_token_from_id( $input['id'], $id_type );

--- a/src/Mutation/SubmitDraftEntry.php
+++ b/src/Mutation/SubmitDraftEntry.php
@@ -80,7 +80,7 @@ class SubmitDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Get the resume token.
 			$id_type      = isset( $input['idType'] ) ? $input['idType'] : 'global_id';
 			$resume_token = self::get_resume_token_from_id( $input['id'], $id_type );

--- a/src/Mutation/SubmitDraftEntry.php
+++ b/src/Mutation/SubmitDraftEntry.php
@@ -36,7 +36,7 @@ class SubmitDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'     => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -52,7 +52,7 @@ class SubmitDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'confirmation' => [
 				'type'        => SubmissionConfirmation::$type,
@@ -79,8 +79,8 @@ class SubmitDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			// Get the resume token.
 			$id_type      = isset( $input['idType'] ) ? $input['idType'] : 'global_id';
 			$resume_token = self::get_resume_token_from_id( $input['id'], $id_type );

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -39,7 +39,7 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'          => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -71,7 +71,7 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'confirmation' => [
 				'type'        => SubmissionConfirmation::$type,
@@ -130,8 +130,8 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			// Get the form database_id.
 			$form_id = Utils::get_form_id_from_id( $input['id'] );
 
@@ -177,7 +177,7 @@ class SubmitForm extends AbstractMutation {
 	 *
 	 * @param array $input .
 	 */
-	private static function prepare_entry_data( array $input ) : array {
+	private static function prepare_entry_data( array $input ): array {
 		$data = [];
 
 		// Update Created by id.
@@ -210,7 +210,7 @@ class SubmitForm extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	private static function prepare_field_values( array $field_values, array $form, bool $save_as_draft ) : array {
+	private static function prepare_field_values( array $field_values, array $form, bool $save_as_draft ): array {
 		$formatted_values = [];
 
 		// Prepares field values to a format GF can understand.
@@ -231,7 +231,7 @@ class SubmitForm extends AbstractMutation {
 	 * @param array $entry_meta .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	private static function update_entry_properties( array $form, array $submission, array $entry_meta ) : void {
+	private static function update_entry_properties( array $form, array $submission, array $entry_meta ): void {
 		if ( ! empty( $submission['resume_token'] ) ) {
 			$decoded_submission = GFUtils::get_draft_submission( $submission['resume_token'] );
 
@@ -278,7 +278,7 @@ class SubmitForm extends AbstractMutation {
 	 * @param array   $field_values . Required so submit_form() can generate the $_POST object.
 	 * @param array   $file_upload_values .
 	 */
-	private static function get_input_values( bool $is_draft, array $field_values, array $file_upload_values ) : array {
+	private static function get_input_values( bool $is_draft, array $field_values, array $file_upload_values ): array {
 		$input_values = [
 			'gform_save' => $is_draft,
 		];

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -97,7 +97,7 @@ class SubmitForm extends AbstractMutation {
 						 * The callback checks if the model is for the current id, and then it's applied
 						 * to the model as a filter.
 						 */
-						$is_private_callback = function ( bool $can_view, int $form_id, $entry_id ) use ( $payload ) {
+						$is_private_callback = static function ( bool $can_view, int $form_id, $entry_id ) use ( $payload ) {
 							if ( $payload['entryId'] === $entry_id ) {
 								return true;
 							}
@@ -131,7 +131,7 @@ class SubmitForm extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Get the form database_id.
 			$form_id = Utils::get_form_id_from_id( $input['id'] );
 
@@ -229,7 +229,7 @@ class SubmitForm extends AbstractMutation {
 	 * @param array $form .
 	 * @param array $submission The Gravity Forms submission result array.
 	 * @param array $entry_meta .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	private static function update_entry_properties( array $form, array $submission, array $entry_meta ) : void {
 		if ( ! empty( $submission['resume_token'] ) ) {

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -97,7 +97,7 @@ class SubmitForm extends AbstractMutation {
 						 * The callback checks if the model is for the current id, and then it's applied
 						 * to the model as a filter.
 						 */
-						$is_private_callback = function( bool $can_view, int $form_id, $entry_id ) use ( $payload ) {
+						$is_private_callback = function ( bool $can_view, int $form_id, $entry_id ) use ( $payload ) {
 							if ( $payload['entryId'] === $entry_id ) {
 								return true;
 							}
@@ -131,7 +131,7 @@ class SubmitForm extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Get the form database_id.
 			$form_id = Utils::get_form_id_from_id( $input['id'] );
 

--- a/src/Mutation/UpdateDraftEntry.php
+++ b/src/Mutation/UpdateDraftEntry.php
@@ -43,7 +43,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'             => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -71,7 +71,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'draftEntry' => [
 				'type'        => DraftEntry::$type,
@@ -97,8 +97,8 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 
@@ -136,7 +136,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * @param array $submission .
 	 * @param array $form .
 	 */
-	private static function prepare_draft_entry_data( array $input, array $submission, array $form ) : array {
+	private static function prepare_draft_entry_data( array $input, array $submission, array $form ): array {
 		$should_validate = isset( $input['shouldValidate'] ) ? (bool) $input['shouldValidate'] : true;
 
 		// Update field values.
@@ -196,7 +196,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * @param array $submission .
 	 * @param bool  $should_validate .
 	 */
-	private static function prepare_field_values( array $field_values, array $form, array $entry, array &$submission, bool $should_validate ) : array {
+	private static function prepare_field_values( array $field_values, array $form, array $entry, array &$submission, bool $should_validate ): array {
 		$formatted_values = [];
 
 		foreach ( $field_values as $values ) {
@@ -220,7 +220,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected static function check_required_inputs( $input = null ) : void {
+	protected static function check_required_inputs( $input = null ): void {
 		if ( empty( $input['entryMeta'] ) && empty( $input['fieldValues'] ) ) {
 			throw new UserError( __( 'Mutation not processed. No data provided to update.', 'wp-graphql-gravity-forms' ) );
 		}

--- a/src/Mutation/UpdateDraftEntry.php
+++ b/src/Mutation/UpdateDraftEntry.php
@@ -98,7 +98,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 
@@ -218,7 +218,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected static function check_required_inputs( $input = null ) : void {
 		if ( empty( $input['entryMeta'] ) && empty( $input['fieldValues'] ) ) {

--- a/src/Mutation/UpdateDraftEntry.php
+++ b/src/Mutation/UpdateDraftEntry.php
@@ -98,7 +98,7 @@ class UpdateDraftEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -93,7 +93,7 @@ class UpdateEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
+		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 
@@ -133,7 +133,7 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	protected static function check_required_inputs( $input = null ) : void {
 		if ( ! empty( $input['entryMeta'] ) && empty( $input['fieldValues'] ) ) {
@@ -147,7 +147,7 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array $input .
 	 * @param array $entry .
 	 * @param array $form .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	private static function prepare_entry_data( array $input, array $entry, array $form ) : array {
 		$should_validate = isset( $input['shouldValidate'] ) ? (bool) $input['shouldValidate'] : true;
@@ -301,9 +301,9 @@ class UpdateEntry extends AbstractMutation {
 	public static function update_post( int $entry_id, array $form ) : void {
 		$entry = GFUtils::get_entry( $entry_id );
 
-		add_filter( 'gform_post_data', [ __CLASS__, 'set_post_id_for_update' ], 10, 3 );
+		add_filter( 'gform_post_data', [ self::class, 'set_post_id_for_update' ], 10, 3 );
 		GFFormsModel::create_post( $form, $entry );
-		remove_filter( 'gform_post_data', [ __CLASS__, 'set_post_id_for_update' ] );
+		remove_filter( 'gform_post_data', [ self::class, 'set_post_id_for_update' ] );
 	}
 
 	/**

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -93,7 +93,7 @@ class UpdateEntry extends AbstractMutation {
 	 * {@inheritDoc}
 	 */
 	public static function mutate_and_get_payload() : callable {
-		return function( $input, AppContext $context, ResolveInfo $info ) : array {
+		return function ( $input, AppContext $context, ResolveInfo $info ) : array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 

--- a/src/Mutation/UpdateEntry.php
+++ b/src/Mutation/UpdateEntry.php
@@ -45,7 +45,7 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_input_fields() : array {
+	public static function get_input_fields(): array {
 		return [
 			'id'             => [
 				'type'        => [ 'non_null' => 'ID' ],
@@ -69,7 +69,7 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_output_fields() : array {
+	public static function get_output_fields(): array {
 		return [
 			'entry'  => [
 				'type'        => SubmittedEntry::$type,
@@ -92,8 +92,8 @@ class UpdateEntry extends AbstractMutation {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function mutate_and_get_payload() : callable {
-		return static function ( $input, AppContext $context, ResolveInfo $info ) : array {
+	public static function mutate_and_get_payload(): callable {
+		return static function ( $input, AppContext $context, ResolveInfo $info ): array {
 			// Check for required fields.
 			static::check_required_inputs( $input );
 
@@ -135,7 +135,7 @@ class UpdateEntry extends AbstractMutation {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	protected static function check_required_inputs( $input = null ) : void {
+	protected static function check_required_inputs( $input = null ): void {
 		if ( ! empty( $input['entryMeta'] ) && empty( $input['fieldValues'] ) ) {
 			throw new UserError( __( 'Mutation not processed. No data provided to update.', 'wp-graphql-gravity-forms' ) );
 		}
@@ -149,7 +149,7 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array $form .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	private static function prepare_entry_data( array $input, array $entry, array $form ) : array {
+	private static function prepare_entry_data( array $input, array $entry, array $form ): array {
 		$should_validate = isset( $input['shouldValidate'] ) ? (bool) $input['shouldValidate'] : true;
 
 		// Update Field values.
@@ -251,7 +251,7 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array $form .
 	 * @param bool  $should_validate .
 	 */
-	private static function prepare_field_values( array $field_values, array $entry, array $form, bool $should_validate ) : array {
+	private static function prepare_field_values( array $field_values, array $entry, array $form, bool $should_validate ): array {
 		$formatted_values = [];
 
 		foreach ( $field_values as $values ) {
@@ -274,7 +274,7 @@ class UpdateEntry extends AbstractMutation {
 	 * @param array $entry the existing entry.
 	 * @param array $form the existing form.
 	 */
-	public static function prepare_field_values_for_save( array $values, array $entry, array $form ) : array {
+	public static function prepare_field_values_for_save( array $values, array $entry, array $form ): array {
 		// We need the entry fresh to prepare the values.
 		$entry = array_merge( $entry, $values );
 
@@ -298,7 +298,7 @@ class UpdateEntry extends AbstractMutation {
 	 * @param integer $entry_id .
 	 * @param array   $form .
 	 */
-	public static function update_post( int $entry_id, array $form ) : void {
+	public static function update_post( int $entry_id, array $form ): void {
 		$entry = GFUtils::get_entry( $entry_id );
 
 		add_filter( 'gform_post_data', [ self::class, 'set_post_id_for_update' ], 10, 3 );

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -12,9 +12,9 @@
 namespace WPGraphQL\GF\Registry;
 
 use GF_Field;
+use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 use WPGraphQL\GF\Type\WPInterface\FieldChoice;
 use WPGraphQL\GF\Utils\Utils;
-use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 use WPGraphQL\Registry\TypeRegistry;
 
 
@@ -38,7 +38,7 @@ class FieldChoiceRegistry {
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
-	public static function get_type_name( GF_Field $field ) : string {
+	public static function get_type_name( GF_Field $field ): string {
 		$input_type = $field->get_input_type();
 
 		switch ( true ) {
@@ -56,7 +56,7 @@ class FieldChoiceRegistry {
 	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
 	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
-	public static function register( GF_Field $field, array $settings, bool $as_interface = false ) : void {
+	public static function register( GF_Field $field, array $settings, bool $as_interface = false ): void {
 		add_action(
 			get_graphql_register_action(),
 			static function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
@@ -101,7 +101,7 @@ class FieldChoiceRegistry {
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 * @param array     $settings The Gravity Forms field settings.
 	 */
-	public static function get_config_from_settings( string $choice_name, GF_Field $field, array $settings ) : array {
+	public static function get_config_from_settings( string $choice_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );
 
 		$fields = self::get_fields( $choice_name, $field, $settings, $interfaces );
@@ -123,7 +123,7 @@ class FieldChoiceRegistry {
 	 *
 	 * @param array $settings .
 	 */
-	public static function get_interfaces( array $settings ) : array {
+	public static function get_interfaces( array $settings ): array {
 		// Every Choice is a FieldChoice.
 		$interfaces = [
 			FieldChoice::$type,
@@ -159,7 +159,7 @@ class FieldChoiceRegistry {
 	 * @param array     $settings The Gravity Forms field settings.
 	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
-	public static function get_fields( string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function get_fields( string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		$fields = FieldChoice::get_fields();
 
 		/**
@@ -175,5 +175,4 @@ class FieldChoiceRegistry {
 
 		return apply_filters( 'graphql_gf_form_field_setting_choice_fields_' . $choice_name, $fields, $field, $settings, $interfaces );
 	}
-
 }

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -36,7 +36,7 @@ class FieldChoiceRegistry {
 	/**
 	 * Gets the GraphQL type name for the generated GF Field input.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
+	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
 	public static function get_type_name( GF_Field $field ) : string {
 		$input_type = $field->get_input_type();
@@ -52,14 +52,14 @@ class FieldChoiceRegistry {
 	/**
 	 * Registers the Choice property for the GF Form Field as a GraphQL object.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings used to define the GraphQL object.
-	 * @param bool     $as_interface Whether to register the choice as an interface. Default false.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
+	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
 	public static function register( GF_Field $field, array $settings, bool $as_interface = false ) : void {
 		add_action(
 			get_graphql_register_action(),
-			function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
+			static function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
 				$choice_name = self::get_type_name( $field );
 				
 				// Skip if already registered.
@@ -70,7 +70,7 @@ class FieldChoiceRegistry {
 				$config = self::get_config_from_settings( $choice_name, $field, $settings );
 
 				if ( $as_interface ) {
-					$config['resolveType'] = function ( $value ) use ( $choice_name ) {
+					$config['resolveType'] = static function ( $value ) use ( $choice_name ) {
 						return $choice_name;
 					};
 
@@ -97,9 +97,9 @@ class FieldChoiceRegistry {
 	/**
 	 * Returns the config array used to register the form field.
 	 *
-	 * @param string   $choice_name The name of the choice.
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings.
+	 * @param string    $choice_name The name of the choice.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings.
 	 */
 	public static function get_config_from_settings( string $choice_name, GF_Field $field, array $settings ) : array {
 		$interfaces = self::get_interfaces( $settings );
@@ -154,10 +154,10 @@ class FieldChoiceRegistry {
 	/**
 	 * Gets the fields to register to the FieldChoice object.
 	 *
-	 * @param string   $choice_name .
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings.
-	 * @param array    $interfaces The list of interfaces to add to the field.
+	 * @param string    $choice_name .
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings.
+	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
 	public static function get_fields( string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
 		$fields = FieldChoice::get_fields();
@@ -167,7 +167,7 @@ class FieldChoiceRegistry {
 		 *
 		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
 		 * @param string   $choice_name The name of the choice type.
-		 * @param GF_Field $field The Gravity Forms Field object.
+		 * @param \GF_Field $field The Gravity Forms Field object.
 		 * @param array    $settings The `form_editor_field_settings()` keys.
 		 * @param array    $interfaces The list of interfaces for the GraphQL type.
 		 */

--- a/src/Registry/FieldChoiceRegistry.php
+++ b/src/Registry/FieldChoiceRegistry.php
@@ -70,7 +70,7 @@ class FieldChoiceRegistry {
 				$config = self::get_config_from_settings( $choice_name, $field, $settings );
 
 				if ( $as_interface ) {
-					$config['resolveType'] = function( $value ) use ( $choice_name ) {
+					$config['resolveType'] = function ( $value ) use ( $choice_name ) {
 						return $choice_name;
 					};
 

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -12,10 +12,10 @@
 namespace WPGraphQL\GF\Registry;
 
 use GF_Field;
+use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 use WPGraphQL\GF\Type\WPInterface\FieldInput;
 use WPGraphQL\GF\Utils\Utils;
 use WPGraphQL\Registry\TypeRegistry;
-use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 
 
 /**
@@ -38,7 +38,7 @@ class FieldInputRegistry {
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
-	public static function get_type_name( GF_Field $field ) : string {
+	public static function get_type_name( GF_Field $field ): string {
 		$input_type = $field->get_input_type();
 
 		$input_name = ( $field->type !== $input_type ? $field->type . '_' . $input_type : $field->type ) . 'InputProperty';
@@ -59,7 +59,7 @@ class FieldInputRegistry {
 	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
 	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
-	public static function register( GF_Field $field, array $settings, bool $as_interface = false ) : void {
+	public static function register( GF_Field $field, array $settings, bool $as_interface = false ): void {
 		add_action(
 			get_graphql_register_action(),
 			static function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
@@ -103,7 +103,7 @@ class FieldInputRegistry {
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 * @param array     $settings The Gravity Forms field settings.
 	 */
-	public static function get_config_from_settings( string $input_name, GF_Field $field, array $settings ) : array {
+	public static function get_config_from_settings( string $input_name, GF_Field $field, array $settings ): array {
 		$interfaces = self::get_interfaces( $settings );
 
 		$fields = self::get_fields( $input_name, $field, $settings, $interfaces );
@@ -125,7 +125,7 @@ class FieldInputRegistry {
 	 *
 	 * @param array $settings .
 	 */
-	public static function get_interfaces( array $settings ) : array {
+	public static function get_interfaces( array $settings ): array {
 		// Every Input is a FieldInput.
 		$interfaces = [
 			FieldInput::$type,
@@ -161,7 +161,7 @@ class FieldInputRegistry {
 	 * @param array     $settings The Gravity Forms field settings.
 	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
-	public static function get_fields( string $input_name, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function get_fields( string $input_name, GF_Field $field, array $settings, array $interfaces ): array {
 		$fields = FieldInput::get_fields();
 
 		/**
@@ -177,5 +177,4 @@ class FieldInputRegistry {
 
 		return apply_filters( 'graphql_gf_form_field_setting_input_fields_' . $input_name, $fields, $field, $settings, $interfaces );
 	}
-
 }

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -36,7 +36,7 @@ class FieldInputRegistry {
 	/**
 	 * Gets the GraphQL type name for the generated GF Field input.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
+	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
 	public static function get_type_name( GF_Field $field ) : string {
 		$input_type = $field->get_input_type();
@@ -55,14 +55,14 @@ class FieldInputRegistry {
 	/**
 	 * Registers the Input property for the GF Form Field as a GraphQL object.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings used to define the GraphQL object.
-	 * @param bool     $as_interface Whether to register the choice as an interface. Default false.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings used to define the GraphQL object.
+	 * @param bool      $as_interface Whether to register the choice as an interface. Default false.
 	 */
 	public static function register( GF_Field $field, array $settings, bool $as_interface = false ) : void {
 		add_action(
 			get_graphql_register_action(),
-			function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
+			static function ( TypeRegistry $type_registry ) use ( $field, $settings, $as_interface ) {
 				$input_name = self::get_type_name( $field );
 
 				// Skip if already registered.
@@ -73,7 +73,7 @@ class FieldInputRegistry {
 				$config = self::get_config_from_settings( $input_name, $field, $settings );
 
 				if ( $as_interface ) {
-					$config['resolveType'] = function ( $value ) use ( $input_name ) {
+					$config['resolveType'] = static function ( $value ) use ( $input_name ) {
 						return $input_name;
 					};
 
@@ -99,9 +99,9 @@ class FieldInputRegistry {
 	/**
 	 * Returns the config array used to register the form field.
 	 *
-	 * @param string   $input_name The name of the input.
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings.
+	 * @param string    $input_name The name of the input.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings.
 	 */
 	public static function get_config_from_settings( string $input_name, GF_Field $field, array $settings ) : array {
 		$interfaces = self::get_interfaces( $settings );
@@ -156,10 +156,10 @@ class FieldInputRegistry {
 	/**
 	 * Gets the fields to register to the FieldInput object.
 	 *
-	 * @param string   $input_name .
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings.
-	 * @param array    $interfaces The list of interfaces to add to the field.
+	 * @param string    $input_name .
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings.
+	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
 	public static function get_fields( string $input_name, GF_Field $field, array $settings, array $interfaces ) : array {
 		$fields = FieldInput::get_fields();
@@ -169,7 +169,7 @@ class FieldInputRegistry {
 		 *
 		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
 		 * @param string   $input_name The name of the input type.
-		 * @param GF_Field $field The Gravity Forms Field object.
+		 * @param \GF_Field $field The Gravity Forms Field object.
 		 * @param array    $settings The `form_editor_field_settings()` key.
 		 * @param array    $interfaces The list of interfaces for the GraphQL type.
 		 */

--- a/src/Registry/FieldInputRegistry.php
+++ b/src/Registry/FieldInputRegistry.php
@@ -73,7 +73,7 @@ class FieldInputRegistry {
 				$config = self::get_config_from_settings( $input_name, $field, $settings );
 
 				if ( $as_interface ) {
-					$config['resolveType'] = function( $value ) use ( $input_name ) {
+					$config['resolveType'] = function ( $value ) use ( $input_name ) {
 						return $input_name;
 					};
 

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -14,9 +14,6 @@ namespace WPGraphQL\GF\Registry;
 use GF_Field;
 use GF_Fields;
 use GraphQL\Error\UserError;
-use WPGraphQL\GF\Type\WPInterface\FieldWithPersonalData;
-use WPGraphQL\GF\Type\WPInterface\FormField;
-use WPGraphQL\GF\Type\WPObject\FormField\FieldValue\FieldValues;
 use WPGraphQL\GF\Registry\TypeRegistry as GFTypeRegistry;
 use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithAddress;
 use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithChoices;
@@ -29,20 +26,22 @@ use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithPassword;
 use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithSelectAllChoices;
 use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithSingleProductInputs;
 use WPGraphQL\GF\Type\WPInterface\FieldSetting\FieldWithTimeFormat;
-use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\GF\Type\WPInterface\FieldWithPersonalData;
+use WPGraphQL\GF\Type\WPInterface\FormField;
+use WPGraphQL\GF\Type\WPObject\FormField\FieldValue\FieldValues;
 use WPGraphQL\GF\Utils\Utils;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - FormFieldRegisty
  */
 class FormFieldRegistry {
-
 	/**
 	 * Register the Form Field type to the WPGraphQL schema.
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
-	public static function register( GF_Field $field ) : void {
+	public static function register( GF_Field $field ): void {
 		$field->graphql_single_name = Utils::get_safe_form_field_type_name( $field->type ) . 'Field';
 
 		$field_settings = self::get_field_settings( $field );
@@ -85,7 +84,7 @@ class FormFieldRegistry {
 	 * @param array     $field_settings The Gravity Forms field settings.
 	 * @param array     $config The config array as expected by WPGraphQL.
 	 */
-	protected static function register_object_type( GF_Field $field, array $field_settings, array $config ) : void {
+	protected static function register_object_type( GF_Field $field, array $field_settings, array $config ): void {
 		add_action(
 			get_graphql_register_action(),
 			static function ( TypeRegistry $type_registry ) use ( $field, $config, $field_settings ) {
@@ -110,7 +109,6 @@ class FormFieldRegistry {
 		);
 	}
 
-
 	/**
 	 * Registers the GF Form Field as a GraphQL interface before registering it's child types as objects.
 	 *
@@ -120,7 +118,7 @@ class FormFieldRegistry {
 	 * @param array     $settings       The field settings.
 	 * @param array     $possible_types The possible child types of the field. Null if no child types.
 	 */
-	protected static function register_interface_and_types( GF_Field $field, array $settings, array $possible_types ) : void {
+	protected static function register_interface_and_types( GF_Field $field, array $settings, array $possible_types ): void {
 		// Store these for later use.
 		$possible_settings = [];
 
@@ -216,7 +214,7 @@ class FormFieldRegistry {
 	 *
 	 * @param \GF_Field $field .
 	 */
-	public static function get_field_settings( GF_Field $field ) : array {
+	public static function get_field_settings( GF_Field $field ): array {
 		$settings = $field->get_form_editor_field_settings();
 
 		// Product inputs are not stored as a setting, so we're going to fake it.
@@ -244,7 +242,7 @@ class FormFieldRegistry {
 	 * @param \GF_Field $field .
 	 * @param array     $settings .
 	 */
-	public static function get_config_from_settings( GF_Field $field, array $settings ) : array {
+	public static function get_config_from_settings( GF_Field $field, array $settings ): array {
 		// Every GF_field is a FormField.
 		$interfaces = [
 			FormField::$type,
@@ -293,7 +291,7 @@ class FormFieldRegistry {
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 * @param string    $setting The Gravity Forms field setting key.
 	 */
-	public static function get_setting_interface_class( GF_Field $field, string $setting ) : ?string {
+	public static function get_setting_interface_class( GF_Field $field, string $setting ): ?string {
 		$class = null;
 
 		$classes = GFTypeRegistry::form_field_settings();
@@ -329,7 +327,7 @@ class FormFieldRegistry {
 	 *
 	 * @param string $field_name The name of the field.
 	 */
-	public static function get_description( string $field_name ) : string {
+	public static function get_description( string $field_name ): string {
 		// translators: GF field type and possibly parent type.
 		return sprintf( __( 'A Gravity Forms %s field.', 'wp-graphql-gravity-forms' ), $field_name );
 	}
@@ -341,7 +339,7 @@ class FormFieldRegistry {
 	 * @param array     $settings The Gravity Forms field settings.
 	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
-	public static function get_fields( GF_Field $field, array $settings, $interfaces ) : array {
+	public static function get_fields( GF_Field $field, array $settings, $interfaces ): array {
 		$fields = [];
 
 		if ( has_filter( 'graphql_gf_form_field_setting_properties' ) ) {
@@ -378,7 +376,7 @@ class FormFieldRegistry {
 	 *
 	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
-	public static function get_field_value_fields( GF_Field $field ) : array {
+	public static function get_field_value_fields( GF_Field $field ): array {
 		$fields = [];
 		if ( ! empty( $field->displayOnly ) || in_array( $field->type, [ 'html', 'page', 'section' ], true ) ) {
 			return $fields;
@@ -460,7 +458,7 @@ class FormFieldRegistry {
 	 * @param array     $field_settings The Gravity Forms field settings.
 	 * @param bool      $as_interface   Whether to register the choices and inputs as an interface.
 	 */
-	protected static function maybe_register_choices_and_inputs( GF_Field $field, array $field_settings, bool $as_interface = false ) : void {
+	protected static function maybe_register_choices_and_inputs( GF_Field $field, array $field_settings, bool $as_interface = false ): void {
 		/**
 		 * Filters the Gravity Forms field settings that should have a `choices` GraphQL Field.
 		 *

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -40,7 +40,7 @@ class FormFieldRegistry {
 	/**
 	 * Register the Form Field type to the WPGraphQL schema.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
+	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
 	public static function register( GF_Field $field ) : void {
 		$field->graphql_single_name = Utils::get_safe_form_field_type_name( $field->type ) . 'Field';
@@ -71,7 +71,7 @@ class FormFieldRegistry {
 		 *
 		 * The fields themselves will only be registered on the next get_graphql_register_action() call.
 		 *
-		 * @param GF_Field $field The Gravity Forms field object.
+		 * @param \GF_Field $field The Gravity Forms field object.
 		 * @param array    $field_settings The field settings.
 		 */
 		do_action( 'graphql_gf_after_register_form_field', $field, $field_settings );
@@ -81,9 +81,9 @@ class FormFieldRegistry {
 	/**
 	 * Registers the GF Form Field as a GraphQL object, wrapped in actions to keep things DRY.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $field_settings The Gravity Forms field settings.
-	 * @param array    $config The config array as expected by WPGraphQL.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $field_settings The Gravity Forms field settings.
+	 * @param array     $config The config array as expected by WPGraphQL.
 	 */
 	protected static function register_object_type( GF_Field $field, array $field_settings, array $config ) : void {
 		add_action(
@@ -100,7 +100,7 @@ class FormFieldRegistry {
 				/**
 				 * Fires after the Gravity Forms field object has been registered to WPGraphQL schema.
 				 *
-				 * @param GF_Field $field The Gravity Forms field object.
+				 * @param \GF_Field $field The Gravity Forms field object.
 				 * @param array    $field_settings The field settings.
 				 * @param array    $config The config array as expected by WPGraphQL.
 				 */
@@ -116,9 +116,9 @@ class FormFieldRegistry {
 	 *
 	 * @uses FormFields::register_gf_field_object() to register the child types.
 	 *
-	 * @param GF_Field $field          The Gravity Forms field object.
-	 * @param array    $settings       The field settings.
-	 * @param array    $possible_types The possible child types of the field. Null if no child types.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings       The field settings.
+	 * @param array     $possible_types The possible child types of the field. Null if no child types.
 	 */
 	protected static function register_interface_and_types( GF_Field $field, array $settings, array $possible_types ) : void {
 		// Store these for later use.
@@ -158,7 +158,7 @@ class FormFieldRegistry {
 
 				$config['description'] = self::get_description( $field->type );
 
-				$config['resolveType'] = function ( $value ) use ( $type_registry, $possible_types ) {
+				$config['resolveType'] = static function ( $value ) use ( $type_registry, $possible_types ) {
 					$input_type = $value->get_input_type();
 					if ( isset( $possible_types[ $input_type ] ) ) {
 						$type = $type_registry->get_type( $possible_types[ $value->$input_type ] );
@@ -214,7 +214,7 @@ class FormFieldRegistry {
 	/**
 	 * Gets the registered field settings, including those of input types.
 	 *
-	 * @param GF_Field $field .
+	 * @param \GF_Field $field .
 	 */
 	public static function get_field_settings( GF_Field $field ) : array {
 		$settings = $field->get_form_editor_field_settings();
@@ -241,8 +241,8 @@ class FormFieldRegistry {
 	/**
 	 * Returns the config array used to register the form field.
 	 *
-	 * @param GF_Field $field .
-	 * @param array    $settings .
+	 * @param \GF_Field $field .
+	 * @param array     $settings .
 	 */
 	public static function get_config_from_settings( GF_Field $field, array $settings ) : array {
 		// Every GF_field is a FormField.
@@ -290,8 +290,8 @@ class FormFieldRegistry {
 	/**
 	 * Gets the PHP class for the interface.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param string   $setting The Gravity Forms field setting key.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param string    $setting The Gravity Forms field setting key.
 	 */
 	public static function get_setting_interface_class( GF_Field $field, string $setting ) : ?string {
 		$class = null;
@@ -337,9 +337,9 @@ class FormFieldRegistry {
 	/**
 	 * Gets the GraphQL fields config for the form field.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
-	 * @param array    $settings The Gravity Forms field settings.
-	 * @param array    $interfaces The list of interfaces to add to the field.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $settings The Gravity Forms field settings.
+	 * @param array     $interfaces The list of interfaces to add to the field.
 	 */
 	public static function get_fields( GF_Field $field, array $settings, $interfaces ) : array {
 		$fields = [];
@@ -353,7 +353,7 @@ class FormFieldRegistry {
 				 *
 				 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
 				 * @param string    $setting_key   The `form_editor_field_settings()` key.
-				 * @param GF_Field $field      The Gravity Forms Field object.
+				 * @param \GF_Field $field The Gravity Forms Field object.
 				 * @param array    $interfaces The list of interfaces for the GraphQL type.
 				 */
 				$fields = apply_filters_deprecated( 'graphql_gf_form_field_setting_properties', [ $fields, $setting_key, $field ], '0.12.0', 'graphql_gf_form_field_setting_fields' );
@@ -364,7 +364,7 @@ class FormFieldRegistry {
 		 * Filter to modify the Form Field GraphQL fields.
 		 *
 		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param GF_Field $field The Gravity Forms Field object.
+		 * @param \GF_Field $field The Gravity Forms Field object.
 		 * @param array    $settings The `form_editor_field_settings()` key.
 		 * @param array    $interfaces The list of interfaces for the GraphQL type.
 		 */
@@ -376,7 +376,7 @@ class FormFieldRegistry {
 	/**
 	 * Gets the Field Value field config.
 	 *
-	 * @param GF_Field $field The Gravity Forms field object.
+	 * @param \GF_Field $field The Gravity Forms field object.
 	 */
 	public static function get_field_value_fields( GF_Field $field ) : array {
 		$fields = [];
@@ -438,7 +438,7 @@ class FormFieldRegistry {
 		 * @deprecated 0.12.0 Use `graphql_gf_form_field_value_fields` instead.
 		 *
 		 * @param array $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param GF_Field $field The Gravity Forms Field object.
+		 * @param \GF_Field $field The Gravity Forms Field object.
 		 */
 		$fields = apply_filters_deprecated( 'graphql_gf_form_field_value_properties', [ $fields, $field ], '0.12.0', 'graphql_gf_form_field_value_fields' );
 
@@ -446,7 +446,7 @@ class FormFieldRegistry {
 		 * Filter to modify the Form Field Value GraphQL fields.
 		 *
 		 * @param array    $fields An array of GraphQL field configs. See https://www.wpgraphql.com/functions/register_graphql_fields/
-		 * @param GF_Field $field The Gravity Forms Field object.
+		 * @param \GF_Field $field The Gravity Forms Field object.
 		 */
 		$fields = apply_filters( 'graphql_gf_form_field_value_fields', $fields, $field );
 
@@ -456,9 +456,9 @@ class FormFieldRegistry {
 	/**
 	 * Calls the actions to register the choices and inputs to the type.
 	 *
-	 * @param GF_Field $field          The Gravity Forms field object.
-	 * @param array    $field_settings The Gravity Forms field settings.
-	 * @param bool     $as_interface   Whether to register the choices and inputs as an interface.
+	 * @param \GF_Field $field The Gravity Forms field object.
+	 * @param array     $field_settings The Gravity Forms field settings.
+	 * @param bool      $as_interface   Whether to register the choices and inputs as an interface.
 	 */
 	protected static function maybe_register_choices_and_inputs( GF_Field $field, array $field_settings, bool $as_interface = false ) : void {
 		/**
@@ -466,7 +466,7 @@ class FormFieldRegistry {
 		 *
 		 * @param array    $settings_with_choices The field settings that should have a `choices` GraphQL Field.
 		 * @param array    $field_settings The Gravity Forms field settings.
-		 * @param GF_Field $field The Gravity Forms field object.
+		 * @param \GF_Field $field The Gravity Forms field object.
 		 * @param bool     $as_interface Whether to register the choice as an interface.
 		 */
 		$settings_with_choices = apply_filters(
@@ -495,7 +495,7 @@ class FormFieldRegistry {
 		 *
 		 * @param array    $settings_with_inputs The field settings that should have an `inputs` GraphQL Field.
 		 * @param array    $field_settings The Gravity Forms field settings.
-		 * @param GF_Field $field The Gravity Forms field object.
+		 * @param \GF_Field $field The Gravity Forms field object.
 		 * @param bool     $as_interface Whether to register the inputs as an interface.
 		 */
 		$settings_with_inputs = apply_filters(

--- a/src/Registry/FormFieldRegistry.php
+++ b/src/Registry/FormFieldRegistry.php
@@ -158,7 +158,7 @@ class FormFieldRegistry {
 
 				$config['description'] = self::get_description( $field->type );
 
-				$config['resolveType'] = function( $value ) use ( $type_registry, $possible_types ) {
+				$config['resolveType'] = function ( $value ) use ( $type_registry, $possible_types ) {
 					$input_type = $value->get_input_type();
 					if ( isset( $possible_types[ $input_type ] ) ) {
 						$type = $type_registry->get_type( $possible_types[ $value->$input_type ] );

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -22,7 +22,6 @@ use WPGraphQL\GF\Utils\Utils;
  * Class - TypeRegistry
  */
 class TypeRegistry {
-
 	/**
 	 * The local registry of registered types.
 	 *
@@ -40,7 +39,7 @@ class TypeRegistry {
 	/**
 	 * Gets an array of all the registered GraphQL types along with their class name.
 	 */
-	public static function get_registered_types() : array {
+	public static function get_registered_types(): array {
 		if ( empty( self::$registry ) ) {
 			self::initialize_registry();
 		}
@@ -51,7 +50,7 @@ class TypeRegistry {
 	/**
 	 * Gets an array of all the registered GraphQL types along with their class name.
 	 */
-	public static function get_registered_classes() : array {
+	public static function get_registered_classes(): array {
 		if ( empty( self::$registered_classes ) ) {
 			self::initialize_registry();
 		}
@@ -62,7 +61,7 @@ class TypeRegistry {
 	/**
 	 * Registers types, connections, unions, and mutations to GraphQL schema.
 	 */
-	public static function init() : void {
+	public static function init(): void {
 		/**
 		 * Fires before all types have been registered.
 		 */
@@ -79,7 +78,7 @@ class TypeRegistry {
 	/**
 	 * Initializes the GF type registry. If $type_registry is nulled, these fields wont be (re)-registered to WPGraphQL.
 	 */
-	private static function initialize_registry() : void {
+	private static function initialize_registry(): void {
 		$classes_to_register = array_merge(
 			self::enums(),
 			self::inputs(),
@@ -95,14 +94,12 @@ class TypeRegistry {
 		self::register_types( self::$registered_classes );
 	}
 
-
-
 	/**
 	 * List of Enum classes to register.
 	 *
 	 * @return class-string[]
 	 */
-	private static function enums() : array {
+	private static function enums(): array {
 		// Enums to register.
 		$classes_to_register = [
 			Enum\AddressFieldCountryEnum::class,
@@ -174,7 +171,7 @@ class TypeRegistry {
 	 *
 	 * @return class-string[]
 	 */
-	private static function inputs() : array {
+	private static function inputs(): array {
 		$classes_to_register = [
 			Input\AddressFieldInput::class,
 			Input\CheckboxFieldInput::class,
@@ -214,7 +211,7 @@ class TypeRegistry {
 	 *
 	 * @return class-string[]
 	 */
-	public static function interfaces() : array {
+	public static function interfaces(): array {
 		$classes_to_register = [
 			WPInterface\Entry::class,
 			WPInterface\FormField::class,
@@ -246,7 +243,7 @@ class TypeRegistry {
 	 *
 	 * @return class-string[]
 	 */
-	public static function objects() : array {
+	public static function objects(): array {
 		$classes_to_register = [
 			// Buttons.
 			WPObject\Button\FormButton::class,
@@ -315,7 +312,7 @@ class TypeRegistry {
 	 *
 	 * @return array<string, class-string>
 	 */
-	public static function form_field_settings() : array {
+	public static function form_field_settings(): array {
 		// Key-value pairs of settings and their corresponding class name.
 		$classes_to_register = [
 			'add_icon_url_setting'               => WPInterface\FieldSetting\FieldWithAddIconUrl::class,
@@ -402,7 +399,7 @@ class TypeRegistry {
 	 *
 	 * @return array<string, class-string>
 	 */
-	public static function form_field_setting_inputs() : array {
+	public static function form_field_setting_inputs(): array {
 		// Key-value pairs of settings and their corresponding class name.
 		$classes_to_register = [
 			'address_setting'            => WPInterface\FieldInputSetting\InputWithAddress::class,
@@ -430,7 +427,7 @@ class TypeRegistry {
 	 *
 	 * @return array<string, class-string>
 	 */
-	public static function form_field_setting_choices() : array {
+	public static function form_field_setting_choices(): array {
 		// Key-value pairs of settings and their corresponding class name.
 		$classes_to_register = [
 			'choices_setting'      => WPInterface\FieldChoiceSetting\ChoiceWithChoices::class,
@@ -452,7 +449,7 @@ class TypeRegistry {
 	/**
 	 * List of Field classes to register.
 	 */
-	public static function fields() : array {
+	public static function fields(): array {
 		$classes_to_register = [];
 
 		/**
@@ -468,7 +465,7 @@ class TypeRegistry {
 	/**
 	 * List of Connection classes to register.
 	 */
-	public static function connections() : array {
+	public static function connections(): array {
 		$classes_to_register = [
 			Connection\EntriesConnection::class,
 			Connection\FormsConnection::class,
@@ -488,7 +485,7 @@ class TypeRegistry {
 	/**
 	 * Registers mutation.
 	 */
-	public static function mutations() : array {
+	public static function mutations(): array {
 		$classes_to_register = [
 			Mutation\DeleteDraftEntry::class,
 			Mutation\DeleteEntry::class,
@@ -519,7 +516,7 @@ class TypeRegistry {
 	 *
 	 * @throws \Exception .
 	 */
-	private static function register_types( array $classes_to_register ) : void {
+	private static function register_types( array $classes_to_register ): void {
 		// Bail if there are no classes to register.
 		if ( empty( $classes_to_register ) ) {
 			return;

--- a/src/Registry/TypeRegistry.php
+++ b/src/Registry/TypeRegistry.php
@@ -517,7 +517,7 @@ class TypeRegistry {
 	 *
 	 * @param array $classes_to_register .
 	 *
-	 * @throws Exception .
+	 * @throws \Exception .
 	 */
 	private static function register_types( array $classes_to_register ) : void {
 		// Bail if there are no classes to register.

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -34,12 +34,12 @@ abstract class AbstractType implements Hookable, Registrable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		add_action( 'graphql_register_types', [ static::class, 'register' ] );
 	}
 
 	/**
 	 * Gets the WPGraphQL config array used to register the type.
 	 */
-	abstract public static function get_type_config() : array;
+	abstract public static function get_type_config(): array;
 }

--- a/src/Type/Enum/AbstractEnum.php
+++ b/src/Type/Enum/AbstractEnum.php
@@ -26,7 +26,7 @@ abstract class AbstractEnum extends AbstractType implements Enum, TypeWithDescri
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		$config = static::get_type_config();
 
 		register_graphql_enum_type( static::$type, $config );
@@ -35,7 +35,7 @@ abstract class AbstractEnum extends AbstractType implements Enum, TypeWithDescri
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		return [
 			'description' => static::get_description(),
 			'values'      => static::get_values(),

--- a/src/Type/Enum/AddressFieldCountryEnum.php
+++ b/src/Type/Enum/AddressFieldCountryEnum.php
@@ -25,14 +25,14 @@ class AddressFieldCountryEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Countries supported by Gravity Forms Address Field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		/**
 		 * A gravity forms address field.
 		 *

--- a/src/Type/Enum/AddressFieldCountryEnum.php
+++ b/src/Type/Enum/AddressFieldCountryEnum.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\GF\Type\Enum;
 
-use GF_Field_Address;
 use GF_Fields;
 use WPGraphQL\Type\WPEnumType;
 
@@ -37,7 +36,7 @@ class AddressFieldCountryEnum extends AbstractEnum {
 		/**
 		 * A gravity forms address field.
 		 *
-		 * @var GF_Field_Address $field
+		 * @var \GF_Field_Address $field
 		 */
 		$field     = GF_Fields::get( 'address' );
 		$countries = $field->get_default_countries();

--- a/src/Type/Enum/AddressFieldProvinceEnum.php
+++ b/src/Type/Enum/AddressFieldProvinceEnum.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\GF\Type\Enum;
 
-use GF_Field_Address;
 use GF_Fields;
 use WPGraphQL\Type\WPEnumType;
 
@@ -37,7 +36,7 @@ class AddressFieldProvinceEnum extends AbstractEnum {
 		/**
 		 * A gravity forms address field.
 		 *
-		 * @var GF_Field_Address $field
+		 * @var \GF_Field_Address $field
 		 */
 		$field     = GF_Fields::get( 'address' );
 		$provinces = $field->get_canadian_provinces();

--- a/src/Type/Enum/AddressFieldProvinceEnum.php
+++ b/src/Type/Enum/AddressFieldProvinceEnum.php
@@ -25,14 +25,14 @@ class AddressFieldProvinceEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Canadian Provinces supported by Gravity Forms Address Field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		/**
 		 * A gravity forms address field.
 		 *

--- a/src/Type/Enum/AddressFieldStateEnum.php
+++ b/src/Type/Enum/AddressFieldStateEnum.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\GF\Type\Enum;
 
-use GF_Field_Address;
 use GF_Fields;
 use WPGraphQL\Type\WPEnumType;
 
@@ -37,7 +36,7 @@ class AddressFieldStateEnum extends AbstractEnum {
 		/**
 		 * A gravity forms address field.
 		 *
-		 * @var GF_Field_Address $field
+		 * @var \GF_Field_Address $field
 		 */
 		$field  = GF_Fields::get( 'address' );
 		$states = $field->get_us_states();

--- a/src/Type/Enum/AddressFieldStateEnum.php
+++ b/src/Type/Enum/AddressFieldStateEnum.php
@@ -25,14 +25,14 @@ class AddressFieldStateEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'US States supported by Gravity Forms Address Field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		/**
 		 * A gravity forms address field.
 		 *

--- a/src/Type/Enum/AddressFieldTypeEnum.php
+++ b/src/Type/Enum/AddressFieldTypeEnum.php
@@ -27,14 +27,14 @@ class AddressFieldTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines the type of address to be displayed.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'INTERNATIONAL' => [
 				'description' => __( 'International address type.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/AddressFieldTypeEnum.php
+++ b/src/Type/Enum/AddressFieldTypeEnum.php
@@ -20,9 +20,9 @@ class AddressFieldTypeEnum extends AbstractEnum {
 	public static string $type = 'AddressFieldTypeEnum';
 
 	// Individual elements.
-	const INTERNATIONAL = 'international';
-	const US            = 'us';
-	const CANADIAN      = 'canadian';
+	public const INTERNATIONAL = 'international';
+	public const US            = 'us';
+	public const CANADIAN      = 'canadian';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/AmPmEnum.php
+++ b/src/Type/Enum/AmPmEnum.php
@@ -20,8 +20,8 @@ class AmPmEnum extends AbstractEnum {
 	public static string $type = 'AmPmEnum';
 
 	// Individual elements.
-	const AM = 'am';
-	const PM = 'pm';
+	public const AM = 'am';
+	public const PM = 'pm';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/AmPmEnum.php
+++ b/src/Type/Enum/AmPmEnum.php
@@ -26,14 +26,14 @@ class AmPmEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The AM or PM cycle in a 12-hour clock.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'AM' => [
 				'description' => __( 'AM. The first 12-hour cycle of the day.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/CaptchaFieldBadgePositionEnum.php
+++ b/src/Type/Enum/CaptchaFieldBadgePositionEnum.php
@@ -20,9 +20,9 @@ class CaptchaFieldBadgePositionEnum extends AbstractEnum {
 	public static string $type = 'CaptchaFieldBadgePositionEnum';
 
 	// Individual elements.
-	const BOTTOM_RIGHT = 'bottomright';
-	const BOTTOM_LEFT  = 'bottomleft';
-	const INLINE       = 'inline';
+	public const BOTTOM_RIGHT = 'bottomright';
+	public const BOTTOM_LEFT  = 'bottomleft';
+	public const INLINE       = 'inline';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/CaptchaFieldBadgePositionEnum.php
+++ b/src/Type/Enum/CaptchaFieldBadgePositionEnum.php
@@ -27,14 +27,14 @@ class CaptchaFieldBadgePositionEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The position to place the (invisible) reCaptcha badge.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'BOTTOM_LEFT'  => [
 				'description' => __( 'Bottom-left position.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/CaptchaFieldThemeEnum.php
+++ b/src/Type/Enum/CaptchaFieldThemeEnum.php
@@ -20,8 +20,8 @@ class CaptchaFieldThemeEnum extends AbstractEnum {
 	public static string $type = 'CaptchaFieldThemeEnum';
 
 	// Individual elements.
-	const DARK  = 'dark';
-	const LIGHT = 'light';
+	public const DARK  = 'dark';
+	public const LIGHT = 'light';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/CaptchaFieldThemeEnum.php
+++ b/src/Type/Enum/CaptchaFieldThemeEnum.php
@@ -26,14 +26,14 @@ class CaptchaFieldThemeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The theme to be used for the reCAPTCHA field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'LIGHT' => [
 				'description' => __( 'Light reCAPTCHA theme.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/CaptchaFieldTypeEnum.php
+++ b/src/Type/Enum/CaptchaFieldTypeEnum.php
@@ -20,9 +20,9 @@ class CaptchaFieldTypeEnum extends AbstractEnum {
 	public static string $type = 'CaptchaFieldTypeEnum';
 
 	// Individual elements.
-	const RECAPTCHA = 'recaptcha';
-	const SIMPLE    = 'simple_captcha';
-	const MATH      = 'math';
+	public const RECAPTCHA = 'recaptcha';
+	public const SIMPLE    = 'simple_captcha';
+	public const MATH      = 'math';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/CaptchaFieldTypeEnum.php
+++ b/src/Type/Enum/CaptchaFieldTypeEnum.php
@@ -27,14 +27,14 @@ class CaptchaFieldTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of CAPTCHA field to be used.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'RECAPTCHA' => [
 				'description' => __( 'reCAPTCHA type.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/ConditionalLogicActionTypeEnum.php
+++ b/src/Type/Enum/ConditionalLogicActionTypeEnum.php
@@ -20,8 +20,8 @@ class ConditionalLogicActionTypeEnum extends AbstractEnum {
 	public static string $type = 'ConditionalLogicActionTypeEnum';
 
 	// Individual elements.
-	const SHOW = 'show';
-	const HIDE = 'hide';
+	public const SHOW = 'show';
+	public const HIDE = 'hide';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/ConditionalLogicActionTypeEnum.php
+++ b/src/Type/Enum/ConditionalLogicActionTypeEnum.php
@@ -26,14 +26,14 @@ class ConditionalLogicActionTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The type of action the conditional logic will perform.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'SHOW' => [
 				'description' => __( 'Image button.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/ConditionalLogicLogicTypeEnum.php
+++ b/src/Type/Enum/ConditionalLogicLogicTypeEnum.php
@@ -26,14 +26,14 @@ class ConditionalLogicLogicTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines how to the rules should be evaluated.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ALL' => [
 				'description' => __( 'Evaulate all logic rules.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/ConditionalLogicLogicTypeEnum.php
+++ b/src/Type/Enum/ConditionalLogicLogicTypeEnum.php
@@ -20,8 +20,8 @@ class ConditionalLogicLogicTypeEnum extends AbstractEnum {
 	public static string $type = 'ConditionalLogicLogicTypeEnum';
 
 	// Individual elements.
-	const ALL = 'all';
-	const ANY = 'any';
+	public const ALL = 'all';
+	public const ANY = 'any';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/CurrencyEnum.php
+++ b/src/Type/Enum/CurrencyEnum.php
@@ -25,14 +25,14 @@ class CurrencyEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Currencies supported by Gravity Forms.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		$currencies = RGCurrency::get_currencies();
 
 		$values = [];

--- a/src/Type/Enum/DateFieldFormatEnum.php
+++ b/src/Type/Enum/DateFieldFormatEnum.php
@@ -31,14 +31,14 @@ class DateFieldFormatEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'How the DateField date is displayed.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'MDY'       => [
 				'description' => __( 'mm/dd/yyyy format.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/DateFieldFormatEnum.php
+++ b/src/Type/Enum/DateFieldFormatEnum.php
@@ -20,13 +20,13 @@ class DateFieldFormatEnum extends AbstractEnum {
 	public static string $type = 'DateFieldFormatEnum';
 
 	// Individual elements.
-	const MDY       = 'mdy';
-	const DMY       = 'dmy';
-	const DMY_DASH  = 'dmy_dash';
-	const DMY_DOT   = 'dmy_dot';
-	const YMD_SLASH = 'ymd_slash';
-	const YMD_DASH  = 'ymd_dash';
-	const YMD_DOT   = 'ymd_dot';
+	public const MDY       = 'mdy';
+	public const DMY       = 'dmy';
+	public const DMY_DASH  = 'dmy_dash';
+	public const DMY_DOT   = 'dmy_dot';
+	public const YMD_SLASH = 'ymd_slash';
+	public const YMD_DASH  = 'ymd_dash';
+	public const YMD_DOT   = 'ymd_dot';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/DateFieldTypeEnum.php
+++ b/src/Type/Enum/DateFieldTypeEnum.php
@@ -20,9 +20,9 @@ class DateFieldTypeEnum extends AbstractEnum {
 	public static string $type = 'DateFieldTypeEnum';
 
 	// Individual elements.
-	const FIELD    = 'datefield';
-	const DROPDOWN = 'datedropdown';
-	const PICKER   = 'datepicker';
+	public const FIELD    = 'datefield';
+	public const DROPDOWN = 'datedropdown';
+	public const PICKER   = 'datepicker';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/DateFieldTypeEnum.php
+++ b/src/Type/Enum/DateFieldTypeEnum.php
@@ -27,14 +27,14 @@ class DateFieldTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of date field to display.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'FIELD'    => [
 				'description' => __( 'A simple date field.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/DraftEntryIdTypeEnum.php
+++ b/src/Type/Enum/DraftEntryIdTypeEnum.php
@@ -26,14 +26,14 @@ class DraftEntryIdTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Type of Identifier used to fetch a single resource.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ID'           => [
 				'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/DraftEntryIdTypeEnum.php
+++ b/src/Type/Enum/DraftEntryIdTypeEnum.php
@@ -20,8 +20,8 @@ class DraftEntryIdTypeEnum extends AbstractEnum {
 	public static string $type = 'DraftEntryIdTypeEnum';
 
 	// Individual elements.
-	const ID           = 'global_id';
-	const RESUME_TOKEN = 'resume_token';
+	public const ID           = 'global_id';
+	public const RESUME_TOKEN = 'resume_token';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/EntryIdTypeEnum.php
+++ b/src/Type/Enum/EntryIdTypeEnum.php
@@ -27,14 +27,14 @@ class EntryIdTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Type of Identifier used to fetch a single resource.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ID'           => [
 				'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/EntryIdTypeEnum.php
+++ b/src/Type/Enum/EntryIdTypeEnum.php
@@ -20,9 +20,9 @@ class EntryIdTypeEnum extends AbstractEnum {
 	public static string $type = 'EntryIdTypeEnum';
 
 	// Individual elements.
-	const ID           = 'global_id';
-	const DATABASE_ID  = 'database_id';
-	const RESUME_TOKEN = 'resume_token';
+	public const ID           = 'global_id';
+	public const DATABASE_ID  = 'database_id';
+	public const RESUME_TOKEN = 'resume_token';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/EntryStatusEnum.php
+++ b/src/Type/Enum/EntryStatusEnum.php
@@ -27,14 +27,14 @@ class EntryStatusEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Status of entries to get. Default is ACTIVE.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ACTIVE' => [
 				'description' => __( 'Active entries (default).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/EntryStatusEnum.php
+++ b/src/Type/Enum/EntryStatusEnum.php
@@ -20,9 +20,9 @@ class EntryStatusEnum extends AbstractEnum {
 	public static string $type = 'EntryStatusEnum';
 
 	// Individual elements.
-	const ACTIVE = 'active';
-	const SPAM   = 'spam';
-	const TRASH  = 'trash';
+	public const ACTIVE = 'active';
+	public const SPAM   = 'spam';
+	public const TRASH  = 'trash';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/EntryTypeEnum.php
+++ b/src/Type/Enum/EntryTypeEnum.php
@@ -20,9 +20,9 @@ class EntryTypeEnum extends AbstractEnum {
 	public static string $type = 'EntryTypeEnum';
 
 	// Individual elements.
-	const DRAFT     = 'draft';
-	const PARTIAL   = 'partial';
-	const SUBMITTED = 'submitted';
+	public const DRAFT     = 'draft';
+	public const PARTIAL   = 'partial';
+	public const SUBMITTED = 'submitted';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/EntryTypeEnum.php
+++ b/src/Type/Enum/EntryTypeEnum.php
@@ -27,14 +27,14 @@ class EntryTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The type of Gravity Forms entry.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'DRAFT'     => [
 				'description' => __( 'A Gravity Forms draft entry.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FieldFiltersModeEnum.php
+++ b/src/Type/Enum/FieldFiltersModeEnum.php
@@ -20,8 +20,8 @@ class FieldFiltersModeEnum extends AbstractEnum {
 	public static string $type = 'FieldFiltersModeEnum';
 
 	// Individual elements.
-	const ALL = 'all';
-	const ANY = 'any';
+	public const ALL = 'all';
+	public const ANY = 'any';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FieldFiltersModeEnum.php
+++ b/src/Type/Enum/FieldFiltersModeEnum.php
@@ -26,14 +26,14 @@ class FieldFiltersModeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Whether to filter by ALL or ANY of the field filters. Default is ALL.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ALL' => [
 				'description' => __( 'All field filters (default).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FieldFiltersOperatorInputEnum.php
+++ b/src/Type/Enum/FieldFiltersOperatorInputEnum.php
@@ -30,14 +30,14 @@ class FieldFiltersOperatorInputEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The operator to use for filtering.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'CONTAINS' => [
 				'description' => __( 'Find field values that contain the passed value. Only one value may be passed when using this operator. SQL Equivalent: `LIKE %value%`.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FieldFiltersOperatorInputEnum.php
+++ b/src/Type/Enum/FieldFiltersOperatorInputEnum.php
@@ -20,12 +20,12 @@ class FieldFiltersOperatorInputEnum extends AbstractEnum {
 	public static string $type = 'FieldFiltersOperatorEnum';
 
 	// Individual elements.
-	const CONTAINS = 'contains';
-	const IN       = 'in';
-	const IS       = 'is';
-	const IS_NOT   = 'is not';
-	const LIKE     = 'like';
-	const NOT_IN   = 'not in';
+	public const CONTAINS = 'contains';
+	public const IN       = 'in';
+	public const IS       = 'is';
+	public const IS_NOT   = 'is not';
+	public const LIKE     = 'like';
+	public const NOT_IN   = 'not in';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormButtonTypeEnum.php
+++ b/src/Type/Enum/FormButtonTypeEnum.php
@@ -26,14 +26,14 @@ class FormButtonTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of button to be displayed. Default is TEXT.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'IMAGE' => [
 				'description' => __( 'Image button.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormButtonTypeEnum.php
+++ b/src/Type/Enum/FormButtonTypeEnum.php
@@ -20,8 +20,8 @@ class FormButtonTypeEnum extends AbstractEnum {
 	public static string $type = 'FormButtonTypeEnum';
 
 	// Individual elements.
-	const TEXT  = 'text';
-	const IMAGE = 'image';
+	public const TEXT  = 'text';
+	public const IMAGE = 'image';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormConfirmationTypeEnum.php
+++ b/src/Type/Enum/FormConfirmationTypeEnum.php
@@ -27,14 +27,14 @@ class FormConfirmationTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of form confirmation to be used.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'MESSAGE'  => [
 				'description' => __( 'Use a confirmation "message".', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormConfirmationTypeEnum.php
+++ b/src/Type/Enum/FormConfirmationTypeEnum.php
@@ -20,9 +20,9 @@ class FormConfirmationTypeEnum extends AbstractEnum {
 	public static string $type = 'FormConfirmationTypeEnum';
 
 	// Individual elements.
-	const MESSAGE  = 'message';
-	const PAGE     = 'page';
-	const REDIRECT = 'redirect';
+	public const MESSAGE  = 'message';
+	public const PAGE     = 'page';
+	public const REDIRECT = 'redirect';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormCreditCardTypeEnum.php
+++ b/src/Type/Enum/FormCreditCardTypeEnum.php
@@ -25,14 +25,14 @@ class FormCreditCardTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of Credit Card supported by Gravity Forms.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		$cards = GFCommon::get_card_types();
 
 		$values = [];

--- a/src/Type/Enum/FormDescriptionPlacementEnum.php
+++ b/src/Type/Enum/FormDescriptionPlacementEnum.php
@@ -20,8 +20,8 @@ class FormDescriptionPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormDescriptionPlacementEnum';
 
 	// Individual elements.
-	const ABOVE = 'above';
-	const BELOW = 'below';
+	public const ABOVE = 'above';
+	public const BELOW = 'below';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormDescriptionPlacementEnum.php
+++ b/src/Type/Enum/FormDescriptionPlacementEnum.php
@@ -26,14 +26,14 @@ class FormDescriptionPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines where the field description is displayed relative to the field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ABOVE' => [
 				'description' => __( 'The field description is displayed above the field input (i.e. immediately after the field label).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldCalendarIconTypeEnum.php
+++ b/src/Type/Enum/FormFieldCalendarIconTypeEnum.php
@@ -20,9 +20,9 @@ class FormFieldCalendarIconTypeEnum extends AbstractEnum {
 	public static string $type = 'FormFieldCalendarIconTypeEnum';
 
 	// Individual elements.
-	const CALENDAR = 'calendar';
-	const CUSTOM   = 'custom';
-	const NONE     = 'none';
+	public const CALENDAR = 'calendar';
+	public const CUSTOM   = 'custom';
+	public const NONE     = 'none';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldCalendarIconTypeEnum.php
+++ b/src/Type/Enum/FormFieldCalendarIconTypeEnum.php
@@ -27,14 +27,14 @@ class FormFieldCalendarIconTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'How the date field displays its calendar icon.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'CALENDAR' => [
 				'description' => __( 'Default calendar icon.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldDescriptionPlacementEnum.php
+++ b/src/Type/Enum/FormFieldDescriptionPlacementEnum.php
@@ -20,9 +20,9 @@ class FormFieldDescriptionPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormFieldDescriptionPlacementEnum';
 
 	// Individual elements.
-	const ABOVE   = 'above';
-	const BELOW   = 'below';
-	const INHERIT = 'inherit';
+	public const ABOVE   = 'above';
+	public const BELOW   = 'below';
+	public const INHERIT = 'inherit';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldDescriptionPlacementEnum.php
+++ b/src/Type/Enum/FormFieldDescriptionPlacementEnum.php
@@ -27,14 +27,14 @@ class FormFieldDescriptionPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines where the field description is displayed relative to the field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ABOVE'   => [
 				'description' => __( 'The field description is displayed above the field input (i.e. immediately after the field label).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldLabelPlacementEnum.php
+++ b/src/Type/Enum/FormFieldLabelPlacementEnum.php
@@ -29,14 +29,14 @@ class FormFieldLabelPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The field label position. Empty when using the form defaults or a value of "hidden_label".', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'HIDDEN'  => [
 				'description' => __( 'Field label is hidden.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldLabelPlacementEnum.php
+++ b/src/Type/Enum/FormFieldLabelPlacementEnum.php
@@ -20,11 +20,11 @@ class FormFieldLabelPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormFieldLabelPlacementEnum';
 
 	// Individual elements.
-	const TOP     = 'top_label';
-	const LEFT    = 'left_label';
-	const RIGHT   = 'right_label';
-	const INHERIT = 'inherit';
-	const HIDDEN  = 'hidden_label';
+	public const TOP     = 'top_label';
+	public const LEFT    = 'left_label';
+	public const RIGHT   = 'right_label';
+	public const INHERIT = 'inherit';
+	public const HIDDEN  = 'hidden_label';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldRequiredIndicatorEnum.php
+++ b/src/Type/Enum/FormFieldRequiredIndicatorEnum.php
@@ -20,9 +20,9 @@ class FormFieldRequiredIndicatorEnum extends AbstractEnum {
 	public static string $type = 'FormFieldRequiredIndicatorEnum';
 
 	// Individual elements.
-	const ASTERISK = 'asterisk';
-	const CUSTOM   = 'custom';
-	const TEXT     = 'text';
+	public const ASTERISK = 'asterisk';
+	public const CUSTOM   = 'custom';
+	public const TEXT     = 'text';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldRequiredIndicatorEnum.php
+++ b/src/Type/Enum/FormFieldRequiredIndicatorEnum.php
@@ -27,14 +27,14 @@ class FormFieldRequiredIndicatorEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of indicator to use when field is required.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ASTERISK' => [
 				'description' => __( 'Asterisk (*) indicator.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldSizeEnum.php
+++ b/src/Type/Enum/FormFieldSizeEnum.php
@@ -27,14 +27,14 @@ class FormFieldSizeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The size of the field when displayed on the page.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'SMALL'  => [
 				'description' => __( 'Small field size.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldSizeEnum.php
+++ b/src/Type/Enum/FormFieldSizeEnum.php
@@ -20,9 +20,9 @@ class FormFieldSizeEnum extends AbstractEnum {
 	public static string $type = 'FormFieldSizeEnum';
 
 	// Individual elements.
-	const SMALL  = 'small';
-	const MEDIUM = 'medium';
-	const LARGE  = 'large';
+	public const SMALL  = 'small';
+	public const MEDIUM = 'medium';
+	public const LARGE  = 'large';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldSubLabelPlacementEnum.php
+++ b/src/Type/Enum/FormFieldSubLabelPlacementEnum.php
@@ -20,9 +20,9 @@ class FormFieldSubLabelPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormFieldSubLabelPlacementEnum';
 
 	// Individual elements.
-	const ABOVE   = 'above';
-	const BELOW   = 'below';
-	const INHERIT = 'inherit';
+	public const ABOVE   = 'above';
+	public const BELOW   = 'below';
+	public const INHERIT = 'inherit';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldSubLabelPlacementEnum.php
+++ b/src/Type/Enum/FormFieldSubLabelPlacementEnum.php
@@ -27,14 +27,14 @@ class FormFieldSubLabelPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines how sub-labels are aligned.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ABOVE'   => [
 				'description' => __( 'The sub-label is displayed above the sub-field input (i.e. immediately after the field label).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormFieldTypeEnum.php
+++ b/src/Type/Enum/FormFieldTypeEnum.php
@@ -8,8 +8,8 @@
 
 namespace WPGraphQL\GF\Type\Enum;
 
-use WPGraphQL\Type\WPEnumType;
 use WPGraphQL\GF\Utils\Utils;
+use WPGraphQL\Type\WPEnumType;
 
 /**
  * Class - FormFieldTypeEnum
@@ -22,18 +22,17 @@ class FormFieldTypeEnum extends AbstractEnum {
 	 */
 	public static string $type = 'FormFieldTypeEnum';
 
-
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms Field Type.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		$fields = Utils::get_registered_form_field_types();
 
 		$values = [];

--- a/src/Type/Enum/FormFieldVisibilityEnum.php
+++ b/src/Type/Enum/FormFieldVisibilityEnum.php
@@ -20,9 +20,9 @@ class FormFieldVisibilityEnum extends AbstractEnum {
 	public static string $type = 'FormFieldVisibilityEnum';
 
 	// Individual elements.
-	const VISIBLE        = 'visible';
-	const HIDDEN         = 'hidden';
-	const ADMINISTRATIVE = 'administrative';
+	public const VISIBLE        = 'visible';
+	public const HIDDEN         = 'hidden';
+	public const ADMINISTRATIVE = 'administrative';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormFieldVisibilityEnum.php
+++ b/src/Type/Enum/FormFieldVisibilityEnum.php
@@ -27,14 +27,14 @@ class FormFieldVisibilityEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Field visibility.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'VISIBLE'        => [
 				'description' => __( 'The field is "visible".', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormIdTypeEnum.php
+++ b/src/Type/Enum/FormIdTypeEnum.php
@@ -26,14 +26,14 @@ class FormIdTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Type of Identifier used to fetch a single resource.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ID'          => [
 				'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormIdTypeEnum.php
+++ b/src/Type/Enum/FormIdTypeEnum.php
@@ -20,8 +20,8 @@ class FormIdTypeEnum extends AbstractEnum {
 	public static string $type = 'FormIdTypeEnum';
 
 	// Individual elements.
-	const ID          = 'global_id';
-	const DATABASE_ID = 'database_id';
+	public const ID          = 'global_id';
+	public const DATABASE_ID = 'database_id';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormLabelPlacementEnum.php
+++ b/src/Type/Enum/FormLabelPlacementEnum.php
@@ -20,9 +20,9 @@ class FormLabelPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormLabelPlacementEnum';
 
 	// Individual elements.
-	const TOP   = 'top_label';
-	const LEFT  = 'left_label';
-	const RIGHT = 'right_label';
+	public const TOP   = 'top_label';
+	public const LEFT  = 'left_label';
+	public const RIGHT = 'right_label';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormLabelPlacementEnum.php
+++ b/src/Type/Enum/FormLabelPlacementEnum.php
@@ -27,14 +27,14 @@ class FormLabelPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines where the field labels should be placed in relation to the field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'TOP'   => [
 				'description' => __( 'Field labels are displayed on top of the fields.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormLimitEntriesPeriodEnum.php
+++ b/src/Type/Enum/FormLimitEntriesPeriodEnum.php
@@ -28,14 +28,14 @@ class FormLimitEntriesPeriodEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'When limitEntries is set to 1, this property specifies the time period during which submissions are allowed.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'DAY'   => [
 				'description' => __( 'Limit entries by "day".', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormLimitEntriesPeriodEnum.php
+++ b/src/Type/Enum/FormLimitEntriesPeriodEnum.php
@@ -20,10 +20,10 @@ class FormLimitEntriesPeriodEnum extends AbstractEnum {
 	public static string $type = 'FormLimitEntriesPeriodEnum';
 
 	// Individual elements.
-	const DAY   = 'day';
-	const WEEK  = 'week';
-	const MONTH = 'month';
-	const YEAR  = 'year';
+	public const DAY   = 'day';
+	public const WEEK  = 'week';
+	public const MONTH = 'month';
+	public const YEAR  = 'year';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormNotificationToTypeEnum.php
+++ b/src/Type/Enum/FormNotificationToTypeEnum.php
@@ -20,10 +20,10 @@ class FormNotificationToTypeEnum extends AbstractEnum {
 	public static string $type = 'FormNotificationToTypeEnum';
 
 	// Individual elements.
-	const EMAIL   = 'email';
-	const FIELD   = 'field';
-	const ROUTING = 'routing';
-	const HIDDEN  = 'hidden';
+	public const EMAIL   = 'email';
+	public const FIELD   = 'field';
+	public const ROUTING = 'routing';
+	public const HIDDEN  = 'hidden';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormNotificationToTypeEnum.php
+++ b/src/Type/Enum/FormNotificationToTypeEnum.php
@@ -28,14 +28,14 @@ class FormNotificationToTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'What to use for the notification "to".', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'EMAIL'   => [
 				'description' => __( 'Email address.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormPageProgressStyleEnum.php
+++ b/src/Type/Enum/FormPageProgressStyleEnum.php
@@ -30,14 +30,14 @@ class FormPageProgressStyleEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Style of progress bar.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'BLUE'   => [
 				'description' => __( 'Blue progress bar style.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormPageProgressStyleEnum.php
+++ b/src/Type/Enum/FormPageProgressStyleEnum.php
@@ -20,12 +20,12 @@ class FormPageProgressStyleEnum extends AbstractEnum {
 	public static string $type = 'FormPageProgressStyleEnum';
 
 	// Individual elements.
-	const BLUE   = 'blue';
-	const GREY   = 'grey';
-	const GREEN  = 'green';
-	const ORANGE = 'orange';
-	const RED    = 'red';
-	const CUSTOM = 'custom';
+	public const BLUE   = 'blue';
+	public const GREY   = 'grey';
+	public const GREEN  = 'green';
+	public const ORANGE = 'orange';
+	public const RED    = 'red';
+	public const CUSTOM = 'custom';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormPageProgressTypeEnum.php
+++ b/src/Type/Enum/FormPageProgressTypeEnum.php
@@ -27,14 +27,14 @@ class FormPageProgressTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of page progress indicator to be displayed.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'PERCENTAGE' => [
 				'description' => __( 'Show page progress indicator as a percentage.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormPageProgressTypeEnum.php
+++ b/src/Type/Enum/FormPageProgressTypeEnum.php
@@ -20,9 +20,9 @@ class FormPageProgressTypeEnum extends AbstractEnum {
 	public static string $type = 'FormPageProgressTypeEnum';
 
 	// Individual elements.
-	const PERCENTAGE = 'percentage';
-	const STEPS      = 'steps';
-	const NONE       = 'none';
+	public const PERCENTAGE = 'percentage';
+	public const STEPS      = 'steps';
+	public const NONE       = 'none';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormRetentionPolicyEnum.php
+++ b/src/Type/Enum/FormRetentionPolicyEnum.php
@@ -20,9 +20,9 @@ class FormRetentionPolicyEnum extends AbstractEnum {
 	public static string $type = 'FormRetentionPolicyEnum';
 
 	// Individual elements.
-	const DELETE = 'delete';
-	const RETAIN = 'retain';
-	const TRASH  = 'trash';
+	public const DELETE = 'delete';
+	public const RETAIN = 'retain';
+	public const TRASH  = 'trash';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormRetentionPolicyEnum.php
+++ b/src/Type/Enum/FormRetentionPolicyEnum.php
@@ -27,14 +27,14 @@ class FormRetentionPolicyEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Personal Data retention policy.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'DELETE' => [
 				'description' => __( 'Entries will be deleted automatically after a specified number of days.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormRuleOperatorEnum.php
+++ b/src/Type/Enum/FormRuleOperatorEnum.php
@@ -31,14 +31,14 @@ class FormRuleOperatorEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Operator to be used when evaluating logic rules.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'IS'           => [
 				'description' => __( 'Evaluates values that match the comparison value.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormRuleOperatorEnum.php
+++ b/src/Type/Enum/FormRuleOperatorEnum.php
@@ -20,13 +20,13 @@ class FormRuleOperatorEnum extends AbstractEnum {
 	public static string $type = 'FormRuleOperatorEnum';
 
 	// Individual elements.
-	const IS           = 'is';
-	const IS_NOT       = 'isnot';
-	const CONTAINS     = 'contains';
-	const GREATER_THAN = '>';
-	const LESS_THAN    = '<';
-	const STARTS_WITH  = 'starts_with';
-	const ENDS_WITH    = 'ends_with';
+	public const IS           = 'is';
+	public const IS_NOT       = 'isnot';
+	public const CONTAINS     = 'contains';
+	public const GREATER_THAN = '>';
+	public const LESS_THAN    = '<';
+	public const STARTS_WITH  = 'starts_with';
+	public const ENDS_WITH    = 'ends_with';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormStatusEnum.php
+++ b/src/Type/Enum/FormStatusEnum.php
@@ -20,10 +20,10 @@ class FormStatusEnum extends AbstractEnum {
 	public static string $type = 'FormStatusEnum';
 
 	// Individual elements.
-	const ACTIVE           = 'ACTIVE';
-	const INACTIVE         = 'INACTIVE';
-	const TRASHED          = 'TRASHED';
-	const INACTIVE_TRASHED = 'INACTIVE_TRASHED';
+	public const ACTIVE           = 'ACTIVE';
+	public const INACTIVE         = 'INACTIVE';
+	public const TRASHED          = 'TRASHED';
+	public const INACTIVE_TRASHED = 'INACTIVE_TRASHED';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormStatusEnum.php
+++ b/src/Type/Enum/FormStatusEnum.php
@@ -28,14 +28,14 @@ class FormStatusEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Status of forms to get. Default is ACTIVE.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			self::ACTIVE           => [
 				'description' => __( 'Active forms (default).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormSubLabelPlacementEnum.php
+++ b/src/Type/Enum/FormSubLabelPlacementEnum.php
@@ -26,14 +26,14 @@ class FormSubLabelPlacementEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines how sub-labels are aligned.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ABOVE' => [
 				'description' => __( 'The sub-label is displayed above the sub-field input (i.e. immediately after the field label).', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormSubLabelPlacementEnum.php
+++ b/src/Type/Enum/FormSubLabelPlacementEnum.php
@@ -20,8 +20,8 @@ class FormSubLabelPlacementEnum extends AbstractEnum {
 	public static string $type = 'FormSubLabelPlacementEnum';
 
 	// Individual elements.
-	const ABOVE = 'above';
-	const BELOW = 'below';
+	public const ABOVE = 'above';
+	public const BELOW = 'below';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormSubmitButtonLocationEnum.php
+++ b/src/Type/Enum/FormSubmitButtonLocationEnum.php
@@ -26,14 +26,14 @@ class FormSubmitButtonLocationEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Where the submit button should be located.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'BOTTOM' => [
 				'description' => __( 'The submit button will be placed in a new row after all fields of the form.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormSubmitButtonLocationEnum.php
+++ b/src/Type/Enum/FormSubmitButtonLocationEnum.php
@@ -20,8 +20,8 @@ class FormSubmitButtonLocationEnum extends AbstractEnum {
 	public static string $type = 'FormSubmitButtonLocationEnum';
 
 	// Individual elements.
-	const BOTTOM = 'bottom';
-	const INLINE = 'inline';
+	public const BOTTOM = 'bottom';
+	public const INLINE = 'inline';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormSubmitButtonWidthEnum.php
+++ b/src/Type/Enum/FormSubmitButtonWidthEnum.php
@@ -26,14 +26,14 @@ class FormSubmitButtonWidthEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Submit button width.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'AUTO' => [
 				'description' => __( 'The width is set to match that of the button text.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/FormSubmitButtonWidthEnum.php
+++ b/src/Type/Enum/FormSubmitButtonWidthEnum.php
@@ -20,8 +20,8 @@ class FormSubmitButtonWidthEnum extends AbstractEnum {
 	public static string $type = 'FormSubmitButtonWidthEnum';
 
 	// Individual elements.
-	const AUTO = 'auto';
-	const FULL = 'full';
+	public const AUTO = 'auto';
+	public const FULL = 'full';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormsConnectionOrderByEnum.php
+++ b/src/Type/Enum/FormsConnectionOrderByEnum.php
@@ -20,11 +20,11 @@ class FormsConnectionOrderByEnum extends AbstractEnum {
 	public static string $type = 'FormsConnectionOrderByEnum';
 
 	// Individual elements.
-	const DATE_CREATED = 'date_created';
-	const ID           = 'id';
-	const IS_ACTIVE    = 'is_active';
-	const IS_TRASH     = 'is_trash';
-	const TITLE        = 'title';
+	public const DATE_CREATED = 'date_created';
+	public const ID           = 'id';
+	public const IS_ACTIVE    = 'is_active';
+	public const IS_TRASH     = 'is_trash';
+	public const TITLE        = 'title';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/FormsConnectionOrderByEnum.php
+++ b/src/Type/Enum/FormsConnectionOrderByEnum.php
@@ -29,14 +29,14 @@ class FormsConnectionOrderByEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of button to be displayed. Default is TEXT.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'DATE_CREATED' => [
 				'description' => __( 'The date the form was created.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/NumberFieldFormatEnum.php
+++ b/src/Type/Enum/NumberFieldFormatEnum.php
@@ -27,14 +27,14 @@ class NumberFieldFormatEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The format allowed for the number field. .', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'CURRENCY'      => [
 				'description' => __( 'Currency format.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/NumberFieldFormatEnum.php
+++ b/src/Type/Enum/NumberFieldFormatEnum.php
@@ -20,9 +20,9 @@ class NumberFieldFormatEnum extends AbstractEnum {
 	public static string $type = 'NumberFieldFormatEnum';
 
 	// Individual elements.
-	const CURRENCY      = 'currency';
-	const DECIMAL_DOT   = 'decimal_dot';
-	const DECIMAL_COMMA = 'decimal_comma';
+	public const CURRENCY      = 'currency';
+	public const DECIMAL_DOT   = 'decimal_dot';
+	public const DECIMAL_COMMA = 'decimal_comma';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/PasswordFieldMinStrengthEnum.php
+++ b/src/Type/Enum/PasswordFieldMinStrengthEnum.php
@@ -28,14 +28,14 @@ class PasswordFieldMinStrengthEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Indicates how strong the password should be.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'SHORT'  => [
 				'description' => __( 'The password strength must be "short" or better.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/PasswordFieldMinStrengthEnum.php
+++ b/src/Type/Enum/PasswordFieldMinStrengthEnum.php
@@ -20,10 +20,10 @@ class PasswordFieldMinStrengthEnum extends AbstractEnum {
 	public static string $type = 'PasswordFieldMinStrengthEnum';
 
 	// Individual elements.
-	const SHORT  = 'short';
-	const BAD    = 'bad';
-	const GOOD   = 'good';
-	const STRONG = 'strong';
+	public const SHORT  = 'short';
+	public const BAD    = 'bad';
+	public const GOOD   = 'good';
+	public const STRONG = 'strong';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/PhoneFieldFormatEnum.php
+++ b/src/Type/Enum/PhoneFieldFormatEnum.php
@@ -20,8 +20,8 @@ class PhoneFieldFormatEnum extends AbstractEnum {
 	public static string $type = 'PhoneFieldFormatEnum';
 
 	// Individual elements.
-	const STANDARD      = 'standard';
-	const INTERNATIONAL = 'international';
+	public const STANDARD      = 'standard';
+	public const INTERNATIONAL = 'international';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/PhoneFieldFormatEnum.php
+++ b/src/Type/Enum/PhoneFieldFormatEnum.php
@@ -26,14 +26,14 @@ class PhoneFieldFormatEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Tthe allowed format for phone numbers.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'STANDARD'      => [
 				'description' => __( 'Standard phone number format.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/PostFormatTypeEnum.php
+++ b/src/Type/Enum/PostFormatTypeEnum.php
@@ -24,14 +24,14 @@ class PostFormatTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'List of possible post formats.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		$values = [
 			'STANDARD' => [
 				'value'       => '0',

--- a/src/Type/Enum/RecaptchaTypeEnum.php
+++ b/src/Type/Enum/RecaptchaTypeEnum.php
@@ -20,8 +20,8 @@ class RecaptchaTypeEnum extends AbstractEnum {
 	public static string $type = 'RecaptchaTypeEnum';
 
 	// Individual elements.
-	const CHECKBOX  = 'checkbox';
-	const INVISIBLE = 'invisible';
+	public const CHECKBOX  = 'checkbox';
+	public const INVISIBLE = 'invisible';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/RecaptchaTypeEnum.php
+++ b/src/Type/Enum/RecaptchaTypeEnum.php
@@ -26,14 +26,14 @@ class RecaptchaTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Determines which version of reCAPTCHA v2 will be used. ', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'CHECKBOX'  => [
 				'description' => __( 'A checkbox reCAPTCHA type.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/SubmissionConfirmationTypeEnum.php
+++ b/src/Type/Enum/SubmissionConfirmationTypeEnum.php
@@ -20,8 +20,8 @@ class SubmissionConfirmationTypeEnum extends AbstractEnum {
 	public static string $type = 'SubmissionConfirmationTypeEnum';
 
 	// Individual elements.
-	const MESSAGE  = 'message';
-	const REDIRECT = 'redirect';
+	public const MESSAGE  = 'message';
+	public const REDIRECT = 'redirect';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/SubmissionConfirmationTypeEnum.php
+++ b/src/Type/Enum/SubmissionConfirmationTypeEnum.php
@@ -26,14 +26,14 @@ class SubmissionConfirmationTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Type of confirmation returned by the submission.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'MESSAGE'  => [
 				'description' => __( 'A confirmation "message".', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/SubmittedEntryIdTypeEnum.php
+++ b/src/Type/Enum/SubmittedEntryIdTypeEnum.php
@@ -20,8 +20,8 @@ class SubmittedEntryIdTypeEnum extends AbstractEnum {
 	public static string $type = 'SubmittedEntryIdTypeEnum';
 
 	// Individual elements.
-	const ID          = 'global_id';
-	const DATABASE_ID = 'database_id';
+	public const ID          = 'global_id';
+	public const DATABASE_ID = 'database_id';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Enum/SubmittedEntryIdTypeEnum.php
+++ b/src/Type/Enum/SubmittedEntryIdTypeEnum.php
@@ -26,14 +26,14 @@ class SubmittedEntryIdTypeEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Type of Identifier used to fetch a single resource.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'ID'          => [
 				'description' => __( 'Unique global ID for the object.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/TimeFieldFormatEnum.php
+++ b/src/Type/Enum/TimeFieldFormatEnum.php
@@ -26,14 +26,14 @@ class TimeFieldFormatEnum extends AbstractEnum {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'How the time is displayed.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_values() : array {
+	public static function get_values(): array {
 		return [
 			'H12' => [
 				'description' => __( '12-hour time format.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/Enum/TimeFieldFormatEnum.php
+++ b/src/Type/Enum/TimeFieldFormatEnum.php
@@ -20,8 +20,8 @@ class TimeFieldFormatEnum extends AbstractEnum {
 	public static string $type = 'TimeFieldFormatEnum';
 
 	// Individual elements.
-	const H12 = '12';
-	const H24 = '24';
+	public const H12 = '12';
+	public const H24 = '24';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Type/Input/AbstractInput.php
+++ b/src/Type/Input/AbstractInput.php
@@ -26,7 +26,7 @@ abstract class AbstractInput extends AbstractType implements TypeWithDescription
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		$config = static::get_type_config();
 
 		register_graphql_input_type( static::$type, $config );
@@ -35,7 +35,7 @@ abstract class AbstractInput extends AbstractType implements TypeWithDescription
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		return [
 			'description' => static::get_description(),
 			'fields'      => static::get_fields(),

--- a/src/Type/Input/AddressFieldInput.php
+++ b/src/Type/Input/AddressFieldInput.php
@@ -25,14 +25,14 @@ class AddressFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for Address FormField.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'street'  => [
 				'type'        => 'String',

--- a/src/Type/Input/CheckboxFieldInput.php
+++ b/src/Type/Input/CheckboxFieldInput.php
@@ -23,14 +23,14 @@ class CheckboxFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for a single checkbox.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'inputId' => [
 				'type'        => 'Float',

--- a/src/Type/Input/CreditCardFieldInput.php
+++ b/src/Type/Input/CreditCardFieldInput.php
@@ -25,14 +25,14 @@ class CreditCardFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for Credit Card FormField.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'cardNumber'      => [
 				'type'        => 'Int',

--- a/src/Type/Input/EmailFieldInput.php
+++ b/src/Type/Input/EmailFieldInput.php
@@ -23,14 +23,14 @@ class EmailFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for email field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'value'             => [
 				'type'        => 'String',

--- a/src/Type/Input/EntriesConnectionOrderbyInput.php
+++ b/src/Type/Input/EntriesConnectionOrderbyInput.php
@@ -23,14 +23,14 @@ class EntriesConnectionOrderbyInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Options for ordering the connection.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'field'     => [
 				'type'        => 'String',

--- a/src/Type/Input/EntriesDateFiltersInput.php
+++ b/src/Type/Input/EntriesDateFiltersInput.php
@@ -23,14 +23,14 @@ class EntriesDateFiltersInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Date Filters input fields for Entries queries.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'startDate' => [
 				'type'        => 'String',

--- a/src/Type/Input/EntriesFieldFiltersInput.php
+++ b/src/Type/Input/EntriesFieldFiltersInput.php
@@ -25,14 +25,14 @@ class EntriesFieldFiltersInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Field Filters input fields for Entries queries.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'key'          => [
 				'type'        => 'String',

--- a/src/Type/Input/FormFieldValuesInput.php
+++ b/src/Type/Input/FormFieldValuesInput.php
@@ -26,14 +26,14 @@ class FormFieldValuesInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Field values input. Includes a field id, and a valid value Input.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		$fields = [
 			'id'             => [
 				'type'        => [ 'non_null' => 'Int' ],

--- a/src/Type/Input/FormsConnectionOrderbyInput.php
+++ b/src/Type/Input/FormsConnectionOrderbyInput.php
@@ -25,14 +25,14 @@ class FormsConnectionOrderbyInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Options for ordering the connection.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'field'  => [
 				'type'              => 'String',

--- a/src/Type/Input/ListFieldInput.php
+++ b/src/Type/Input/ListFieldInput.php
@@ -23,14 +23,14 @@ class ListFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for a single List field item.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'rowValues' => [
 				'type'        => [ 'list_of' => 'String' ],

--- a/src/Type/Input/NameFieldInput.php
+++ b/src/Type/Input/NameFieldInput.php
@@ -23,14 +23,14 @@ class NameFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for name field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'prefix' => [
 				'type'        => 'String',

--- a/src/Type/Input/PostImageFieldInput.php
+++ b/src/Type/Input/PostImageFieldInput.php
@@ -23,14 +23,14 @@ class PostImageFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for a single post Image.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'image'       => [
 				'type'        => [ 'non_null' => 'Upload' ],

--- a/src/Type/Input/ProductFieldInput.php
+++ b/src/Type/Input/ProductFieldInput.php
@@ -23,14 +23,14 @@ class ProductFieldInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Input fields for Product field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'quantity' => [
 				'type'        => 'Float',

--- a/src/Type/Input/SubmitFormMetaInput.php
+++ b/src/Type/Input/SubmitFormMetaInput.php
@@ -23,14 +23,14 @@ class SubmitFormMetaInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Entry meta input fields for submitting Gravity Forms forms.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'createdById'    => [
 				'type'        => 'Int',

--- a/src/Type/Input/SubmitFormMetaInput.php
+++ b/src/Type/Input/SubmitFormMetaInput.php
@@ -9,8 +9,6 @@
 
 namespace WPGraphQL\GF\Type\Input;
 
-use WPGraphQL\GF\Type\Enum\EntryStatusEnum;
-
 /**
  * Class - SubmitFormMetaInput
  */

--- a/src/Type/Input/UpdateDraftEntryMetaInput.php
+++ b/src/Type/Input/UpdateDraftEntryMetaInput.php
@@ -23,14 +23,14 @@ class UpdateDraftEntryMetaInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Entry meta input fields for updating draft Gravity Forms entries.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'createdById'    => [
 				'type'        => 'Int',

--- a/src/Type/Input/UpdateEntryMetaInput.php
+++ b/src/Type/Input/UpdateEntryMetaInput.php
@@ -25,14 +25,14 @@ class UpdateEntryMetaInput extends AbstractInput {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Entry meta input fields for updating Gravity Forms entries.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'createdById'    => [
 				'type'        => 'Int',

--- a/src/Type/WPInterface/AbstractInterface.php
+++ b/src/Type/WPInterface/AbstractInterface.php
@@ -36,7 +36,7 @@ abstract class AbstractInterface extends AbstractType implements TypeWithDescrip
 	/**
 	 * Register Object type to GraphQL schema.
 	 *
-	 * @param TypeRegistry $type_registry .
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry .
 	 */
 	public static function register( TypeRegistry $type_registry = null ) : void {
 		$config = static::get_type_config( $type_registry );

--- a/src/Type/WPInterface/AbstractInterface.php
+++ b/src/Type/WPInterface/AbstractInterface.php
@@ -38,7 +38,7 @@ abstract class AbstractInterface extends AbstractType implements TypeWithDescrip
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry .
 	 */
-	public static function register( TypeRegistry $type_registry = null ) : void {
+	public static function register( TypeRegistry $type_registry = null ): void {
 		$config = static::get_type_config( $type_registry );
 
 		register_graphql_interface_type( static::$type, $config );

--- a/src/Type/WPInterface/Entry.php
+++ b/src/Type/WPInterface/Entry.php
@@ -228,7 +228,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function( $value ) use ( $type_registry ) {
+		return function ( $value ) use ( $type_registry ) {
 			$possible_types = Utils::get_registered_entry_types();
 
 			$id_parts = Relay::fromGlobalId( $value->id );

--- a/src/Type/WPInterface/Entry.php
+++ b/src/Type/WPInterface/Entry.php
@@ -51,15 +51,16 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL TypeRegistry.
 	 */
-	public static function register( TypeRegistry $type_registry = null ) : void {
+	public static function register( TypeRegistry $type_registry = null ): void {
 		parent::register( $type_registry );
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config( TypeRegistry $type_registry = null ) : array {
+	public static function get_type_config( TypeRegistry $type_registry = null ): array {
 		$config = parent::get_type_config();
 
 		$config['connections'] = self::get_connections();
@@ -75,7 +76,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connections() : array {
+	public static function get_connections(): array {
 		return [
 			'formFields' => [
 				'toType'         => FormField::$type,
@@ -100,14 +101,14 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms entry interface.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		$fields = [
 			'createdBy'           => [
 				'type'        => 'User',
@@ -218,7 +219,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [ 'Node', NodeWithForm::$type ];
 	}
 
@@ -227,7 +228,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
-	public static function resolve_type( TypeRegistry $type_registry ) : callable {
+	public static function resolve_type( TypeRegistry $type_registry ): callable {
 		return static function ( $value ) use ( $type_registry ) {
 			$possible_types = Utils::get_registered_entry_types();
 
@@ -254,7 +255,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			'RootQuery',
 			self::$field_name,

--- a/src/Type/WPInterface/Entry.php
+++ b/src/Type/WPInterface/Entry.php
@@ -49,7 +49,7 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * {@in}
 	 *
-	 * @param TypeRegistry $type_registry Instance of the WPGraphQL TypeRegistry.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Instance of the WPGraphQL TypeRegistry.
 	 */
 	public static function register( TypeRegistry $type_registry = null ) : void {
 		parent::register( $type_registry );
@@ -225,10 +225,10 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 	/**
 	 * Resolves the interface to the GraphQL type.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function ( $value ) use ( $type_registry ) {
+		return static function ( $value ) use ( $type_registry ) {
 			$possible_types = Utils::get_registered_entry_types();
 
 			$id_parts = Relay::fromGlobalId( $value->id );

--- a/src/Type/WPInterface/FieldChoice.php
+++ b/src/Type/WPInterface/FieldChoice.php
@@ -71,7 +71,7 @@ class FieldChoice extends AbstractInterface {
 	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function( $value ) use ( $type_registry ) {
+		return function ( $value ) use ( $type_registry ) {
 			$name = '';
 
 			if ( is_array( $value ) && isset( $value['graphql_type'] ) ) {

--- a/src/Type/WPInterface/FieldChoice.php
+++ b/src/Type/WPInterface/FieldChoice.php
@@ -68,10 +68,10 @@ class FieldChoice extends AbstractInterface {
 	/**
 	 * Resolves the interface to the GraphQL type.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function ( $value ) use ( $type_registry ) {
+		return static function ( $value ) use ( $type_registry ) {
 			$name = '';
 
 			if ( is_array( $value ) && isset( $value['graphql_type'] ) ) {

--- a/src/Type/WPInterface/FieldChoice.php
+++ b/src/Type/WPInterface/FieldChoice.php
@@ -45,14 +45,14 @@ class FieldChoice extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms field choice.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'text'  => [
 				'type'        => 'String',
@@ -70,7 +70,7 @@ class FieldChoice extends AbstractInterface {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
-	public static function resolve_type( TypeRegistry $type_registry ) : callable {
+	public static function resolve_type( TypeRegistry $type_registry ): callable {
 		return static function ( $value ) use ( $type_registry ) {
 			$name = '';
 

--- a/src/Type/WPInterface/FieldChoiceSetting/AbstractFieldChoiceSetting.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/AbstractFieldChoiceSetting.php
@@ -54,7 +54,7 @@ abstract class AbstractFieldChoiceSetting extends AbstractInterface implements T
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return sprintf(
 			// translators: The Gravity Forms field Setting.
 			__( 'A Choice for a form field with the `%s` setting.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
@@ -33,7 +33,7 @@ class ChoiceWithChoices extends AbstractFieldChoiceSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ __CLASS__, 'add_fields_to_child_type' ], 10, 5 );
+		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ self::class, 'add_fields_to_child_type' ], 10, 5 );
 
 		parent::register_hooks();
 	}
@@ -53,11 +53,11 @@ class ChoiceWithChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array    $fields An array of GraphQL field configs.
-	 * @param string   $choice_name The name of the choice type.
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
-	 * @param array    $interfaces The list of interfaces for the GraphQL type.
+	 * @param array     $fields An array of GraphQL field configs.
+	 * @param string    $choice_name The name of the choice type.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
 		if (

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithChoices.php
@@ -41,7 +41,7 @@ class ChoiceWithChoices extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isSelected' => [
 				'type'        => 'Boolean',
@@ -59,7 +59,7 @@ class ChoiceWithChoices extends AbstractFieldChoiceSetting {
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
-	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		if (
 			! in_array( self::$type, $interfaces, true ) ||
 			( empty( $field->enablePrice ) && ! in_array( $field->type, [ 'product', 'quantity', 'option', 'shipping' ], true ) )

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithColumns.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithColumns.php
@@ -32,7 +32,7 @@ class ChoiceWithColumns extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		// All types need to have fields, so we explicitly list the interface fields.
 		return FieldChoice::get_fields();
 	}

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
@@ -35,7 +35,7 @@ class ChoiceWithName extends AbstractFieldChoiceSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_action( 'graphql_gf_after_register_form_field', [ __CLASS__, 'add_choice_to_inputs' ], 11, 2 );
+		add_action( 'graphql_gf_after_register_form_field', [ self::class, 'add_choice_to_inputs' ], 11, 2 );
 
 		parent::register_hooks();
 	}
@@ -55,8 +55,8 @@ class ChoiceWithName extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
 	 */
 	public static function add_choice_to_inputs( GF_Field $field, array $settings ) : void {
 		if (

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithName.php
@@ -43,7 +43,7 @@ class ChoiceWithName extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isSelected' => [
 				'type'        => 'Boolean',
@@ -58,7 +58,7 @@ class ChoiceWithName extends AbstractFieldChoiceSetting {
 	 * @param \GF_Field $field The Gravity Forms Field object.
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 */
-	public static function add_choice_to_inputs( GF_Field $field, array $settings ) : void {
+	public static function add_choice_to_inputs( GF_Field $field, array $settings ): void {
 		if (
 			! in_array( self::$field_setting, $settings, true )
 		) {

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
@@ -33,7 +33,7 @@ class ChoiceWithOtherChoice extends AbstractFieldChoiceSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ __CLASS__, 'add_fields_to_child_type' ], 10, 5 );
+		add_filter( 'graphql_gf_form_field_setting_choice_fields', [ self::class, 'add_fields_to_child_type' ], 10, 5 );
 
 		parent::register_hooks();
 	}
@@ -53,11 +53,11 @@ class ChoiceWithOtherChoice extends AbstractFieldChoiceSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array    $fields An array of GraphQL field configs.
-	 * @param string   $choice_name The name of the choice type.
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
-	 * @param array    $interfaces The list of interfaces for the GraphQL type.
+	 * @param array     $fields An array of GraphQL field configs.
+	 * @param string    $choice_name The name of the choice type.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
 	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
 		if (

--- a/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
+++ b/src/Type/WPInterface/FieldChoiceSetting/ChoiceWithOtherChoice.php
@@ -41,7 +41,7 @@ class ChoiceWithOtherChoice extends AbstractFieldChoiceSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isOtherChoice' => [
 				'type'        => 'Boolean',
@@ -59,7 +59,7 @@ class ChoiceWithOtherChoice extends AbstractFieldChoiceSetting {
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
-	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function add_fields_to_child_type( array $fields, string $choice_name, GF_Field $field, array $settings, array $interfaces ): array {
 		if (
 			! in_array( self::$type, $interfaces, true ) ||
 			'quiz' === $field->type

--- a/src/Type/WPInterface/FieldInput.php
+++ b/src/Type/WPInterface/FieldInput.php
@@ -38,14 +38,14 @@ class FieldInput extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms field input.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'label' => [
 				'type'        => 'String',
@@ -63,7 +63,7 @@ class FieldInput extends AbstractInterface {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
-	public static function resolve_type( TypeRegistry $type_registry ) : callable {
+	public static function resolve_type( TypeRegistry $type_registry ): callable {
 		return static function ( $value ) use ( $type_registry ) {
 			$name = '';
 

--- a/src/Type/WPInterface/FieldInput.php
+++ b/src/Type/WPInterface/FieldInput.php
@@ -61,10 +61,10 @@ class FieldInput extends AbstractInterface {
 	/**
 	 * Resolves the interface to the GraphQL type.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function ( $value ) use ( $type_registry ) {
+		return static function ( $value ) use ( $type_registry ) {
 			$name = '';
 
 			if ( is_array( $value ) && isset( $value['graphql_type'] ) ) {

--- a/src/Type/WPInterface/FieldInput.php
+++ b/src/Type/WPInterface/FieldInput.php
@@ -64,7 +64,7 @@ class FieldInput extends AbstractInterface {
 	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function( $value ) use ( $type_registry ) {
+		return function ( $value ) use ( $type_registry ) {
 			$name = '';
 
 			if ( is_array( $value ) && isset( $value['graphql_type'] ) ) {

--- a/src/Type/WPInterface/FieldInputSetting/AbstractFieldInputSetting.php
+++ b/src/Type/WPInterface/FieldInputSetting/AbstractFieldInputSetting.php
@@ -40,7 +40,7 @@ abstract class AbstractFieldInputSetting extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return sprintf(
 			// translators: The Gravity Forms field Setting.
 			__( 'An Input for a form field with the `%s` setting.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/WPInterface/FieldInputSetting/InputWithAddress.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithAddress.php
@@ -31,7 +31,7 @@ class InputWithAddress extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'autocompleteAttribute' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithDateFormat.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithDateFormat.php
@@ -31,7 +31,7 @@ class InputWithDateFormat extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'autocompleteAttribute' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithEmailConfirmation.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithEmailConfirmation.php
@@ -31,7 +31,7 @@ class InputWithEmailConfirmation extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'autocompleteAttribute' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithName.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithName.php
@@ -31,7 +31,7 @@ class InputWithName extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'autocompleteAttribute' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithPassword.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithPassword.php
@@ -31,7 +31,7 @@ class InputWithPassword extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'customLabel' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithSelectAllChoices.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithSelectAllChoices.php
@@ -31,7 +31,7 @@ class InputWithSelectAllChoices extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'name' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithSingleProduct.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithSingleProduct.php
@@ -31,7 +31,7 @@ class InputWithSingleProduct extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'name' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldInputSetting/InputWithTimeFormat.php
+++ b/src/Type/WPInterface/FieldInputSetting/InputWithTimeFormat.php
@@ -31,7 +31,7 @@ class InputWithTimeFormat extends AbstractFieldInputSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'autocompleteAttribute' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/AbstractFieldSetting.php
+++ b/src/Type/WPInterface/FieldSetting/AbstractFieldSetting.php
@@ -31,7 +31,7 @@ abstract class AbstractFieldSetting extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return sprintf(
 			// translators: The Gravity Forms field setting.
 			__( 'A form field with the `%s` setting.', 'wp-graphql-gravity-forms' ),

--- a/src/Type/WPInterface/FieldSetting/FieldWithAddIconUrl.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAddIconUrl.php
@@ -29,7 +29,7 @@ class FieldWithAddIconUrl extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'addIconUrl' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithAddress.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAddress.php
@@ -47,7 +47,7 @@ class FieldWithAddress extends AbstractFieldSetting implements TypeWithInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'addressType'     => [
 				'type'        => AddressFieldTypeEnum::$type,
@@ -71,7 +71,7 @@ class FieldWithAddress extends AbstractFieldSetting implements TypeWithInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithAdminLabel.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAdminLabel.php
@@ -29,7 +29,7 @@ class FieldWithAdminLabel extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'adminLabel' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
@@ -32,7 +32,7 @@ class FieldWithAutocomplete extends AbstractFieldSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_setting_fields', [ __CLASS__, 'add_fields_to_child_type' ], 10, 4 );
+		add_filter( 'graphql_gf_form_field_setting_fields', [ self::class, 'add_fields_to_child_type' ], 10, 4 );
 
 		parent::register_hooks();
 	}
@@ -53,10 +53,10 @@ class FieldWithAutocomplete extends AbstractFieldSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array    $fields An array of GraphQL field configs.
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
-	 * @param array    $interfaces The list of interfaces for the GraphQL type.
+	 * @param array     $fields An array of GraphQL field configs.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
 	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ) : array {
 		// Bail early.

--- a/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithAutocomplete.php
@@ -40,7 +40,7 @@ class FieldWithAutocomplete extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasAutocomplete' => [
 				'type'        => 'Boolean',
@@ -58,7 +58,7 @@ class FieldWithAutocomplete extends AbstractFieldSetting {
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
-	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ): array {
 		// Bail early.
 		if (
 			! in_array( self::$type, $interfaces, true ) ||

--- a/src/Type/WPInterface/FieldSetting/FieldWithBasePrice.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithBasePrice.php
@@ -29,7 +29,7 @@ class FieldWithBasePrice extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'price'          => [
 				'type'        => 'Float',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCalculation.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCalculation.php
@@ -29,7 +29,7 @@ class FieldWithCalculation extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isCalculation'       => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCalculation.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCalculation.php
@@ -43,7 +43,7 @@ class FieldWithCalculation extends AbstractFieldSetting {
 			'calculationRounding' => [
 				'type'        => 'Int',
 				'description' => __( 'Specifies to how many decimal places the number should be rounded. This is available when `isCalculation` is true, but will return null if the number format is `CURRENCY` or if the calculation is set to `Do not round`.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function( $source ) {
+				'resolve'     => static function ( $source ) {
 					// Bail if the field doesn't have a calculationRounding property.
 					if ( empty( $source->enableCalculation ) || ! isset( $source->calculationRounding ) ) {
 						return null;

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaBackground.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaBackground.php
@@ -29,7 +29,7 @@ class FieldWithCaptchaBackground extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'simpleCaptchaBackgroundColor' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaBadge.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaBadge.php
@@ -31,7 +31,7 @@ class FieldWithCaptchaBadge extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'captchaBadgePosition' => [
 				'type'        => CaptchaFieldBadgePositionEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaForeground.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaForeground.php
@@ -29,7 +29,7 @@ class FieldWithCaptchaForeground extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'simpleCaptchaFontColor' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaLanguage.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaLanguage.php
@@ -29,7 +29,7 @@ class FieldWithCaptchaLanguage extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'captchaLanguage' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaSize.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaSize.php
@@ -31,7 +31,7 @@ class FieldWithCaptchaSize extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'simpleCaptchaSize' => [
 				'type'        => FormFieldSizeEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaTheme.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaTheme.php
@@ -31,7 +31,7 @@ class FieldWithCaptchaTheme extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'captchaTheme' => [
 				'type'        => CaptchaFieldThemeEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithCaptchaType.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCaptchaType.php
@@ -31,7 +31,7 @@ class FieldWithCaptchaType extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'captchaType' => [
 				'type'        => CaptchaFieldTypeEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithCheckboxLabel.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCheckboxLabel.php
@@ -29,7 +29,7 @@ class FieldWithCheckboxLabel extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'checkboxLabel' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithChoices.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithChoices.php
@@ -45,7 +45,7 @@ class FieldWithChoices extends AbstractFieldSetting  implements TypeWithInterfac
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasChoiceValue' => [
 				'type'        => 'Boolean',
@@ -58,11 +58,10 @@ class FieldWithChoices extends AbstractFieldSetting  implements TypeWithInterfac
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithChoicesInterface::$type,
 			FieldWithInputs::$type,
 		];
 	}
-
 }

--- a/src/Type/WPInterface/FieldSetting/FieldWithColumns.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithColumns.php
@@ -44,7 +44,7 @@ class FieldWithColumns extends AbstractFieldSetting implements TypeWithInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasColumns' => [
 				'type'        => 'Boolean',
@@ -57,7 +57,7 @@ class FieldWithColumns extends AbstractFieldSetting implements TypeWithInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithChoices::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithConditionalLogic.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithConditionalLogic.php
@@ -33,7 +33,7 @@ class FieldWithConditionalLogic extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'conditionalLogic' => [
 				'type'        => ConditionalLogic::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithContent.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithContent.php
@@ -29,7 +29,7 @@ class FieldWithContent extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'content' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCopyValuesOption.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCopyValuesOption.php
@@ -29,7 +29,7 @@ class FieldWithCopyValuesOption extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'shouldCopyValuesOption'  => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithCreditCard.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCreditCard.php
@@ -31,7 +31,7 @@ class FieldWithCreditCard extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'supportedCreditCards' => [
 				'type'        => [ 'list_of' => FormCreditCardTypeEnum::$type ],

--- a/src/Type/WPInterface/FieldSetting/FieldWithCssClass.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithCssClass.php
@@ -29,7 +29,7 @@ class FieldWithCssClass extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'cssClass' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDateFormat.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDateFormat.php
@@ -8,9 +8,7 @@
 
 namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 
-use GF_Field;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
-use WPGraphQL\GF\Registry\FieldInputRegistry;
 use WPGraphQL\GF\Type\Enum\DateFieldFormatEnum;
 use WPGraphQL\GF\Type\WPInterface\FieldWithInputs;
 use WPGraphQL\Registry\TypeRegistry;

--- a/src/Type/WPInterface/FieldSetting/FieldWithDateFormat.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDateFormat.php
@@ -45,7 +45,7 @@ class FieldWithDateFormat extends AbstractFieldSetting implements TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'dateFormat' => [
 				'type'        => DateFieldFormatEnum::$type,
@@ -57,7 +57,7 @@ class FieldWithDateFormat extends AbstractFieldSetting implements TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithDateInputType.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDateInputType.php
@@ -32,7 +32,7 @@ class FieldWithDateInputType extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'calendarIconType' => [
 				'type'        => FormFieldCalendarIconTypeEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithDefaultValue.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDefaultValue.php
@@ -29,7 +29,7 @@ class FieldWithDefaultValue extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'defaultValue' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDeleteIconUrl.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDeleteIconUrl.php
@@ -29,7 +29,7 @@ class FieldWithDeleteIconUrl extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'deleteIconUrl' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDescription.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDescription.php
@@ -29,7 +29,7 @@ class FieldWithDescription extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'description' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDisableMargins.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDisableMargins.php
@@ -29,7 +29,7 @@ class FieldWithDisableMargins extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasMargins' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDisableQuantity.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDisableQuantity.php
@@ -29,7 +29,7 @@ class FieldWithDisableQuantity extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasQuantity'        => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithDuplicates.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithDuplicates.php
@@ -29,7 +29,7 @@ class FieldWithDuplicates extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'shouldAllowDuplicates' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithEmailConfirmation.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithEmailConfirmation.php
@@ -44,7 +44,7 @@ class FieldWithEmailConfirmation extends AbstractFieldSetting implements TypeWit
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasEmailConfirmation' => [
 				'type'        => 'Boolean',
@@ -57,7 +57,7 @@ class FieldWithEmailConfirmation extends AbstractFieldSetting implements TypeWit
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithSubLabelPlacement::$type,
 			FieldWithInputs::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithEnhancedUI.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithEnhancedUI.php
@@ -29,7 +29,7 @@ class FieldWithEnhancedUI extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasEnhancedUI' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithErrorMessage.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithErrorMessage.php
@@ -29,7 +29,7 @@ class FieldWithErrorMessage extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'errorMessage' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithFileExtensions.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithFileExtensions.php
@@ -29,7 +29,7 @@ class FieldWithFileExtensions extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'allowedExtensions' => [
 				'type'        => [ 'list_of' => 'String' ],

--- a/src/Type/WPInterface/FieldSetting/FieldWithFileSize.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithFileSize.php
@@ -29,7 +29,7 @@ class FieldWithFileSize extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'maxFileSize' => [
 				'type'        => 'Int',

--- a/src/Type/WPInterface/FieldSetting/FieldWithForceSSLField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithForceSSLField.php
@@ -29,7 +29,7 @@ class FieldWithForceSSLField extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isSSLForced' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithInputMask.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithInputMask.php
@@ -29,7 +29,7 @@ class FieldWithInputMask extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'inputMaskValue' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithLabel.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithLabel.php
@@ -29,7 +29,7 @@ class FieldWithLabel extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'label' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithLabelPlacement.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithLabelPlacement.php
@@ -32,7 +32,7 @@ class FieldWithLabelPlacement extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'descriptionPlacement' => [
 				'type'        => FormFieldDescriptionPlacementEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithMaxLength.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithMaxLength.php
@@ -31,12 +31,12 @@ class FieldWithMaxLength extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'maxLength' => [
 				'type'        => 'Int',
 				'description' => __( 'Specifies the maximum number of characters allowed in a text or textarea (paragraph) field.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( GF_Field $field ) : int {
+				'resolve'     => static function ( GF_Field $field ): int {
 					return (int) $field['maxLength'];
 				},
 			],

--- a/src/Type/WPInterface/FieldSetting/FieldWithMaxRows.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithMaxRows.php
@@ -29,7 +29,7 @@ class FieldWithMaxRows extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'maxRows' => [
 				'type'        => 'Int',

--- a/src/Type/WPInterface/FieldSetting/FieldWithMultipleFiles.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithMultipleFiles.php
@@ -29,7 +29,7 @@ class FieldWithMultipleFiles extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'canAcceptMultipleFiles' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithName.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithName.php
@@ -8,9 +8,9 @@
 
 namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 
-use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
 use WPGraphQL\GF\Type\WPInterface\FieldWithInputs;
+use WPGraphQL\Registry\TypeRegistry;
 
 /**
  * Class - FieldWithName
@@ -44,14 +44,14 @@ class FieldWithName extends AbstractFieldSetting implements TypeWithInterfaces {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return FieldWithInputs::get_fields();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithNextButton.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithNextButton.php
@@ -31,7 +31,7 @@ class FieldWithNextButton extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'nextButton' => [
 				'type'        => FormButton::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithNumberFormat.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithNumberFormat.php
@@ -31,7 +31,7 @@ class FieldWithNumberFormat extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'numberFormat' => [
 				'type'        => NumberFieldFormatEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithOtherChoice.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithOtherChoice.php
@@ -43,7 +43,7 @@ class FieldWithOtherChoice extends AbstractFieldSetting implements TypeWithInter
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasOtherChoice' => [
 				'type'        => 'Boolean',
@@ -53,11 +53,10 @@ class FieldWithOtherChoice extends AbstractFieldSetting implements TypeWithInter
 		];
 	}
 
-	
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithChoices::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithPassword.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPassword.php
@@ -8,9 +8,7 @@
 
 namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 
-use GF_Field;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
-use WPGraphQL\GF\Registry\FieldInputRegistry;
 use WPGraphQL\GF\Type\WPInterface\FieldWithInputs;
 use WPGraphQL\Registry\TypeRegistry;
 

--- a/src/Type/WPInterface/FieldSetting/FieldWithPassword.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPassword.php
@@ -44,15 +44,14 @@ class FieldWithPassword extends AbstractFieldSetting implements TypeWithInterfac
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return FieldWithInputs::get_fields();
 	}
 
-	
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithPasswordField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPasswordField.php
@@ -29,7 +29,7 @@ class FieldWithPasswordField extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isPasswordInput' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPasswordStrength.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPasswordStrength.php
@@ -31,7 +31,7 @@ class FieldWithPasswordStrength extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasPasswordStrengthIndicator' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPasswordVisibility.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPasswordVisibility.php
@@ -29,7 +29,7 @@ class FieldWithPasswordVisibility extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasPasswordVisibilityToggle' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPhoneFormat.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPhoneFormat.php
@@ -31,7 +31,7 @@ class FieldWithPhoneFormat extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'phoneFormat' => [
 				'type'        => PhoneFieldFormatEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithPlaceholder.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPlaceholder.php
@@ -29,7 +29,7 @@ class FieldWithPlaceholder extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'placeholder' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPostCategoryCheckbox.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPostCategoryCheckbox.php
@@ -29,7 +29,7 @@ class FieldWithPostCategoryCheckbox extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasAllCategories' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPostCategoryInitialItem.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPostCategoryInitialItem.php
@@ -29,7 +29,7 @@ class FieldWithPostCategoryInitialItem extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'dropdownPlaceholder' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPostCustomField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPostCustomField.php
@@ -29,7 +29,7 @@ class FieldWithPostCustomField extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'postMetaFieldName' => [
 				'type'        => 'String',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPostImage.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPostImage.php
@@ -32,7 +32,7 @@ class FieldWithPostImage extends AbstractFieldSetting implements TypeWithInterfa
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config( TypeRegistry $type_registry = null ) : array {
+	public static function get_type_config( TypeRegistry $type_registry = null ): array {
 		$config = parent::get_type_config( $type_registry );
 
 		$config['interfaces'] = static::get_interfaces();
@@ -43,7 +43,7 @@ class FieldWithPostImage extends AbstractFieldSetting implements TypeWithInterfa
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasAlt'         => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPostImageFeaturedImage.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPostImageFeaturedImage.php
@@ -29,7 +29,7 @@ class FieldWithPostImageFeaturedImage extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isFeaturedImage' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
@@ -40,7 +40,7 @@ class FieldWithPrepopulateField extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'canPrepopulate' => [
 				'type'        => 'Boolean',
@@ -58,7 +58,7 @@ class FieldWithPrepopulateField extends AbstractFieldSetting {
 	 * @param array     $settings The `form_editor_field_settings()` key.
 	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
-	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ) : array {
+	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ): array {
 		// Bail early.
 		if (
 			! in_array( self::$type, $interfaces, true ) ||

--- a/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPrepopulateField.php
@@ -32,7 +32,7 @@ class FieldWithPrepopulateField extends AbstractFieldSetting {
 	 * {@inheritDoc}
 	 */
 	public static function register_hooks(): void {
-		add_filter( 'graphql_gf_form_field_setting_fields', [ __CLASS__, 'add_fields_to_child_type' ], 10, 4 );
+		add_filter( 'graphql_gf_form_field_setting_fields', [ self::class, 'add_fields_to_child_type' ], 10, 4 );
 
 		parent::register_hooks();
 	}
@@ -53,10 +53,10 @@ class FieldWithPrepopulateField extends AbstractFieldSetting {
 	/**
 	 * Registers a GraphQL field to the GraphQL type that implements this interface.
 	 *
-	 * @param array    $fields An array of GraphQL field configs.
-	 * @param GF_Field $field The Gravity Forms Field object.
-	 * @param array    $settings The `form_editor_field_settings()` key.
-	 * @param array    $interfaces The list of interfaces for the GraphQL type.
+	 * @param array     $fields An array of GraphQL field configs.
+	 * @param \GF_Field $field The Gravity Forms Field object.
+	 * @param array     $settings The `form_editor_field_settings()` key.
+	 * @param array     $interfaces The list of interfaces for the GraphQL type.
 	 */
 	public static function add_fields_to_child_type( array $fields, GF_Field $field, array $settings, array $interfaces ) : array {
 		// Bail early.

--- a/src/Type/WPInterface/FieldSetting/FieldWithPreviousButton.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithPreviousButton.php
@@ -31,7 +31,7 @@ class FieldWithPreviousButton extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'previousButton' => [
 				'type'        => FormButton::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
@@ -29,7 +29,7 @@ class FieldWithProductField extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		// @todo make connection.
 		return [
 			'productField' => [

--- a/src/Type/WPInterface/FieldSetting/FieldWithRange.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithRange.php
@@ -29,12 +29,12 @@ class FieldWithRange extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'rangeMax' => [
 				'type'        => 'Float',
 				'description' => __( 'Maximum allowed value for a number field. Values higher than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?float {
+				'resolve'     => static function ( $source ): ?float {
 					if ( ! isset( $source->rangeMax ) ) {
 						return null;
 					}
@@ -47,7 +47,7 @@ class FieldWithRange extends AbstractFieldSetting {
 			'rangeMin' => [
 				'type'        => 'Float',
 				'description' => __( 'Minimum allowed value for a number field. Values lower than the number specified by this property will cause the field to fail validation.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function ( $source ) : ?float {
+				'resolve'     => static function ( $source ): ?float {
 					if ( ! isset( $source->rangeMin ) ) {
 						return null;
 					}

--- a/src/Type/WPInterface/FieldSetting/FieldWithRichTextEditor.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithRichTextEditor.php
@@ -29,7 +29,7 @@ class FieldWithRichTextEditor extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasRichTextEditor' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithRules.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithRules.php
@@ -29,7 +29,7 @@ class FieldWithRules extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isRequired' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPInterface/FieldSetting/FieldWithSelectAllChoices.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithSelectAllChoices.php
@@ -45,12 +45,12 @@ class FieldWithSelectAllChoices extends AbstractFieldSetting implements TypeWith
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasSelectAll' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether the \"select all\" choice should be displayed.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source->enableSelectAll ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source->enableSelectAll ),
 			],
 		];
 	}
@@ -58,7 +58,7 @@ class FieldWithSelectAllChoices extends AbstractFieldSetting implements TypeWith
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithChoices::$type,
 			FieldWithInputs::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithSingleProductInputs.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithSingleProductInputs.php
@@ -48,14 +48,14 @@ class FieldWithSingleProductInputs extends AbstractFieldSetting implements TypeW
 	 *
 	 * The only added field is `inputs`, which is handled by the Input registry.
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return FieldWithInputs::get_fields();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldSetting/FieldWithSize.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithSize.php
@@ -31,7 +31,7 @@ class FieldWithSize extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'size' => [
 				'type'        => FormFieldSizeEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithSubLabelPlacement.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithSubLabelPlacement.php
@@ -31,7 +31,7 @@ class FieldWithSubLabelPlacement extends AbstractFieldSetting {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'subLabelPlacement' => [
 				'type'        => FormFieldSubLabelPlacementEnum::$type,

--- a/src/Type/WPInterface/FieldSetting/FieldWithTimeFormat.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithTimeFormat.php
@@ -45,7 +45,7 @@ class FieldWithTimeFormat extends AbstractFieldSetting implements TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'timeFormat' => [
 				'type'        => TimeFieldFormatEnum::$type,
@@ -57,7 +57,7 @@ class FieldWithTimeFormat extends AbstractFieldSetting implements TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldWithInputs::$type,
 		];

--- a/src/Type/WPInterface/FieldValue/FieldValueWithChoice.php
+++ b/src/Type/WPInterface/FieldValue/FieldValueWithChoice.php
@@ -25,14 +25,14 @@ class FieldValueWithChoice extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms field value with connected choice.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'connectedChoice' => [
 				'type'        => FieldChoice::$type,

--- a/src/Type/WPInterface/FieldValue/FieldValueWithInput.php
+++ b/src/Type/WPInterface/FieldValue/FieldValueWithInput.php
@@ -25,14 +25,14 @@ class FieldValueWithInput extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms field value with connected input.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'connectedInput' => [
 				'type'        => FieldInput::$type,

--- a/src/Type/WPInterface/FieldWithChoices.php
+++ b/src/Type/WPInterface/FieldWithChoices.php
@@ -25,14 +25,14 @@ class FieldWithChoices extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A Gravity Forms field with possible field choices.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'choices' => [
 				'type'        => [ 'list_of' => FieldChoice::$type ],
@@ -41,8 +41,8 @@ class FieldWithChoices extends AbstractInterface {
 						/** @var \GF_Field $source */
 						$context->gfField = $source;
 
-						return ! empty( $source->choices ) ? 
-						// Include GraphQL Type in resolver.
+						return ! empty( $source->choices )
+																			? // Include GraphQL Type in resolver.
 						array_map(
 							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldChoiceRegistry::get_type_name( $source );
@@ -50,7 +50,8 @@ class FieldWithChoices extends AbstractInterface {
 								return $choice;
 							},
 							$source->choices
-						) : null;
+						)
+																			: null;
 				},
 			],
 		];

--- a/src/Type/WPInterface/FieldWithChoices.php
+++ b/src/Type/WPInterface/FieldWithChoices.php
@@ -38,12 +38,12 @@ class FieldWithChoices extends AbstractInterface {
 				'type'        => [ 'list_of' => FieldChoice::$type ],
 				'description' => __( 'The choices for the field.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
-						/** @var \GF_Field $source */
-						$context->gfField = $source;
+					/** @var \GF_Field $source */
+					$context->gfField = $source;
 
-						return ! empty( $source->choices )
-																			? // Include GraphQL Type in resolver.
-						array_map(
+					return ! empty( $source->choices )
+						// Include GraphQL Type in resolver.
+						? array_map(
 							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldChoiceRegistry::get_type_name( $source );
 
@@ -51,7 +51,7 @@ class FieldWithChoices extends AbstractInterface {
 							},
 							$source->choices
 						)
-																			: null;
+						: null;
 				},
 			],
 		];

--- a/src/Type/WPInterface/FieldWithChoices.php
+++ b/src/Type/WPInterface/FieldWithChoices.php
@@ -38,14 +38,14 @@ class FieldWithChoices extends AbstractInterface {
 			'choices' => [
 				'type'        => [ 'list_of' => FieldChoice::$type ],
 				'description' => __( 'The choices for the field.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function( $source, array $args, AppContext $context, $info ) {
+				'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
 						/** @var \GF_Field $source */
 						$context->gfField = $source;
 
 						return ! empty( $source->choices ) ? 
 						// Include GraphQL Type in resolver.
 						array_map(
-							static function( $choice ) use ( $source ) {
+							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldChoiceRegistry::get_type_name( $source );
 
 								return $choice;

--- a/src/Type/WPInterface/FieldWithChoices.php
+++ b/src/Type/WPInterface/FieldWithChoices.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\GF\Type\WPInterface;
 
-use GF_Field;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Registry\FieldChoiceRegistry;
 

--- a/src/Type/WPInterface/FieldWithInputs.php
+++ b/src/Type/WPInterface/FieldWithInputs.php
@@ -38,12 +38,12 @@ class FieldWithInputs extends AbstractInterface {
 				'type'        => [ 'list_of' => FieldInput::$type ],
 				'description' => __( 'The inputs for the field.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
-						/** @var \GF_Field $source */
-						$context->gfField = $source;
+					/** @var \GF_Field $source */
+					$context->gfField = $source;
 
-						return ! empty( $source->inputs )
-																			? // Include GraphQL Type in resolver.
-						array_map(
+					return ! empty( $source->inputs )
+						// Include GraphQL Type in resolver.
+						? array_map(
 							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldInputRegistry::get_type_name( $source );
 
@@ -51,7 +51,7 @@ class FieldWithInputs extends AbstractInterface {
 							},
 							$source->inputs
 						)
-																			: null;
+						: null;
 				},
 			],
 		];

--- a/src/Type/WPInterface/FieldWithInputs.php
+++ b/src/Type/WPInterface/FieldWithInputs.php
@@ -38,14 +38,14 @@ class FieldWithInputs extends AbstractInterface {
 			'inputs' => [
 				'type'        => [ 'list_of' => FieldInput::$type ],
 				'description' => __( 'The inputs for the field.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static function( $source, array $args, AppContext $context, $info ) {
+				'resolve'     => static function ( $source, array $args, AppContext $context, $info ) {
 						/** @var \GF_Field $source */
 						$context->gfField = $source;
 
 						return ! empty( $source->inputs ) ? 
 						// Include GraphQL Type in resolver.
 						array_map(
-							static function( $choice ) use ( $source ) {
+							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldInputRegistry::get_type_name( $source );
 
 								return $choice;

--- a/src/Type/WPInterface/FieldWithInputs.php
+++ b/src/Type/WPInterface/FieldWithInputs.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\GF\Type\WPInterface;
 
-use GF_Field;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Registry\FieldInputRegistry;
 

--- a/src/Type/WPInterface/FieldWithInputs.php
+++ b/src/Type/WPInterface/FieldWithInputs.php
@@ -25,14 +25,14 @@ class FieldWithInputs extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A Gravity Forms field with possible field inputs.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'inputs' => [
 				'type'        => [ 'list_of' => FieldInput::$type ],
@@ -41,8 +41,8 @@ class FieldWithInputs extends AbstractInterface {
 						/** @var \GF_Field $source */
 						$context->gfField = $source;
 
-						return ! empty( $source->inputs ) ? 
-						// Include GraphQL Type in resolver.
+						return ! empty( $source->inputs )
+																			? // Include GraphQL Type in resolver.
 						array_map(
 							static function ( $choice ) use ( $source ) {
 								$choice['graphql_type'] = FieldInputRegistry::get_type_name( $source );
@@ -50,7 +50,8 @@ class FieldWithInputs extends AbstractInterface {
 								return $choice;
 							},
 							$source->inputs
-						) : null;
+						)
+																			: null;
 				},
 			],
 		];

--- a/src/Type/WPInterface/FieldWithPersonalData.php
+++ b/src/Type/WPInterface/FieldWithPersonalData.php
@@ -26,14 +26,14 @@ class FieldWithPersonalData extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The form field-specifc policies for exporting and erasing personal data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'personalData' => [
 				'type'        => FormFieldDataPolicy::$type,

--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -102,10 +102,10 @@ class FormField extends AbstractInterface {
 	/**
 	 * Resolves the interface to the GraphQL type.
 	 *
-	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function ( $value ) use ( $type_registry ) {
+		return static function ( $value ) use ( $type_registry ) {
 			$possible_types    = Utils::get_registered_form_field_types();
 			$possible_subtypes = Utils::get_possible_form_field_child_types( $value->type );
 

--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -32,7 +32,7 @@ class FormField extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config( TypeRegistry $type_registry = null ) : array {
+	public static function get_type_config( TypeRegistry $type_registry = null ): array {
 		$config = parent::get_type_config( $type_registry );
 
 		if ( null !== $type_registry ) {
@@ -45,19 +45,19 @@ class FormField extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'displayOnly'                => [
 				'type'        => 'Boolean',
 				'description' => __( 'Indicates the field is only displayed and its contents are not submitted with the form/saved with the entry. This is set to true.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : bool => ! empty( $source->displayOnly ),
+				'resolve'     => static fn ( $source ): bool => ! empty( $source->displayOnly ),
 			],
 			'id'                         => [
 				'type'              => [ 'non_null' => 'Int' ],
@@ -67,7 +67,7 @@ class FormField extends AbstractInterface {
 			'databaseId'                 => [
 				'type'        => [ 'non_null' => 'Int' ],
 				'description' => __( 'Field database ID.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : int => absint( $source->id ),
+				'resolve'     => static fn ( $source ): int => absint( $source->id ),
 			],
 			'inputType'                  => [
 				'type'        => FormFieldTypeEnum::$type,
@@ -94,7 +94,7 @@ class FormField extends AbstractInterface {
 			'visibility'                 => [
 				'type'        => FormFieldVisibilityEnum::$type,
 				'description' => __( 'Field visibility.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source ) : string => ! empty( $source->visibility ) ? $source->visibility : ( ! empty( $source->adminOnly ) ? 'administrative' : 'visible' ),
+				'resolve'     => static fn ( $source ): string => ! empty( $source->visibility ) ? $source->visibility : ( ! empty( $source->adminOnly ) ? 'administrative' : 'visible' ),
 			],
 		];
 	}
@@ -104,7 +104,7 @@ class FormField extends AbstractInterface {
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
-	public static function resolve_type( TypeRegistry $type_registry ) : callable {
+	public static function resolve_type( TypeRegistry $type_registry ): callable {
 		return static function ( $value ) use ( $type_registry ) {
 			$possible_types    = Utils::get_registered_form_field_types();
 			$possible_subtypes = Utils::get_possible_form_field_child_types( $value->type );

--- a/src/Type/WPInterface/FormField.php
+++ b/src/Type/WPInterface/FormField.php
@@ -105,7 +105,7 @@ class FormField extends AbstractInterface {
 	 * @param TypeRegistry $type_registry The WPGraphQL type registry.
 	 */
 	public static function resolve_type( TypeRegistry $type_registry ) : callable {
-		return function( $value ) use ( $type_registry ) {
+		return function ( $value ) use ( $type_registry ) {
 			$possible_types    = Utils::get_registered_form_field_types();
 			$possible_subtypes = Utils::get_possible_form_field_child_types( $value->type );
 

--- a/src/Type/WPInterface/NodeWithForm.php
+++ b/src/Type/WPInterface/NodeWithForm.php
@@ -27,14 +27,14 @@ class NodeWithForm extends AbstractInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A node that can have a Gravity Forms form assigned to it.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'formDatabaseId' => [
 				'type'        => 'Int',

--- a/src/Type/WPObject/AbstractObject.php
+++ b/src/Type/WPObject/AbstractObject.php
@@ -35,7 +35,7 @@ abstract class AbstractObject extends AbstractType implements TypeWithDescriptio
 	/**
 	 * Register Object type to GraphQL schema.
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		$config = static::get_type_config();
 
 		register_graphql_object_type( static::$type, $config );

--- a/src/Type/WPObject/Button/FormButton.php
+++ b/src/Type/WPObject/Button/FormButton.php
@@ -28,14 +28,14 @@ class FormButton extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms button.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'type'             => [
 				'type'        => FormButtonTypeEnum::$type,

--- a/src/Type/WPObject/Button/FormLastPageButton.php
+++ b/src/Type/WPObject/Button/FormLastPageButton.php
@@ -27,14 +27,14 @@ class FormLastPageButton extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms button.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'type'     => [
 				'type'        => FormButtonTypeEnum::$type,

--- a/src/Type/WPObject/ConditionalLogic/ConditionalLogic.php
+++ b/src/Type/WPObject/ConditionalLogic/ConditionalLogic.php
@@ -28,14 +28,14 @@ class ConditionalLogic extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms conditional logic.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'actionType' => [
 				'type'        => ConditionalLogicActionTypeEnum::$type,

--- a/src/Type/WPObject/ConditionalLogic/ConditionalLogicRule.php
+++ b/src/Type/WPObject/ConditionalLogic/ConditionalLogicRule.php
@@ -27,14 +27,14 @@ class ConditionalLogicRule extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms conditional logic rule.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'fieldId'  => [
 				'type'        => 'Float',

--- a/src/Type/WPObject/Entry/DraftEntry.php
+++ b/src/Type/WPObject/Entry/DraftEntry.php
@@ -38,19 +38,19 @@ class DraftEntry extends AbstractObject implements TypeWithInterfaces, Field {
 	 */
 	public static string $field_name = 'gfDraftEntry';
 
-
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		$config = parent::get_type_config();
 
 		$config['interfaces'] = self::get_interfaces();
@@ -61,14 +61,14 @@ class DraftEntry extends AbstractObject implements TypeWithInterfaces, Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A Gravity Forms draft entry.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'resumeToken' => [
 				'type'        => 'String',
@@ -80,14 +80,14 @@ class DraftEntry extends AbstractObject implements TypeWithInterfaces, Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [ Entry::$type ];
 	}
 
 	/**
 	 * Register entry query.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			'RootQuery',
 			self::$field_name,

--- a/src/Type/WPObject/Entry/SubmittedEntry.php
+++ b/src/Type/WPObject/Entry/SubmittedEntry.php
@@ -14,8 +14,8 @@ use WPGraphQL\AppContext;
 use WPGraphQL\GF\Data\Factory;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
-use WPGraphQL\GF\Type\Enum\SubmittedEntryIdTypeEnum;
 use WPGraphQL\GF\Type\Enum\EntryStatusEnum;
+use WPGraphQL\GF\Type\Enum\SubmittedEntryIdTypeEnum;
 use WPGraphQL\GF\Type\WPInterface\Entry;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Utils\Utils;
@@ -41,8 +41,9 @@ class SubmittedEntry extends AbstractObject implements TypeWithInterfaces, Field
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
@@ -60,14 +61,14 @@ class SubmittedEntry extends AbstractObject implements TypeWithInterfaces, Field
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'A Gravity Forms submitted entry.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'entryId'        => [
 				'type'              => 'Int',
@@ -102,14 +103,14 @@ class SubmittedEntry extends AbstractObject implements TypeWithInterfaces, Field
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [ 'DatabaseIdentifier', Entry::$type ];
 	}
 
 	/**
 	 * Register entry query.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			'RootQuery',
 			self::$field_name,

--- a/src/Type/WPObject/FieldError.php
+++ b/src/Type/WPObject/FieldError.php
@@ -25,14 +25,14 @@ class FieldError extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Field error.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'id'      => [
 				'type'        => 'Float',

--- a/src/Type/WPObject/Form/Form.php
+++ b/src/Type/WPObject/Form/Form.php
@@ -10,7 +10,6 @@
 
 namespace WPGraphQL\GF\Type\WPObject\Form;
 
-use GF_Query;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Connection\EntriesConnection;
@@ -84,12 +83,12 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 							 *
 							 * @todo get the connection resolver directly, once supported by WPGraphQL AppContext::get_current_connection();
 							 *
-							 * @var GF_Query
+							 * @var \GF_Query
 							 */
 							$connection = $root['edges'][0]['connection'] instanceof EntriesConnectionResolver ? $root['edges'][0]['connection']->get_query() : null;
 
 							// Needed to resolve the counts.
-							$ids = $connection->get_ids();
+							$connection->get_ids();
 
 							return $connection->total_found;
 						},

--- a/src/Type/WPObject/Form/Form.php
+++ b/src/Type/WPObject/Form/Form.php
@@ -14,8 +14,8 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Connection\EntriesConnection;
 use WPGraphQL\GF\Connection\FormFieldsConnection;
-use WPGraphQL\GF\Data\Connection\FormFieldsConnectionResolver;
 use WPGraphQL\GF\Data\Connection\EntriesConnectionResolver;
+use WPGraphQL\GF\Data\Connection\FormFieldsConnectionResolver;
 use WPGraphQL\GF\Data\Factory;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Interfaces\TypeWithConnections;
@@ -48,15 +48,16 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		$config = parent::get_type_config();
 
 		$config['connections'] = static::get_connections();
@@ -68,7 +69,7 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connections() : array {
+	public static function get_connections(): array {
 		return [
 			'entries'    => [
 				'toType'           => Entry::$type,
@@ -121,14 +122,14 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'button'                       => [
 				'type'              => FormSubmitButton::$type,
@@ -270,14 +271,14 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [ 'Node', 'DatabaseIdentifier' ];
 	}
 
 	/**
 	 * Register form query.
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			'RootQuery',
 			self::$field_name,

--- a/src/Type/WPObject/Form/FormConfirmation.php
+++ b/src/Type/WPObject/Form/FormConfirmation.php
@@ -32,7 +32,7 @@ class FormConfirmation extends AbstractObject implements TypeWithConnections {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		$config = parent::get_type_config();
 
 		$config['connections'] = self::get_connections();
@@ -64,14 +64,14 @@ class FormConfirmation extends AbstractObject implements TypeWithConnections {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'conditionalLogic' => [
 				'type'        => ConditionalLogic::$type,

--- a/src/Type/WPObject/Form/FormDataPolicies.php
+++ b/src/Type/WPObject/Form/FormDataPolicies.php
@@ -24,14 +24,14 @@ class FormDataPolicies extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The policies governing which entry data to include when erasing and exporting personal data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'canExportAndErase'             => [
 				'type'        => 'Boolean',

--- a/src/Type/WPObject/Form/FormEntryDataPolicy.php
+++ b/src/Type/WPObject/Form/FormEntryDataPolicy.php
@@ -24,14 +24,14 @@ class FormEntryDataPolicy extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual entry data exporting and erasing policies.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'key'          => [
 				'type'        => 'String',

--- a/src/Type/WPObject/Form/FormEntryLimits.php
+++ b/src/Type/WPObject/Form/FormEntryLimits.php
@@ -25,14 +25,14 @@ class FormEntryLimits extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form entry limititation details.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasLimit'            => [
 				'type'        => 'Boolean',

--- a/src/Type/WPObject/Form/FormLogin.php
+++ b/src/Type/WPObject/Form/FormLogin.php
@@ -24,14 +24,14 @@ class FormLogin extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form login requirements data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isLoginRequired'      => [
 				'type'        => 'Boolean',

--- a/src/Type/WPObject/Form/FormNotification.php
+++ b/src/Type/WPObject/Form/FormNotification.php
@@ -28,14 +28,14 @@ class FormNotification extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'bcc'                   => [
 				'type'        => 'String',

--- a/src/Type/WPObject/Form/FormNotificationRouting.php
+++ b/src/Type/WPObject/Form/FormNotificationRouting.php
@@ -28,14 +28,14 @@ class FormNotificationRouting extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Properties for all the email notifications which exist for a form.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'fieldId'  => [
 				'type'        => 'Int',

--- a/src/Type/WPObject/Form/FormPagination.php
+++ b/src/Type/WPObject/Form/FormPagination.php
@@ -29,14 +29,14 @@ class FormPagination extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form pagination data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'backgroundColor'              => [
 				'type'        => 'String',

--- a/src/Type/WPObject/Form/FormPersonalData.php
+++ b/src/Type/WPObject/Form/FormPersonalData.php
@@ -25,14 +25,14 @@ class FormPersonalData extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form Personal Data settings.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'daysToRetain'    => [
 				'type'        => 'Int',

--- a/src/Type/WPObject/Form/FormPostCreation.php
+++ b/src/Type/WPObject/Form/FormPostCreation.php
@@ -26,14 +26,14 @@ class FormPostCreation extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form entry limititation details.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'authorDatabaseId'             => [
 				'type'        => 'Int',

--- a/src/Type/WPObject/Form/FormSaveAndContinue.php
+++ b/src/Type/WPObject/Form/FormSaveAndContinue.php
@@ -24,14 +24,14 @@ class FormSaveAndContinue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form Save and Continue data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'hasSaveAndContinue' => [
 				'type'        => 'Boolean',
@@ -41,7 +41,7 @@ class FormSaveAndContinue extends AbstractObject {
 			'buttonText'         => [
 				'type'        => 'String',
 				'description' => __( 'Contains the save button text.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source): string  => ! empty( $source['button']['text'] ) ? $source['button']['text'] : null,
+				'resolve'     => static fn ( $source): string => ! empty( $source['button']['text'] ) ? $source['button']['text'] : null,
 			],
 		];
 	}

--- a/src/Type/WPObject/Form/FormSchedule.php
+++ b/src/Type/WPObject/Form/FormSchedule.php
@@ -24,14 +24,14 @@ class FormSchedule extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form scheduling data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'closedMessage'  => [
 				'type'        => 'String',

--- a/src/Type/WPObject/Form/FormScheduleDetails.php
+++ b/src/Type/WPObject/Form/FormScheduleDetails.php
@@ -25,14 +25,14 @@ class FormScheduleDetails extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms form scheduling data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'amPm'    => [
 				'type'        => AmPmEnum::$type,

--- a/src/Type/WPObject/Form/FormSubmitButton.php
+++ b/src/Type/WPObject/Form/FormSubmitButton.php
@@ -30,14 +30,14 @@ class FormSubmitButton extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms submit button.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'type'                 => [
 				'type'        => FormButtonTypeEnum::$type,

--- a/src/Type/WPObject/FormField/FieldValue/FieldValues.php
+++ b/src/Type/WPObject/FormField/FieldValue/FieldValues.php
@@ -10,9 +10,9 @@ namespace WPGraphQL\GF\Type\WPObject\FormField\FieldValue;
 
 use GFAPI;
 use GFCommon;
+use GFFormsModel;
 use GF_Field;
 use GF_Field_FileUpload;
-use GFFormsModel;
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Registry\FieldChoiceRegistry;
 use WPGraphQL\GF\Registry\FieldInputRegistry;
@@ -26,7 +26,7 @@ class FieldValues {
 	/**
 	 * Get `value` property.
 	 */
-	public static function value() : array {
+	public static function value(): array {
 		return [
 			'value' => [
 				'type'        => 'String',
@@ -45,7 +45,7 @@ class FieldValues {
 	/**
 	 * Get `addressValues` property.
 	 */
-	public static function address_values() : array {
+	public static function address_values(): array {
 		return [
 			'addressValues' => [
 				'type'        => ValueProperty\AddressFieldValue::$type,
@@ -71,7 +71,7 @@ class FieldValues {
 	/**
 	 * Get `checkboxValues` property.
 	 */
-	public static function checkbox_values() : array {
+	public static function checkbox_values(): array {
 		return [
 			'checkboxValues' => [
 				'type'        => [ 'list_of' => ValueProperty\CheckboxFieldValue::$type ],
@@ -115,7 +115,7 @@ class FieldValues {
 	 *
 	 * @return array
 	 */
-	public static function consent_value() : array {
+	public static function consent_value(): array {
 		return [
 			'consentValue' => [
 				'type'        => 'Boolean',
@@ -137,7 +137,7 @@ class FieldValues {
 	 *
 	 * @return array
 	 */
-	public static function file_upload_values() : array {
+	public static function file_upload_values(): array {
 		return [
 			'fileUploadValues' => [
 				'type'        => [ 'list_of' => ValueProperty\FileUploadFieldValue::$type ],
@@ -156,7 +156,7 @@ class FieldValues {
 	/**
 	 * Get `imageValues` property.
 	 */
-	public static function image_values() : array {
+	public static function image_values(): array {
 		return [
 			'imageValues' => [
 				'type'        => ValueProperty\ImageFieldValue::$type,
@@ -201,7 +201,7 @@ class FieldValues {
 	/**
 	 * Get `listValues` property.
 	 */
-	public static function list_values() : array {
+	public static function list_values(): array {
 		return [
 			'listValues' => [
 				'type'        => [ 'list_of' => ValueProperty\ListFieldValue::$type ],
@@ -222,7 +222,7 @@ class FieldValues {
 					if ( $source->enableColumns ) {
 						// Save each row-value pair.
 						return array_map(
-							static function ( $row ) : array {
+							static function ( $row ): array {
 								$row_values = [];
 
 								foreach ( $row as $single_value ) {
@@ -238,7 +238,7 @@ class FieldValues {
 					}
 					// If no columns, entry values can be mapped directly to 'value'.
 					return array_map(
-						static function ( $single_value ) : array {
+						static function ( $single_value ): array {
 							return [
 								'values' => [ $single_value ], // $single_value must be Iteratable.
 							];
@@ -253,7 +253,7 @@ class FieldValues {
 	/**
 	 * Get `nameValues` property.
 	 */
-	public static function name_values() : array {
+	public static function name_values(): array {
 		return [
 			'nameValues' => [
 				'type'        => ValueProperty\NameFieldValue::$type,
@@ -278,7 +278,7 @@ class FieldValues {
 	/**
 	 * Get `productValues` property.
 	 */
-	public static function product_values() : array {
+	public static function product_values(): array {
 		return [
 			'productValues' => [
 				'type'        => ValueProperty\ProductFieldValue::$type,
@@ -349,7 +349,7 @@ class FieldValues {
 	/**
 	 * Get `timeValues` property.
 	 */
-	public static function time_values() : array {
+	public static function time_values(): array {
 		return [
 			'timeValues' => [
 				'type'        => ValueProperty\TimeFieldValue::$type,
@@ -382,7 +382,7 @@ class FieldValues {
 	/**
 	 * Get `values` property.
 	 */
-	public static function values() : array {
+	public static function values(): array {
 		return [
 			'values' => [
 				'type'        => [ 'list_of' => 'String' ],
@@ -422,7 +422,7 @@ class FieldValues {
 	 * @param mixed                 $source .
 	 * @param \WPGraphQL\AppContext $context .
 	 */
-	protected static function is_field_and_entry( $source, AppContext $context ) : bool {
+	protected static function is_field_and_entry( $source, AppContext $context ): bool {
 		return $source instanceof GF_Field
 			&& isset( $context->gfEntry )
 			&& isset( $context->gfEntry->entry );
@@ -437,7 +437,7 @@ class FieldValues {
 	 * @param array                $entry .
 	 * @param array                $form .
 	 */
-	protected static function get_file_upload_extra_entry_metadata( GF_Field_FileUpload $field, array $entry, array $form ) : array {
+	protected static function get_file_upload_extra_entry_metadata( GF_Field_FileUpload $field, array $entry, array $form ): array {
 		$file_values = $entry[ $field->id ] ?? null;
 
 		// Bail if no files.
@@ -508,7 +508,7 @@ class FieldValues {
 	 * @param \GF_Field $field The gravity forms field object.
 	 * @param int       $input_key The input key that represents field's selected choice.
 	 */
-	public static function prepare_connected_choice( GF_Field $field, int $input_key ) : array {
+	public static function prepare_connected_choice( GF_Field $field, int $input_key ): array {
 		$type = FieldChoiceRegistry::get_type_name( $field );
 
 		$choice                 = $field->choices[ $input_key ] ?? [];
@@ -523,7 +523,7 @@ class FieldValues {
 	 * @param \GF_Field $field The gravity forms field object.
 	 * @param int       $input_key The input key that represents field's selected input.
 	 */
-	public static function prepare_connected_input( GF_Field $field, int $input_key ) : array {
+	public static function prepare_connected_input( GF_Field $field, int $input_key ): array {
 		$type = FieldInputRegistry::get_type_name( $field );
 
 		$input                 = $field->inputs[ $input_key ] ?? [];

--- a/src/Type/WPObject/FormField/FieldValue/FieldValues.php
+++ b/src/Type/WPObject/FormField/FieldValue/FieldValues.php
@@ -419,8 +419,8 @@ class FieldValues {
 	/**
 	 * Checks that the necessary values to retrieve the values are set in the resolver.
 	 *
-	 * @param mixed      $source .
-	 * @param AppContext $context .
+	 * @param mixed                 $source .
+	 * @param \WPGraphQL\AppContext $context .
 	 */
 	protected static function is_field_and_entry( $source, AppContext $context ) : bool {
 		return $source instanceof GF_Field
@@ -433,9 +433,9 @@ class FieldValues {
 	 *
 	 * Shim GF_Field_FileUpload::get_extra_entry_metadata().
 	 *
-	 * @param GF_Field_FileUpload $field .
-	 * @param array               $entry .
-	 * @param array               $form .
+	 * @param \GF_Field_FileUpload $field .
+	 * @param array                $entry .
+	 * @param array                $form .
 	 */
 	protected static function get_file_upload_extra_entry_metadata( GF_Field_FileUpload $field, array $entry, array $form ) : array {
 		$file_values = $entry[ $field->id ] ?? null;
@@ -505,8 +505,8 @@ class FieldValues {
 	/**
 	 * Prepares the selected choice for concumption for the FieldChoice interface by adding the GraphQL object type to the return array.
 	 *
-	 * @param GF_Field $field The gravity forms field object.
-	 * @param int      $input_key The input key that represents field's selected choice.
+	 * @param \GF_Field $field The gravity forms field object.
+	 * @param int       $input_key The input key that represents field's selected choice.
 	 */
 	public static function prepare_connected_choice( GF_Field $field, int $input_key ) : array {
 		$type = FieldChoiceRegistry::get_type_name( $field );
@@ -520,8 +520,8 @@ class FieldValues {
 	/**
 	 * Prepares the selected input for concumption for the FieldInput interface by adding the GraphQL object type to the return array.
 	 *
-	 * @param GF_Field $field The gravity forms field object.
-	 * @param int      $input_key The input key that represents field's selected input.
+	 * @param \GF_Field $field The gravity forms field object.
+	 * @param int       $input_key The input key that represents field's selected input.
 	 */
 	public static function prepare_connected_input( GF_Field $field, int $input_key ) : array {
 		$type = FieldInputRegistry::get_type_name( $field );

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/AddressFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/AddressFieldValue.php
@@ -26,7 +26,7 @@ class AddressFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the address value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/CheckboxFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/CheckboxFieldValue.php
@@ -28,7 +28,7 @@ class CheckboxFieldValue extends AbstractObject implements TypeWithInterfaces {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_type_config() : array {
+	public static function get_type_config(): array {
 		$config = parent::get_type_config();
 
 		$config['interfaces'] = self::get_interfaces();
@@ -39,14 +39,14 @@ class CheckboxFieldValue extends AbstractObject implements TypeWithInterfaces {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the Checkbox value field.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_interfaces() : array {
+	public static function get_interfaces(): array {
 		return [
 			FieldValueWithChoice::$type,
 			FieldValueWithInput::$type,

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/FileUploadFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/FileUploadFieldValue.php
@@ -25,7 +25,7 @@ class FileUploadFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual file properties from an uploaded file.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/ImageFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/ImageFieldValue.php
@@ -25,7 +25,7 @@ class ImageFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the PostImage value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/ListFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/ListFieldValue.php
@@ -25,7 +25,7 @@ class ListFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the List value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/NameFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/NameFieldValue.php
@@ -25,7 +25,7 @@ class NameFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the Name value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/ProductFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/ProductFieldValue.php
@@ -25,7 +25,7 @@ class ProductFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the Product value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FieldValue/ValueProperty/TimeFieldValue.php
+++ b/src/Type/WPObject/FormField/FieldValue/ValueProperty/TimeFieldValue.php
@@ -26,7 +26,7 @@ class TimeFieldValue extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The individual properties for each element of the Time value field.', 'wp-graphql-gravity-forms' );
 	}
 

--- a/src/Type/WPObject/FormField/FormFieldDataPolicy.php
+++ b/src/Type/WPObject/FormField/FormFieldDataPolicy.php
@@ -24,14 +24,14 @@ class FormFieldDataPolicy extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The form field-specifc policies for exporting and erasing personal data.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'shouldErase'           => [
 				'type'        => 'Boolean',

--- a/src/Type/WPObject/FormField/FormFields.php
+++ b/src/Type/WPObject/FormField/FormFields.php
@@ -31,7 +31,7 @@ class FormFields implements Hookable, Registrable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		// Hooks are applied later in the lifecycle, to ensure the TypeRegister is always up to date.
 		self::register();
 	}
@@ -39,7 +39,7 @@ class FormFields implements Hookable, Registrable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		$fields = GF_Fields::get_all();
 
 		foreach ( $fields as $field ) {
@@ -62,5 +62,4 @@ class FormFields implements Hookable, Registrable {
 			}
 		}
 	}
-
 }

--- a/src/Type/WPObject/Order/OrderItem.php
+++ b/src/Type/WPObject/Order/OrderItem.php
@@ -28,14 +28,14 @@ class OrderItem extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The entry order item.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'section'            => [
 				'type'        => 'String',
@@ -53,32 +53,32 @@ class OrderItem extends AbstractObject {
 			'isDiscount'         => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a discount item', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source)  => ! empty( $source['is_discount'] ),
+				'resolve'     => static fn ( $source) => ! empty( $source['is_discount'] ),
 			],
 			'isLineItem'         => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a line item', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source )  => ! empty( $source['is_line_item'] ),
+				'resolve'     => static fn ( $source ) => ! empty( $source['is_line_item'] ),
 			],
 			'isRecurring'        => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a recurring item', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source )  => ! empty( $source['is_recurring'] ),
+				'resolve'     => static fn ( $source ) => ! empty( $source['is_recurring'] ),
 			],
 			'isSetupFee'         => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a setup fee', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source )  => ! empty( $source['is_setup'] ),
+				'resolve'     => static fn ( $source ) => ! empty( $source['is_setup'] ),
 			],
 			'isShipping'         => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a shipping fee', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source )  => ! empty( $source['is_shipping'] ),
+				'resolve'     => static fn ( $source ) => ! empty( $source['is_shipping'] ),
 			],
 			'isTrial'            => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether this is a trial item', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn ( $source )  => ! empty( $source['is_trial'] ),
+				'resolve'     => static fn ( $source ) => ! empty( $source['is_trial'] ),
 			],
 			'name'               => [
 				'type'        => 'String',

--- a/src/Type/WPObject/Order/OrderItemOption.php
+++ b/src/Type/WPObject/Order/OrderItemOption.php
@@ -27,14 +27,14 @@ class OrderItemOption extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'An option on an Order item.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'connectedFormField' => [
 				'type'        => FormField::$type,

--- a/src/Type/WPObject/Order/OrderSummary.php
+++ b/src/Type/WPObject/Order/OrderSummary.php
@@ -27,14 +27,14 @@ class OrderSummary extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The entry order information.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'currency' => [
 				'type'        => CurrencyEnum::$type,

--- a/src/Type/WPObject/Order/OrderSummary.php
+++ b/src/Type/WPObject/Order/OrderSummary.php
@@ -10,7 +10,6 @@
 
 namespace WPGraphQL\GF\Type\WPObject\Order;
 
-use WPGraphQL\AppContext;
 use WPGraphQL\GF\Type\Enum\CurrencyEnum;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
 

--- a/src/Type/WPObject/Settings/Logger.php
+++ b/src/Type/WPObject/Settings/Logger.php
@@ -24,14 +24,14 @@ class Logger extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms Logging Settings.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isEnabled' => [
 				'type'        => 'Boolean',

--- a/src/Type/WPObject/Settings/Settings.php
+++ b/src/Type/WPObject/Settings/Settings.php
@@ -34,52 +34,53 @@ class Settings extends AbstractObject implements Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register() : void {
+	public static function register(): void {
 		parent::register();
+
 		self::register_field();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms Settings.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'currency'                => [
 				'type'        => CurrencyEnum::$type,
 				'description' => __( 'The default currency for your forms. Used for product, credit card, and other fields.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : string => GFCommon::get_currency(),
+				'resolve'     => static fn (): string => GFCommon::get_currency(),
 			],
 			'hasDefaultCss'           => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to output Gravity Forms\' default CSS.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => ! (bool) get_option( 'rg_gforms_disable_css' ),
+				'resolve'     => static fn (): bool => ! (bool) get_option( 'rg_gforms_disable_css' ),
 			],
 			'hasBackgroundUpdates'    => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether Gravity Forms to download and install bug fixes and security updates automatically in the background. Requires a valid license key.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => (bool) get_option( 'gform_enable_background_updates' ),
+				'resolve'     => static fn (): bool => (bool) get_option( 'gform_enable_background_updates' ),
 			],
 			'hasToolbar'              => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to display the forms menu in the WordPress top toolbar. The forms menu will display the ten forms recently opened in the form editor.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => (bool) get_option( 'gform_enable_toolbar_menu' ),
+				'resolve'     => static fn (): bool => (bool) get_option( 'gform_enable_toolbar_menu' ),
 			],
 			'isHtml5Enabled'          => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether the server-generated form markup uses HTML5.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => (bool) get_option( 'rg_gforms_enable_html5', false ),
+				'resolve'     => static fn (): bool => (bool) get_option( 'rg_gforms_enable_html5', false ),
 			],
 			'isNoConflictModeEnabled' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Enable to prevent extraneous scripts and styles from being printed on a Gravity Forms admin pages, reducing conflicts with other plugins and themes.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => (bool) get_option( 'gform_enable_noconflict' ),
+				'resolve'     => static fn (): bool => (bool) get_option( 'gform_enable_noconflict' ),
 			],
 			'logging'                 => [
 				'type'        => SettingsLogging::$type,
@@ -97,7 +98,7 @@ class Settings extends AbstractObject implements Field {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_field() : void {
+	public static function register_field(): void {
 		register_graphql_field(
 			'RootQuery',
 			self::$field_name,

--- a/src/Type/WPObject/Settings/SettingsLogging.php
+++ b/src/Type/WPObject/Settings/SettingsLogging.php
@@ -25,19 +25,19 @@ class SettingsLogging extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms Logging Settings.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'isLoggingEnabled' => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether Gravity Forms internal logging is enabled. Logging allows you to easily debug the inner workings of Gravity Forms to solve any possible issues.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : bool => (bool) get_option( 'gform_enable_logging' ),
+				'resolve'     => static fn (): bool => (bool) get_option( 'gform_enable_logging' ),
 			],
 			'loggers'          => [
 				'type'        => [ 'list_of' => Logger::$type ],

--- a/src/Type/WPObject/Settings/SettingsRecaptcha.php
+++ b/src/Type/WPObject/Settings/SettingsRecaptcha.php
@@ -25,24 +25,24 @@ class SettingsRecaptcha extends AbstractObject {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'Gravity Forms reCAPTCHA Settings.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'publicKey' => [
 				'type'        => 'String',
 				'description' => __( 'The public reCAPTCHA site key.', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : ?string => get_option( 'rg_gforms_captcha_public_key', null ),
+				'resolve'     => static fn (): ?string => get_option( 'rg_gforms_captcha_public_key', null ),
 			],
 			'type'      => [
 				'type'        => RecaptchaTypeEnum::$type,
 				'description' => __( 'The type of of reCAPTCHA v2 to be used', 'wp-graphql-gravity-forms' ),
-				'resolve'     => static fn () : string => get_option( 'rg_gforms_captcha_type', 'checkbox' ),
+				'resolve'     => static fn (): string => get_option( 'rg_gforms_captcha_type', 'checkbox' ),
 			],
 		];
 	}

--- a/src/Type/WPObject/SubmissionConfirmation.php
+++ b/src/Type/WPObject/SubmissionConfirmation.php
@@ -14,8 +14,8 @@ use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\GF\Interfaces\TypeWithConnections;
-use WPGraphQL\GF\Type\WPObject\AbstractObject;
 use WPGraphQL\GF\Type\Enum\SubmissionConfirmationTypeEnum;
+use WPGraphQL\GF\Type\WPObject\AbstractObject;
 
 /**
  * Class - Submission Confirmation
@@ -42,7 +42,7 @@ class SubmissionConfirmation extends AbstractObject implements TypeWithConnectio
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_connections() : array {
+	public static function get_connections(): array {
 		return [
 			'page' => [
 				'toType'   => 'Page',
@@ -63,14 +63,14 @@ class SubmissionConfirmation extends AbstractObject implements TypeWithConnectio
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_description() : string {
+	public static function get_description(): string {
 		return __( 'The Confirmation object returned on submission. Null if the submission was not successful.', 'wp-graphql-gravity-forms' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function get_fields() : array {
+	public static function get_fields(): array {
 		return [
 			'message'     => [
 				'type'        => 'String',

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -18,7 +18,7 @@ class UpdateChecker implements Hookable {
 	/**
 	 * Registers hooks to WordPress.
 	 */
-	public static function register_hooks() : void {
+	public static function register_hooks(): void {
 		add_filter( 'auto_update_plugin', [ self::class, 'disable_autoupdates' ], 10, 2 );
 		add_action( 'admin_init', [ self::class, 'check_updates' ] );
 		add_action( 'in_plugin_update_message-wp-graphql-gravity-forms/wp-graphql-gravity-forms.php', [ self::class, 'in_plugin_update_message' ], 10, 2 );
@@ -27,7 +27,7 @@ class UpdateChecker implements Hookable {
 	/**
 	 * Checks github for latest release.
 	 */
-	public static function check_updates() : void {
+	public static function check_updates(): void {
 		/**
 		 * Filters the repo url used in the update checker.
 		 *
@@ -73,7 +73,7 @@ class UpdateChecker implements Hookable {
 	 * @param array  $plugin_data .
 	 * @param object $response .
 	 */
-	public static function in_plugin_update_message( array $plugin_data, $response ) : void {
+	public static function in_plugin_update_message( array $plugin_data, $response ): void {
 		if ( empty( $response->new_version ) ) {
 			return;
 		}

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -9,7 +9,6 @@
 namespace WPGraphQL\GF;
 
 use Puc_v4_Factory;
-use Puc_v4p13_Vcs_PluginUpdateChecker;
 use WPGraphQL\GF\Interfaces\Hookable;
 
 /**
@@ -20,9 +19,9 @@ class UpdateChecker implements Hookable {
 	 * Registers hooks to WordPress.
 	 */
 	public static function register_hooks() : void {
-		add_filter( 'auto_update_plugin', [ __CLASS__, 'disable_autoupdates' ], 10, 2 );
-		add_action( 'admin_init', [ __CLASS__, 'check_updates' ] );
-		add_action( 'in_plugin_update_message-wp-graphql-gravity-forms/wp-graphql-gravity-forms.php', [ __CLASS__, 'in_plugin_update_message' ], 10, 2 );
+		add_filter( 'auto_update_plugin', [ self::class, 'disable_autoupdates' ], 10, 2 );
+		add_action( 'admin_init', [ self::class, 'check_updates' ] );
+		add_action( 'in_plugin_update_message-wp-graphql-gravity-forms/wp-graphql-gravity-forms.php', [ self::class, 'in_plugin_update_message' ], 10, 2 );
 	}
 
 	/**
@@ -40,7 +39,7 @@ class UpdateChecker implements Hookable {
 		 */
 		$repo_link = apply_filters( 'graphql_gf_update_repo_url', 'https://github.com/harness-software/wp-graphql-gravity-forms/' );
 
-		/** @var Puc_v4p13_Vcs_PluginUpdateChecker */
+		/** @var \Puc_v4p13_Vcs_PluginUpdateChecker */
 		$update_checker = Puc_v4_Factory::buildUpdateChecker(
 			trailingslashit( $repo_link ),
 			WPGRAPHQL_GF_PLUGIN_FILE,

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -281,7 +281,7 @@ class GFUtils {
 		 */
 		return esc_url(
 			apply_filters(
-				'gform_save_and_continue_resume_url',
+				'gform_save_and_continue_resume_url', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 				add_query_arg( [ 'gf_token' => $resume_token ], $source_url ),
 				$form,
 				$resume_token,

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -106,7 +106,7 @@ class GFUtils {
 	 * @param array $form .
 	 */
 	public static function get_last_form_page( array $form ): int {
-		require_once GFCommon::get_base_path() . '/form_display.php';
+		require_once GFCommon::get_base_path() . '/form_display.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 
 		return GFFormDisplay::get_max_page_number( $form );
 	}
@@ -466,7 +466,7 @@ class GFUtils {
 		$new_file = $target['path'] . sprintf( '/%s', $filename );
 
 		// Use copy and unlink because rename breaks streams.
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- duplicating default WP Core functionality.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Generic.PHP.NoSilencedErrors.Forbidden -- duplicating default WP Core functionality.
 		$move_new_file = @copy( $file['tmp_name'], $new_file );
 		unlink( $file['tmp_name'] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -40,7 +40,7 @@ class GFUtils {
 	 * @param integer $form_id .
 	 * @param bool    $active_only Whether to only return the form if it is active.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_form( int $form_id, bool $active_only = true ) : array {
 		$form = GFAPI::get_form( $form_id );
@@ -132,7 +132,7 @@ class GFUtils {
 	 * @param array $form     The form.
 	 * @param int   $field_id Field ID.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_field_by_id( array $form, int $field_id ) : GF_Field {
 		$matching_fields = array_values(
@@ -163,7 +163,7 @@ class GFUtils {
 	 *
 	 * @param integer $entry_id .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_entry( int $entry_id ) : array {
 		$entry = GFAPI::get_entry( $entry_id );
@@ -188,7 +188,7 @@ class GFUtils {
 	 * @param array $entry_data .
 	 * @param int   $entry_id .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function update_entry( array $entry_data, int $entry_id = null ) : int {
 		$entry_id = $entry_id ?? $entry_data['id'];
@@ -212,7 +212,7 @@ class GFUtils {
 	 *
 	 * @param string $resume_token .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_draft_entry( string $resume_token ) : array {
 		$draft_entry = GFFormsModel::get_draft_submission_values( $resume_token );
@@ -234,7 +234,7 @@ class GFUtils {
 	 *
 	 * @param string $resume_token Draft entry resume token.
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_draft_submission( string $resume_token ) : array {
 		$draft_entry = self::get_draft_entry( $resume_token );
@@ -304,7 +304,7 @@ class GFUtils {
 	 * @param string  $source_url .
 	 * @param string  $resume_token .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function save_draft_submission( array $form, array $entry, array $field_values = null, int $page_number = 1, array $files = [], string $form_unique_id = null, string $ip = '', string $source_url = '', string $resume_token = '' ) : string {
 		if ( empty( $form ) || empty( $entry ) ) {
@@ -345,7 +345,7 @@ class GFUtils {
 	 * @param integer $target_page .
 	 * @param integer $source_page .
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function submit_form( int $form_id, array $input_values, array $field_values = [], int $target_page = 0, int $source_page = 0 ) : array {
 		$submission = GFAPI::submit_form(
@@ -373,7 +373,7 @@ class GFUtils {
 	 * @param int $form_id GF form ID.
 	 *
 	 * @return array     GF uploads dir config.
-	 * @throws UserError If directory doesn't exist or cant be created.
+	 * @throws \GraphQL\Error\UserError If directory doesn't exist or cant be created.
 	 */
 	public static function get_gravity_forms_upload_dir( int $form_id ) : array {
 		// Determine YYYY/MM values.
@@ -444,7 +444,7 @@ class GFUtils {
 	 *
 	 * @deprecated 0.11.0
 	 *
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function handle_file_upload( $file, $target ) {
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'GFUtils::handle_file_upload() is deprecated. Please use native WP/GF methods instead.', 'wp-graphql-gravity-forms' ), '0.11.0' );

--- a/src/Utils/GFUtils.php
+++ b/src/Utils/GFUtils.php
@@ -10,11 +10,11 @@
 
 namespace WPGraphQL\GF\Utils;
 
-use GF_Field;
 use GFAPI;
 use GFCommon;
 use GFFormDisplay;
 use GFFormsModel;
+use GF_Field;
 use GraphQL\Error\UserError;
 
 /**
@@ -27,7 +27,7 @@ class GFUtils {
 	 *
 	 * @param string $ip .
 	 */
-	public static function get_ip( string $ip ) : string {
+	public static function get_ip( string $ip ): string {
 		return empty( $ip ) ? GFFormsModel::get_ip() : sanitize_text_field( $ip );
 	}
 
@@ -42,7 +42,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_form( int $form_id, bool $active_only = true ) : array {
+	public static function get_form( int $form_id, bool $active_only = true ): array {
 		$form = GFAPI::get_form( $form_id );
 
 		if ( ! $form ) {
@@ -84,7 +84,7 @@ class GFUtils {
 	 *
 	 * @return array The array of Form Objects.
 	 */
-	public static function get_forms( array $ids = [], bool $active = true, bool $trash = false, string $sort_column = 'id', string $sort_dir = 'DESC' ) : array {
+	public static function get_forms( array $ids = [], bool $active = true, bool $trash = false, string $sort_column = 'id', string $sort_dir = 'DESC' ): array {
 		$form_ids = ! empty( $ids ) ? $ids : GFFormsModel::get_form_ids( $active, $trash, $sort_column, $sort_dir );
 
 		if ( empty( $form_ids ) ) {
@@ -105,7 +105,7 @@ class GFUtils {
 	 *
 	 * @param array $form .
 	 */
-	public static function get_last_form_page( array $form ) : int {
+	public static function get_last_form_page( array $form ): int {
 		require_once GFCommon::get_base_path() . '/form_display.php';
 
 		return GFFormDisplay::get_max_page_number( $form );
@@ -118,7 +118,7 @@ class GFUtils {
 	 *
 	 * @return string Unique ID.
 	 */
-	public static function get_form_unique_id( int $form_id ) : string {
+	public static function get_form_unique_id( int $form_id ): string {
 		if ( ! isset( GFFormsModel::$unique_ids[ $form_id ] ) ) {
 			GFFormsModel::$unique_ids[ $form_id ] = uniqid();
 		}
@@ -134,11 +134,11 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_field_by_id( array $form, int $field_id ) : GF_Field {
+	public static function get_field_by_id( array $form, int $field_id ): GF_Field {
 		$matching_fields = array_values(
 			array_filter(
 				$form['fields'],
-				static function ( GF_Field $field ) use ( $field_id ) : bool {
+				static function ( GF_Field $field ) use ( $field_id ): bool {
 					return $field['id'] === $field_id;
 				}
 			)
@@ -154,7 +154,6 @@ class GFUtils {
 		return $matching_fields[0];
 	}
 
-
 	/**
 	 * Gets the Gravity Form entry object for the given form ID.
 	 * Uses GFAPI::get_entry().
@@ -165,7 +164,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_entry( int $entry_id ) : array {
+	public static function get_entry( int $entry_id ): array {
 		$entry = GFAPI::get_entry( $entry_id );
 
 		if ( is_wp_error( $entry ) ) {
@@ -178,7 +177,6 @@ class GFUtils {
 		return $entry;
 	}
 
-
 	/**
 	 * Updates the existing Gravity Form entry.
 	 * Uses GFAPI::update_entry().
@@ -190,7 +188,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function update_entry( array $entry_data, int $entry_id = null ) : int {
+	public static function update_entry( array $entry_data, int $entry_id = null ): int {
 		$entry_id = $entry_id ?? $entry_data['id'];
 
 		$is_entry_updated = GFAPI::update_entry( $entry_data, $entry_id );
@@ -205,7 +203,6 @@ class GFUtils {
 		return $entry_id;
 	}
 
-
 	/**
 	 * Returns draft entry array from a given resume token.
 	 * Uses GFFormsModel::get_draft_submission_values().
@@ -214,7 +211,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_draft_entry( string $resume_token ) : array {
+	public static function get_draft_entry( string $resume_token ): array {
 		$draft_entry = GFFormsModel::get_draft_submission_values( $resume_token );
 
 		if ( ! is_array( $draft_entry ) || empty( $draft_entry ) ) {
@@ -227,8 +224,6 @@ class GFUtils {
 		return $draft_entry;
 	}
 
-
-
 	/**
 	 * Returns draft entry submittion data.
 	 *
@@ -236,7 +231,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_draft_submission( string $resume_token ) : array {
+	public static function get_draft_submission( string $resume_token ): array {
 		$draft_entry = self::get_draft_entry( $resume_token );
 
 		$submission = json_decode( $draft_entry['submission'], true );
@@ -254,8 +249,6 @@ class GFUtils {
 		return $submission;
 	}
 
-
-
 	/**
 	 * Get the draft resume URL.
 	 *
@@ -265,7 +258,7 @@ class GFUtils {
 	 *
 	 * @return string Resume URL, or empty string if no source URL was provided.
 	 */
-	public static function get_resume_url( string $resume_token, string $source_url = '', $form = [] ) : string {
+	public static function get_resume_url( string $resume_token, string $source_url = '', $form = [] ): string {
 		if ( empty( $source_url ) ) {
 			$source_url = GFFormsModel::get_current_page_url();
 		}
@@ -306,7 +299,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function save_draft_submission( array $form, array $entry, array $field_values = null, int $page_number = 1, array $files = [], string $form_unique_id = null, string $ip = '', string $source_url = '', string $resume_token = '' ) : string {
+	public static function save_draft_submission( array $form, array $entry, array $field_values = null, int $page_number = 1, array $files = [], string $form_unique_id = null, string $ip = '', string $source_url = '', string $resume_token = '' ): string {
 		if ( empty( $form ) || empty( $entry ) ) {
 			throw new UserError( __( 'An error occured while trying to save the draft entry. Form or Entry not set.', 'wp-graphql-gravity-forms' ) );
 		}
@@ -332,7 +325,6 @@ class GFUtils {
 		return $new_resume_token ? (string) $new_resume_token : $resume_token;
 	}
 
-
 	/**
 	 * Submits a Gravity Forms form.
 	 * Uses GFAPI::submit_form().
@@ -347,7 +339,7 @@ class GFUtils {
 	 *
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function submit_form( int $form_id, array $input_values, array $field_values = [], int $target_page = 0, int $source_page = 0 ) : array {
+	public static function submit_form( int $form_id, array $input_values, array $field_values = [], int $target_page = 0, int $source_page = 0 ): array {
 		$submission = GFAPI::submit_form(
 			$form_id,
 			$input_values,
@@ -375,7 +367,7 @@ class GFUtils {
 	 * @return array     GF uploads dir config.
 	 * @throws \GraphQL\Error\UserError If directory doesn't exist or cant be created.
 	 */
-	public static function get_gravity_forms_upload_dir( int $form_id ) : array {
+	public static function get_gravity_forms_upload_dir( int $form_id ): array {
 		// Determine YYYY/MM values.
 		$time     = current_time( 'mysql' );
 		$y        = substr( $time, 0, 4 );

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -23,7 +23,6 @@ use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
  * Class - Utils
  */
 class Utils {
-
 	/**
 	 * Adds deprecation reason to GraphQL field property.
 	 *
@@ -32,7 +31,7 @@ class Utils {
 	 *
 	 * @since 0.2.0
 	 */
-	public static function deprecate_property( array $property, string $reason ) : array {
+	public static function deprecate_property( array $property, string $reason ): array {
 		$property_key = array_key_first( $property );
 
 		// Add deprecation reason to property.
@@ -50,7 +49,7 @@ class Utils {
 	 *
 	 * @param string $string the original string.
 	 */
-	public static function to_snake_case( $string ) : string {
+	public static function to_snake_case( $string ): string {
 		return strtolower( (string) preg_replace( [ '/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/' ], '$1_$2', $string ) );
 	}
 
@@ -61,7 +60,7 @@ class Utils {
 	 *
 	 * @param string $string the original string.
 	 */
-	public static function get_safe_form_field_type_name( $string ) : string {
+	public static function get_safe_form_field_type_name( $string ): string {
 		// Shim to map fields with existing PascalCase.
 		$fields_to_map = [
 			'chainedselect'     => 'ChainedSelect',
@@ -93,7 +92,7 @@ class Utils {
 	 *
 	 * @return string The string, possibly truncated.
 	 */
-	public static function truncate( string $str, int $length ) : string {
+	public static function truncate( string $str, int $length ): string {
 		if ( strlen( $str ) > $length ) {
 			$str = substr( $str, 0, $length );
 		}
@@ -132,7 +131,7 @@ class Utils {
 	/**
 	 * Returns whether WPGraphQL Upload is enabled.
 	 */
-	public static function is_graphql_upload_enabled() : bool {
+	public static function is_graphql_upload_enabled(): bool {
 		return class_exists( 'WPGraphQL\Upload\Type\Upload' );
 	}
 
@@ -141,7 +140,7 @@ class Utils {
 	 *
 	 * E.g. `[ 'text' => 'TextField' ]`.
 	 */
-	public static function get_registered_form_field_types() : array {
+	public static function get_registered_form_field_types(): array {
 		$types = [];
 
 		$fields = GF_Fields::get_all();
@@ -159,7 +158,7 @@ class Utils {
 	 *
 	 * E.g. `[ 'draft_entry' => 'GfDraftEntry' ]`
 	 */
-	public static function get_registered_entry_types() : array {
+	public static function get_registered_entry_types(): array {
 		$types = [
 			EntriesLoader::$name      => SubmittedEntry::$type,
 			DraftEntriesLoader::$name => DraftEntry::$type,
@@ -178,7 +177,7 @@ class Utils {
 	 *
 	 * @param string $type The current GF field type.
 	 */
-	public static function get_possible_form_field_child_types( string $type ) : array {
+	public static function get_possible_form_field_child_types( string $type ): array {
 		$prefix = self::get_safe_form_field_type_name( $type );
 
 		switch ( $type ) {
@@ -273,7 +272,7 @@ class Utils {
 	/**
 	 * Gets a filterable list of Gravity Forms field types that should be disabled for this instance.
 	 */
-	public static function get_ignored_gf_field_types() : array {
+	public static function get_ignored_gf_field_types(): array {
 		$ignored_fields = [
 			'donation', // These fields are no longer supported by GF.
 			'repeater', // This still in beta.
@@ -300,7 +299,7 @@ class Utils {
 	/**
 	 * Returns an array of Gravity Forms field settings to ignore.
 	 */
-	public static function get_ignored_gf_settings() : array {
+	public static function get_ignored_gf_settings(): array {
 		return [
 			'default_input_values_setting',
 			'input_placeholders_setting',
@@ -328,7 +327,7 @@ class Utils {
 	 * @param int|string $id .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_entry_id_from_id( $id ) : int {
+	public static function get_entry_id_from_id( $id ): int {
 		return self::get_database_id_from_id( $id, EntriesLoader::$name );
 	}
 
@@ -340,7 +339,7 @@ class Utils {
 	 * @param int|string $id .
 	 * @throws \GraphQL\Error\UserError .
 	 */
-	public static function get_form_id_from_id( $id ) : int {
+	public static function get_form_id_from_id( $id ): int {
 		return self::get_database_id_from_id( $id, FormsLoader::$name );
 	}
 
@@ -354,7 +353,7 @@ class Utils {
 	 *
 	 * @throws \GraphQL\Error\UserError If the ID is not a valid Global ID.
 	 */
-	protected static function get_database_id_from_id( $id, $type ) : int {
+	protected static function get_database_id_from_id( $id, $type ): int {
 		// If we already have the database ID, send it back as an integer.
 		if ( is_numeric( $id ) ) {
 			return absint( $id );

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -18,7 +18,6 @@ use WPGraphQL\GF\Data\Loader\EntriesLoader;
 use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Type\WPObject\Entry\DraftEntry;
 use WPGraphQL\GF\Type\WPObject\Entry\SubmittedEntry;
-use WPGraphQL\Type\ObjectType\User;
 
 /**
  * Class - Utils
@@ -327,7 +326,7 @@ class Utils {
 	 * @since @todo
 	 *
 	 * @param int|string $id .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_entry_id_from_id( $id ) : int {
 		return self::get_database_id_from_id( $id, EntriesLoader::$name );
@@ -339,7 +338,7 @@ class Utils {
 	 * @since @todo
 	 *
 	 * @param int|string $id .
-	 * @throws UserError .
+	 * @throws \GraphQL\Error\UserError .
 	 */
 	public static function get_form_id_from_id( $id ) : int {
 		return self::get_database_id_from_id( $id, FormsLoader::$name );
@@ -353,7 +352,7 @@ class Utils {
 	 * @param int|string $id The provided ID.
 	 * @param string     $type The expected dataloader type.
 	 *
-	 * @throws UserError If the ID is not a valid Global ID.
+	 * @throws \GraphQL\Error\UserError If the ID is not a valid Global ID.
 	 */
 	protected static function get_database_id_from_id( $id, $type ) : int {
 		// If we already have the database ID, send it back as an integer.

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'harness-software/wp-graphql-gravity-forms',
-        'pretty_version' => 'dev-main',
-        'version' => 'dev-main',
-        'reference' => '142fac8e02f97a82609a97ce8eb824e5cc7f8557',
+        'pretty_version' => 'dev-develop',
+        'version' => 'dev-develop',
+        'reference' => '3eea1485efe991d7ef113b92117b131406f7a9e9',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'harness-software/wp-graphql-gravity-forms' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => '142fac8e02f97a82609a97ce8eb824e5cc7f8557',
+            'pretty_version' => 'dev-develop',
+            'version' => 'dev-develop',
+            'reference' => '3eea1485efe991d7ef113b92117b131406f7a9e9',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Updates the PHPCS ruleset to use [`axepress/wp-graphql-cs`](https://github.com/axewp/WPGraphQL-Coding-Standards) and fixes associated sniffs.

Sniffs from the WPGraphQL-Extra ruleset regarding generic array types are currently excluded for a future PR.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
https://github.com/AxeWP/WPGraphQL-Coding-Standards#why-use-these-standards

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
