### PR TITLE
dev: add compat for GF2.9.x + WPGraphQL 2.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- perf: Add support for AppContext::get() and ::set() in WPGraphQL v2.3.8+.
+- feat: Refactor File Upload handling for Gravity Forms 2.8.6+ compatibility.
+- ci: Test compatibility against WPGraphQL v2.6.0 and WordPress 6.8.3.
 - perf: migrate DataLoader registration to use lazy-loaded `graphql_data_loader_classes` filter. H/t @bpkennedy
 - fix: cleanup activation lifecycle.
 - fix: Prevent duplicate file counts for Single File Upload fields. Props @Gytjarek

--- a/docs/recipes/register-custom-form-field.md
+++ b/docs/recipes/register-custom-form-field.md
@@ -37,17 +37,18 @@ register_graphql_field(
   [
     'type' => 'MyCustomFormFieldValueObject',
     'description' => static fn () => __( 'The Field Value object for my custom GF field.', 'my-plugin'),
-    'resolve' => function( $source ){
+    'resolve' => function( $source, array $args, AppContext $context ) {
       /**
        * Usually, the entry is saved in the formField's context/
        * If you are fetching this field in a custom setup, you may need to use GFAPI::get_entry().
        */
-      if( ! isset( $context->gfEntry->entry ) ){
+      $gf_entry = $context->get( 'gf', 'gfEntry' );
+      if( ! isset( $gf_entry, $gf_entry->entry ) ){
         return null;
       }
 
       // Grab the field value from the entry, null if it isnt set.
-      $value = $context->gfEntry->entry[ $source->id ] ?? null;
+      $value = $gf_entry->entry[ $source->id ] ?? null;
 
       // This will be resolved by `MyCustomFieldFieldValueObject`.
       return process_my_custom_field_value($value);

--- a/src/Connection/FormFieldsConnection.php
+++ b/src/Connection/FormFieldsConnection.php
@@ -43,7 +43,8 @@ class FormFieldsConnection extends AbstractConnection {
 						}
 
 						// If the form isn't stored in the context, we need to fetch it.
-						if ( empty( $context->gfForm ) && ! empty( $source['form_id'] ) ) {
+						$form = Compat::get_app_context( $context, 'gfForm' );
+						if ( empty( $form ) && ! empty( $source['form_id'] ) ) {
 							/** @var \WPGraphQL\GF\Model\Form $form */
 							$form = $context->get_loader( FormsLoader::$name )->load( (int) $source['form_id'] );
 
@@ -52,17 +53,17 @@ class FormFieldsConnection extends AbstractConnection {
 							}
 
 							// Store it in the context for easy access.
-							$context->gfForm = $form;
+							Compat::set_app_context( $context, 'gfForm', $form );
 						}
 
-						if ( empty( $context->gfForm->formFields ) ) {
+						if ( empty( $form->formFields ) ) {
 							return null;
 						}
 
 						// Set the Args for the connection resolver.
 						$args['where']['pageNumber'] = $source['targetPageNumber'];
 
-						return Factory::resolve_form_fields_connection( $context->gfForm, $args, $context, $info );
+						return Factory::resolve_form_fields_connection( $form, $args, $context, $info );
 					},
 				]
 			)

--- a/src/Data/Connection/FormFieldsConnectionResolver.php
+++ b/src/Data/Connection/FormFieldsConnectionResolver.php
@@ -18,6 +18,7 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
 use WPGraphQL\GF\Model\Form;
 use WPGraphQL\GF\Model\FormField;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - FormFieldsConnectionResolver
@@ -45,11 +46,12 @@ class FormFieldsConnectionResolver extends AbstractConnectionResolver {
 	 * @throws \Exception If the Form model is not set on the AppContext.
 	 */
 	public function __construct( $source, array $args, AppContext $context, ResolveInfo $info ) {
-		if ( ! isset( $context->gfForm ) ) {
+		$form = Compat::get_app_context( $context, 'gfForm' );
+		if ( ! isset( $form ) ) {
 			throw new \Exception( 'The FormFieldsConnectionResolver requires a Form to be set on the AppContext.' );
 		}
 
-		$this->form        = $context->gfForm;
+		$this->form        = $form;
 		$this->form_fields = ! empty( $source->formFields ) ? $source->formFields : [];
 
 		parent::__construct( $source, $args, $context, $info );

--- a/src/Data/FieldValueInput/FileUploadValuesInput.php
+++ b/src/Data/FieldValueInput/FileUploadValuesInput.php
@@ -39,7 +39,7 @@ class FileUploadValuesInput extends AbstractFieldValueInput {
 	 * @throws \GraphQL\Error\UserError
 	 */
 	protected function prepare_value() {
-		if ( $this->is_draft ) {
+		if ( $this->is_draft && 'post_image' !== $this->field->type ) {
 			return '';
 		}
 

--- a/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
+++ b/src/Extensions/GFChainedSelects/Type/WPObject/FormField/FieldValue/ValueProperty.php
@@ -13,6 +13,7 @@ namespace WPGraphQL\GF\Extensions\GFChainedSelects\Type\WPObject\FormField\Field
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Model\FormField;
 use WPGraphQL\GF\Type\WPObject\FormField\FieldValue\FieldValues;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - ValueProperty
@@ -29,13 +30,18 @@ class ValueProperty extends FieldValues {
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => static fn () => __( 'ChainedSelect field value.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ): ?array {
-					if ( ! $source instanceof FormField || ! isset( $context->gfEntry ) ) {
+					if ( ! $source instanceof FormField ) {
+						return null;
+					}
+
+					$gf_entry = Compat::get_app_context( $context, 'gfEntry' );
+					if ( ! $gf_entry ) {
 						return null;
 					}
 
 					return array_map(
-						static function ( $input ) use ( $context ) {
-							return $context->gfEntry->entry[ $input['id'] ] ?: null;
+						static function ( $input ) use ( $gf_entry ) {
+							return $gf_entry->entry[ $input['id'] ] ?: null;
 						},
 						$source->inputs
 					);

--- a/src/Extensions/GFQuiz/Type/WPInterface/FieldChoiceSetting/ChoiceWithQuizChoices.php
+++ b/src/Extensions/GFQuiz/Type/WPInterface/FieldChoiceSetting/ChoiceWithQuizChoices.php
@@ -12,6 +12,7 @@ namespace WPGraphQL\GF\Extensions\GFQuiz\Type\WPInterface\FieldChoiceSetting;
 
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Type\WPInterface\FieldChoiceSetting\AbstractFieldChoiceSetting;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - ChoiceWithQuizChoices
@@ -45,11 +46,12 @@ class ChoiceWithQuizChoices extends AbstractFieldChoiceSetting {
 				'type'        => 'Float',
 				'description' => static fn () => __( 'The weighted score awarded for the choice.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
-					if ( ! property_exists( $context, 'gfField' ) || ! $context->gfField instanceof \GF_Field ) {
+					$field = Compat::get_app_context( $context, 'gfField' );
+					if ( ! isset( $field ) ) {
 						return null;
 					}
 
-					if ( isset( $context->gfField->gquizWeightedScoreEnabled ) && false === $context->gfField->gquizWeightedScoreEnabled ) {
+					if ( isset( $field->gquizWeightedScoreEnabled ) && false === $field->gquizWeightedScoreEnabled ) {
 						return isset( $source['gquizIsCorrect'] ) ? (float) $source['gquizIsCorrect'] : 0;
 					}
 

--- a/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/Form/FormQuiz.php
@@ -141,11 +141,12 @@ class FormQuiz extends AbstractObject implements Field {
 				'type'        => 'Float',
 				'description' => static fn () => __( 'The maximum score for this form.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ): ?float {
-					if ( ! isset( $context->gfForm ) ) {
+					$form_model = Compat::get_app_context( $context, 'gfForm' );
+					if ( ! isset( $form_model ) ) {
 						return null;
 					}
 
-					return ( gf_quiz() )->get_max_score( $context->gfForm->form ) ?: null;
+					return ( gf_quiz() )->get_max_score( $form_model->form ) ?: null;
 				},
 			],
 			'passPercent'                    => [
@@ -189,7 +190,7 @@ class FormQuiz extends AbstractObject implements Field {
 					'description' => static fn () => __( 'Quiz-specific settings that will affect ALL Quiz fields in the form. Requires Gravity Forms Quiz addon.', 'wp-graphql-gravity-forms' ),
 					'resolve'     => static function ( $source, array $args, AppContext $context ): ?array {
 						// FYI: If a user doesn't explicitly save the quiz settings on the backend, this will be null.
-						$context->gfForm = $source;
+						Compat::set_app_context( $context, 'gfForm', $source );
 						return empty( $source->quiz ) ? null : $source->quiz;
 					},
 				]

--- a/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
+++ b/src/Extensions/GFQuiz/Type/WPObject/QuizResults/QuizResults.php
@@ -115,17 +115,17 @@ class QuizResults extends AbstractObject implements Field {
 					'type'        => static::$type,
 					'description' => static fn () => __( 'The quiz results for the given form.', 'wp-graphql-gravity-forms' ),
 					'resolve'     => static function ( $source, array $args, AppContext $context ) {
-						if ( ! isset( $context->gfForm ) ) {
+						$form_model = Compat::get_app_context( $context, 'gfForm' );
+						if ( ! isset( $form_model ) ) {
 							return null;
 						}
 
-						$form           = $context->gfForm->form;
 						$quiz           = GFQuiz::get_instance();
 						$results_config = $quiz->get_results_page_config();
 
-						$results = self::get_quiz_results_data( $form, $results_config );
+						$results = self::get_quiz_results_data( $form_model->form, $results_config );
 
-						return self::prepare_results_data( $results, $form );
+						return self::prepare_results_data( $results, $form_model->form );
 					},
 				]
 			)

--- a/src/Mutation/SubmitForm.php
+++ b/src/Mutation/SubmitForm.php
@@ -149,7 +149,7 @@ class SubmitForm extends AbstractMutation {
 
 			$field_values = self::prepare_field_values( $input['fieldValues'], $form, $save_as_draft );
 
-			$files        = EntryObjectMutation::initialize_files( $form['fields'], $input['fieldValues'], $save_as_draft );
+			$files        = EntryObjectMutation::initialize_files( $form['fields'], $input['fieldValues'], $save_as_draft, false );
 			$input_values = self::get_input_values( $save_as_draft, $field_values, $files );
 
 			$submission = GFUtils::submit_form(

--- a/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
+++ b/src/Type/WPInterface/FieldSetting/FieldWithProductField.php
@@ -12,6 +12,7 @@ namespace WPGraphQL\GF\Type\WPInterface\FieldSetting;
 
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - FieldWithProductField
@@ -45,11 +46,12 @@ class FieldWithProductField extends AbstractFieldSetting {
 				'type'        => 'ProductField',
 				'description' => static fn () => __( 'The product field to which the field is associated.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
-					if ( ! isset( $context->gfForm ) || empty( $source->productField ) ) {
+					$form_model = Compat::get_app_context( $context, 'gfForm' );
+					if ( ! isset( $form_model ) || empty( $source->productField ) ) {
 						return null;
 					}
 
-					$id_for_loader = FormFieldsLoader::prepare_loader_id( $context->gfForm->databaseId, (int) $source->productField );
+					$id_for_loader = FormFieldsLoader::prepare_loader_id( $form_model->databaseId, (int) $source->productField );
 
 					return $context->get_loader( FormFieldsLoader::$name )->load_deferred( $id_for_loader );
 				},

--- a/src/Type/WPInterface/FieldWithPersonalData.php
+++ b/src/Type/WPInterface/FieldWithPersonalData.php
@@ -12,6 +12,7 @@ namespace WPGraphQL\GF\Type\WPInterface;
 
 use WPGraphQL\AppContext;
 use WPGraphQL\GF\Type\WPObject\FormField\FormFieldDataPolicy;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - FieldWithPersonalData
@@ -40,13 +41,14 @@ class FieldWithPersonalData extends AbstractInterface {
 				'type'        => FormFieldDataPolicy::$type,
 				'description' => static fn () => __( 'The form field-specifc policies for exporting and erasing personal data.', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
-					if ( empty( $context->gfForm->personalData['dataPolicies']['identificationFieldDatabaseId'] ) ) {
+					$form_model = Compat::get_app_context( $context, 'gfForm' );
+					if ( empty( $form_model->personalData['dataPolicies']['identificationFieldDatabaseId'] ) ) {
 						return null;
 					}
 
 					return [
 						'id'                    => $source->databaseId ?? null,
-						'isIdentificationField' => isset( $context->gfForm->personalData['dataPolicies']['identificationFieldDatabaseId'] ) && $context->gfForm->personalData['dataPolicies']['identificationFieldDatabaseId'] === $source->databaseId,
+						'isIdentificationField' => isset( $form_model->personalData['dataPolicies']['identificationFieldDatabaseId'] ) && $form_model->personalData['dataPolicies']['identificationFieldDatabaseId'] === $source->databaseId,
 						'shouldErase'           => ! empty( $source->personalDataErase ),
 						'shouldExport'          => ! empty( $source->personalDataExport ),
 					];

--- a/src/Type/WPObject/Form/Form.php
+++ b/src/Type/WPObject/Form/Form.php
@@ -103,7 +103,7 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 				],
 				'description'      => static fn () => __( 'The entries submitted to the form.', 'wp-graphql-gravity-forms' ),
 				'resolve'          => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-					$context->gfForm = $source;
+					Compat::set_app_context( $context, 'gfForm', $source );
 
 					$args['where']['formIds'] = $source->databaseId;
 
@@ -115,7 +115,7 @@ class Form extends AbstractObject implements TypeWithConnections, TypeWithInterf
 				'description'    => static fn () => __( 'The form fields associated with the form.', 'wp-graphql-gravity-forms' ),
 				'connectionArgs' => FormFieldsConnection::get_filtered_connection_args(),
 				'resolve'        => static function ( $source, array $args, AppContext $context, ResolveInfo $info ) {
-					$context->gfForm = $source;
+					Compat::set_app_context( $context, 'gfForm', $source );
 
 					if ( empty( $source->formFields ) ) {
 						return null;

--- a/src/Type/WPObject/Order/OrderItem.php
+++ b/src/Type/WPObject/Order/OrderItem.php
@@ -15,6 +15,7 @@ use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
 use WPGraphQL\GF\Type\Enum\CurrencyEnum;
 use WPGraphQL\GF\Type\WPInterface\FormField;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - OrderItem
@@ -109,11 +110,12 @@ class OrderItem extends AbstractObject {
 				'type'        => FormField::$type,
 				'description' => static fn () => __( 'The form field that the order item is connected to', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
-					if ( ! isset( $context->gfForm ) || empty( $source['id'] ) ) {
+					$gf_form = Compat::get_app_context( $context, 'gfForm' );
+					if ( ! isset( $gf_form ) || empty( $source['id'] ) ) {
 						return null;
 					}
 
-					$id_for_loader = FormFieldsLoader::prepare_loader_id( $context->gfForm->databaseId, (int) $source['id'] );
+					$id_for_loader = FormFieldsLoader::prepare_loader_id( $gf_form->databaseId, (int) $source['id'] );
 
 					return $context->get_loader( FormFieldsLoader::$name )->load_deferred( $id_for_loader );
 				},

--- a/src/Type/WPObject/Order/OrderItemOption.php
+++ b/src/Type/WPObject/Order/OrderItemOption.php
@@ -14,6 +14,7 @@ use WPGraphQL\AppContext;
 use WPGraphQL\GF\Data\Loader\FormFieldsLoader;
 use WPGraphQL\GF\Type\WPInterface\FormField;
 use WPGraphQL\GF\Type\WPObject\AbstractObject;
+use WPGraphQL\GF\Utils\Compat;
 
 /**
  * Class - OrderItemOption
@@ -42,11 +43,12 @@ class OrderItemOption extends AbstractObject {
 				'type'        => FormField::$type,
 				'description' => static fn () => __( 'The form field that the order item is connected to', 'wp-graphql-gravity-forms' ),
 				'resolve'     => static function ( $source, array $args, AppContext $context ) {
-					if ( ! isset( $context->gfForm ) || ! isset( $source['id'] ) ) {
+					$gf_form = Compat::get_app_context( $context, 'gfForm' );
+					if ( ! isset( $gf_form ) || ! isset( $source['id'] ) ) {
 						return null;
 					}
 
-					$id_for_loader = (string) $context->gfForm->databaseId . ':' . (string) $source['id'];
+					$id_for_loader = (string) $gf_form->databaseId . ':' . (string) $source['id'];
 
 					return $context->get_loader( FormFieldsLoader::$name )->load_deferred( $id_for_loader );
 				},

--- a/src/Utils/Compat.php
+++ b/src/Utils/Compat.php
@@ -91,4 +91,50 @@ class Compat {
 
 		return $config;
 	}
+
+	/**
+	 * Gets context from AppContext.
+	 *
+	 * @todo remove when WPGraphQL < 2.3.8 is no longer supported.
+	 *
+	 * @param \WPGraphQL\AppContext $app_context The app context.
+	 * @param string                $key The context key.
+	 *
+	 * @return (
+	 *   $key is 'gfForm' ? ?\WPGraphQL\GF\Model\Form : (
+	 *     $key is 'gfEntry' ? \WPGraphQL\GF\Model\SubmittedEntry|\WPGraphQL\GF\Model\DraftEntry|null : (
+	 *       $key is 'gfField' ? ?\WPGraphQL\GF\Model\FormField : mixed
+	 *     )
+	 *   )
+	 * )
+	 */
+	public static function get_app_context( \WPGraphQL\AppContext $app_context, string $key ) {
+		// @phpstan-ignore function.alreadyNarrowedType (@todo remove when we don't support WPGraphQL < 2.3.8.)
+		if ( method_exists( $app_context, 'get' ) ) {
+			return $app_context->get( 'gf', $key );
+		}
+
+		// Old versions don't have namespaced context keys.
+		return property_exists( $app_context, $key ) ? $app_context->$key : null;
+	}
+
+	/**
+	 * Sets context on AppContext.
+	 *
+	 * @todo remove when WPGraphQL < 2.3.8 is no longer supported.
+	 *
+	 * @param \WPGraphQL\AppContext $app_context The app context.
+	 * @param string                $key The context key.
+	 * @param mixed                 $value The context value.
+	 */
+	public static function set_app_context( \WPGraphQL\AppContext $app_context, string $key, $value ): void {
+		// @phpstan-ignore function.alreadyNarrowedType (@todo remove when we don't support WPGraphQL < 2.3.8.)
+		if ( method_exists( $app_context, 'set' ) ) {
+			$app_context->set( 'gf', $key, $value );
+			return;
+		}
+
+		// Old versions don't have namespaced context keys.
+		$app_context->$key = $value;
+	}
 }

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -383,6 +383,7 @@ class Wpunit extends \Codeception\Module {
 			'maxFiles',
 			'maxFileSize',
 			'multipleFiles',
+			'allowsPrepopulate',
 			[ 'type' => 'fileupload' ],
 		];
 	}

--- a/tests/_support/TestCase/GFGraphQLTestCase.php
+++ b/tests/_support/TestCase/GFGraphQLTestCase.php
@@ -66,14 +66,16 @@ class GFGraphQLTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 */
 	public function tearDown(): void {
 		// Your tear down methods here.
-		wp_delete_user( $this->admin->id );
+		wp_delete_user( $this->admin->ID );
 		global $_gf_state, $_gf_uploaded_files;
-		$_gf_state = [];
-		unset( $_gf_uploaded_files );
+		$_gf_state          = [];
+		$_gf_uploaded_files = [];
+		$_FILES             = [];
+		$_POST              = [];
 
-		global $_gf_state, $_gf_uploaded_files;
-		$_gf_state = [];
-		unset( $_gf_uploaded_files );
+		if ( class_exists( 'GFFormsModel' ) ) {
+			\GFFormsModel::$uploaded_files = [];
+		}
 
 		// Then...
 		parent::tearDown();

--- a/tests/acceptance/ActivationCest.php
+++ b/tests/acceptance/ActivationCest.php
@@ -13,13 +13,11 @@ class ActivationCest {
 		$I->amOnPluginsPage();
 
 		$I->seePluginInstalled( $slug );
-
-		$I->activatePlugin( $slug );
 		$I->seePluginActivated( $slug );
 
 		$I->deactivatePlugin( $slug );
 
-		// For some reason, data-slug changes after deactivation.
+		// For some reason, data-slug changes after live-refresh.
 		$I->seePluginDeactivated( 'wpgraphql-for-gravity-forms' );
 
 		$I->activatePlugin( 'wpgraphql-for-gravity-forms' );

--- a/tests/wpunit/FileUploadFieldTest.php
+++ b/tests/wpunit/FileUploadFieldTest.php
@@ -210,6 +210,7 @@ class FileUploadFieldTest extends FormFieldTestCase implements FormFieldTestCase
 						value
 					}
 				}
+				canPrepopulate
 				cssClass
 				description
 				descriptionPlacement

--- a/tests/wpunit/PostImageFieldTest.php
+++ b/tests/wpunit/PostImageFieldTest.php
@@ -13,6 +13,14 @@ use Tests\WPGraphQL\GF\TestCase\FormFieldTestCaseInterface;
 use WPGraphQL\GF\Utils\GFUtils;
 
 class FooPostImage extends \GF_Field_Post_Image {
+	public function is_invalid_file( $file, $is_new = true ) {
+		// Mock valid upload for test files in /tmp
+		if ( $is_new && isset( $file['tmp_name'] ) && strpos( $file['tmp_name'], '/tmp/img' ) === 0 ) {
+			return false;
+		}
+		return parent::is_invalid_file( $file, $is_new );
+	}
+
 	public function upload_file( $form_id, $file ) {
 		\GFCommon::log_debug( __METHOD__ . '(): Uploading file: ' . $file['name'] );
 		$target = GFFormsModel::get_file_upload_path( $form_id, $file['name'] );
@@ -35,6 +43,7 @@ class FooPostImage extends \GF_Field_Post_Image {
 		}
 	}
 }
+
 /**
  * Class -PostImageFieldTest
  */

--- a/wp-graphql-gravity-forms.php
+++ b/wp-graphql-gravity-forms.php
@@ -11,12 +11,12 @@
  * Text Domain: wp-graphql-gravity-forms
  * Domain Path: /languages
  * Requires at least: 6.0
- * Tested up to: 6.8.1
+ * Tested up to: 6.8.3
  * Requires PHP: 7.4
  * Requires Plugins: wp-graphql
  * Gravity Forms requires at least: 2.7.0
  * WPGraphQL requires at least: 1.26.0
- * WPGraphQL tested up to: 2.3.3
+ * WPGraphQL tested up to: 2.6.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Fixes failing tests and ensure compatibility with latest WPGraphQL and GF. More specifically:
-  added support + testing for the new GF_Field_FileUpload
- added support for AppContext::set() and ::get()

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->

- [x] This PR is tested to the best of my abilities.
- [x] This PR follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] This PR has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] This PR has unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
