### PR TITLE
chore: cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"phpstan/extension-installer": "^1.1",
 		"szepeviktor/phpstan-wordpress": "^1.0",
 		"axepress/wp-graphql-stubs": "^1.11.1",
-		"axepress/wp-graphql-cs": "dev-develop",
+		"axepress/wp-graphql-cs": "^1.0.0-beta",
 		"wp-cli/wp-cli-bundle": "^2.8.1",
 		"php-coveralls/php-coveralls": "^2.5"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bdccf5a99014b96b2567f69e558d9b8",
+    "content-hash": "1dbd8da85ae4ba5eadefd96015f946e1",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -160,7 +160,7 @@
         },
         {
             "name": "axepress/wp-graphql-cs",
-            "version": "dev-develop",
+            "version": "1.0.0-beta.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/WPGraphQL-Coding-Standards.git",
@@ -1105,16 +1105,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "74780ccf8c19d6acb8d65c5f39cd72110e132bbd"
+                "reference": "90d087e988ff194065333d16bc5cf649872d9cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/74780ccf8c19d6acb8d65c5f39cd72110e132bbd",
-                "reference": "74780ccf8c19d6acb8d65c5f39cd72110e132bbd",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/90d087e988ff194065333d16bc5cf649872d9cdb",
+                "reference": "90d087e988ff194065333d16bc5cf649872d9cdb",
                 "shasum": ""
             },
             "require": {
@@ -1161,7 +1161,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.5"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.6"
             },
             "funding": [
                 {
@@ -1177,7 +1177,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T08:27:00+00:00"
+            "time": "2023-06-06T12:02:59+00:00"
         },
         {
             "name": "composer/composer",
@@ -10565,7 +10565,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "axepress/wp-graphql-cs": 20
+        "axepress/wp-graphql-cs": 10
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Type/WPInterface/Entry.php
+++ b/src/Type/WPInterface/Entry.php
@@ -17,6 +17,7 @@ use WPGraphQL\GF\Connection\FormFieldsConnection;
 use WPGraphQL\GF\Data\Connection\FormFieldsConnectionResolver;
 use WPGraphQL\GF\Data\Loader\DraftEntriesLoader;
 use WPGraphQL\GF\Data\Loader\EntriesLoader;
+use WPGraphQL\GF\Data\Loader\FormsLoader;
 use WPGraphQL\GF\Interfaces\Field;
 use WPGraphQL\GF\Interfaces\TypeWithConnections;
 use WPGraphQL\GF\Interfaces\TypeWithInterfaces;
@@ -84,8 +85,15 @@ class Entry extends AbstractInterface implements TypeWithConnections, TypeWithIn
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
 					$context->gfEntry = $source;
 
+					// If the form isn't stored in the context, we need to fetch it.
 					if ( empty( $context->gfForm ) ) {
-						$context->gfForm = new Form( GFUtils::get_form( $source->formDatabaseId, false ) );
+						$form = GFUtils::get_form( $source->formDatabaseId, false );
+
+						// Cache the form for later use.
+						$context->get_loader( FormsLoader::$name )->prime( $form['id'], $form );
+
+						// Store it in the context for easy access.
+						$context->gfForm = new Form( $form );
 					}
 
 					if ( empty( $context->gfForm->formFields ) ) {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'harness-software/wp-graphql-gravity-forms',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '3eea1485efe991d7ef113b92117b131406f7a9e9',
+        'reference' => 'fae94d402f424d14d5d9e2d93dce0f6303e24844',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'harness-software/wp-graphql-gravity-forms' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '3eea1485efe991d7ef113b92117b131406f7a9e9',
+            'reference' => 'fae94d402f424d14d5d9e2d93dce0f6303e24844',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This pr switches `axpress/wp-graphql-cs` from the `dev-develop` branch back to the `1.0.0-beta` release.
It also primes the `FormsLoader` when forms are fetched in the `FormFieldsConnectionResolver`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
These were unintentionally omitted from #369 and #368, respectively.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
